### PR TITLE
Changed how LOSE_BENEFIT HEALTH is handled in RTS

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -24,6 +24,9 @@ General Improvements
 
 + DDFSTYLE text styles can now have their own individual X_OFFSET and Y_OFFSET values,
   giving more flexibility for menu item placement
+  
++ Changed how LOSE_BENEFIT HEALTH is handled in RTS. Now it will simply subtract from current health and not
+  behave like DAMAGE_PLAYER(which reduces armour, causes pain states, respects immunity/resistence/invulnerable/immortal etc).
 
 
 New Features

--- a/source_files/edge/p_inter.cc
+++ b/source_files/edge/p_inter.cc
@@ -386,7 +386,19 @@ static void GiveHealth(pickup_info_t *pu, benefit_t *be)
 {
 	if (pu->lose_em)
 	{
-		P_DamageMobj(pu->player->mo, pu->special, NULL, be->amount, NULL);
+		//P_DamageMobj(pu->player->mo, pu->special, NULL, be->amount, NULL);
+		if (pu->player->health <= 0)
+			return;
+
+		pu->player->health -= be->amount;
+		pu->player->mo->health = pu->player->health;
+
+		if (pu->player->mo->health <= 0)
+		{
+			P_KillMobj(NULL, pu->player->mo);
+			//return;
+		}
+
 		pu->got_it = true;
 		return;
 	}


### PR DESCRIPTION
Now it will simply subtract from current health and not behave like DAMAGE_PLAYER (which reduces armour, causes pain states, respects immunity / resistence / invulnerable / immortal etc).