### PR TITLE
Doom2 Map05 bug fix

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,6 @@
 https://github.com/dashodanger/EDGE-classic
 
-Current as of: January 2023
+Current as of: February 2023
 
 CHANGELOG for EDGE-Classic 1.33 (since EDGE-Classic 1.32)
 ====================================
@@ -17,6 +17,8 @@ Bugs fixed
 + Fixed Boom vector linedef scroll directions for angles other than 0/45/90
 + Fixed Boom displacement scrollers not returning back to their exact original position
 + Fixed overzealous oofing when falling
++ Doom2 Map05 bug fixed properly this time ;)
+
 
 General Improvements
 --------------------


### PR DESCRIPTION
The IWAD for Doom2 has a bug in MAP05 where 2 sectors are incorrectly tagged 9.  This fixes it properly and finally ;)