### PR TITLE
GLASS linetype: improvement

### DIFF
--- a/source_files/edge/p_local.h
+++ b/source_files/edge/p_local.h
@@ -292,6 +292,8 @@ void P_LineAttack(mobj_t * t1, angle_t angle, float distance, float slope, float
 
 void P_UnblockLineEffectDebris(line_t *TheLine, const linetype_c *special);
 
+bool ReplaceMidTexFromPart(line_t *TheLine, scroll_part_e parts);
+
 //
 // P_SETUP
 //


### PR DESCRIPTION
Added LINE_PARTS= as an alternative method of assigning the texture to use instead of
 BROKEN_TEXTURE=.
We can now use LINE_PARTS= to take it directly from the map linedef i.e. LINE_PARTS=RIGHT_LOWER; to use the linedefs front lower texture.