### PR TITLE
CMake Improvements

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -35,7 +35,7 @@ jobs:
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
 
     - name: Copy Executable
-      run: cp ${{github.workspace}}/build/edge-classic ${{github.workspace}}
+      run: cp ${{github.workspace}}/build/source_files/edge/edge-classic ${{github.workspace}}
 
     - uses: actions/upload-artifact@v3
       with:
@@ -72,7 +72,7 @@ jobs:
       - name: Build
         run: cmake --build build --config ${{env.BUILD_TYPE}}
       - name: Copy Executable
-        run: cp build/edge-classic.exe .
+        run: cp /build/source_files/edge/edge-classic.exe .
       - uses: actions/upload-artifact@v3
         with:
           name: edge-classic-msys2
@@ -106,7 +106,7 @@ jobs:
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
 
     - name: Copy Executable
-      run: cp ${{github.workspace}}/build/edge-classic ${{github.workspace}}
+      run: cp ${{github.workspace}}/build/source_files/edge/edge-classic ${{github.workspace}}
 
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -34,9 +34,6 @@ jobs:
       # Build your program with the given configuration
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
 
-    - name: Copy Executable
-      run: cp ${{github.workspace}}/build/source_files/edge/edge-classic ${{github.workspace}}
-
     - uses: actions/upload-artifact@v3
       with:
         name: edge-classic-linux
@@ -71,8 +68,6 @@ jobs:
         run: cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -G "MSYS Makefiles"
       - name: Build
         run: cmake --build build --config ${{env.BUILD_TYPE}}
-      - name: Copy Executable
-        run: cp /build/source_files/edge/edge-classic.exe .
       - uses: actions/upload-artifact@v3
         with:
           name: edge-classic-msys2
@@ -104,9 +99,6 @@ jobs:
     - name: Build
       # Build your program with the given configuration
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
-
-    - name: Copy Executable
-      run: cp ${{github.workspace}}/build/source_files/edge/edge-classic ${{github.workspace}}
 
     - uses: actions/upload-artifact@v3
       with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,44 +1,48 @@
-cmake_minimum_required(VERSION 3.12..3.20)
+##########################################
+# Edge Classic - CMake Script
+##########################################
 
-add_subdirectory(source_files/ajbsp)
-add_subdirectory(source_files/coal)
-add_subdirectory(source_files/crsid)
-add_subdirectory(source_files/ddf)
-add_subdirectory(source_files/dehacked)
-add_subdirectory(source_files/ec_voxelib)
-add_subdirectory(source_files/epi)
-add_subdirectory(source_files/fmmidi)
-add_subdirectory(source_files/fluidlite)
-add_subdirectory(source_files/glad)
-add_subdirectory(source_files/libgme)
-add_subdirectory(source_files/libymfm)
-add_subdirectory(source_files/m4p)
-add_subdirectory(source_files/miniz)
-add_subdirectory(source_files/ymfmidi)
+cmake_minimum_required(VERSION 3.12..3.20)
 
 project(
   edge-classic
-  LANGUAGES CXX
+  LANGUAGES C CXX
   VERSION 0.1.0
 )
 
-set(CMAKE_MODULE_PATH cmake)
-if(WIN32 AND NOT MSYS)
-  set(SDL2_DIR "${CMAKE_SOURCE_DIR}/source_files/sdl2")
-endif()
-
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
-set(CMAKE_CXX_FLAGS "-O2 -Wall")
-if(WIN32 AND NOT MSYS AND NOT MINGW)
+
+if (MSVC)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /fp:fast")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /fp:fast /EHs")
+  
+  # Set /W4, can add /W4 to CMAKE_CXX_FLAGS instead, when bump to cmake 3.19 minimum
+  string(REGEX REPLACE "/W3" "/W4" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+  string(REGEX REPLACE "/W3" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+
+  # Disable some very noisy warnings from the MSVC build
+  # CRT security and POSIX deprecation warnings
+  add_definitions("-D_CRT_SECURE_NO_WARNINGS /wd4996")
+  # Loss of precision/data on assignment, requires lots of explicit casting
+  add_definitions("/wd4244 /wd4267")
+  # Unreferenced formal parameter, and there are many of these
+  add_definitions("/wd4100")
+  
   set(CMAKE_EXE_LINKER_FLAGS "/SUBSYSTEM:WINDOWS")
 else()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffast-math -fno-strict-aliasing")
+  set(CMAKE_CXX_FLAGS "-ffast-math -fno-strict-aliasing -Wall")
 endif()
-if(MSYS)
-  set(CMAKE_EXE_LINKER_FLAGS "-static -mwindows")
+
+if (MSVC OR MINGW OR MSYS)
+  set(CMAKE_MODULE_PATH cmake)
+  if(MSVC OR MINGW)
+    set(SDL2_DIR "${CMAKE_SOURCE_DIR}/source_files/sdl2")
+  else()
+    set(CMAKE_EXE_LINKER_FLAGS "-static -mwindows")
+  endif()
 endif()
+
 if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm64" AND APPLE)
 	add_compile_definitions(APPLE_SILICON)
 elseif(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64" AND APPLE)
@@ -48,246 +52,22 @@ if(APPLE OR ${CMAKE_SYSTEM} MATCHES "BSD")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I /usr/local/include")
 endif()
 
-add_executable(
-  edge-classic
-	source_files/edge/i_main.cc     
-	source_files/edge/i_ctrl.cc     
-	source_files/edge/i_video.cc    
-	source_files/edge/i_sound.cc    
-	source_files/edge/i_net.cc      
-	source_files/edge/am_map.cc     
-	source_files/edge/bot_nav.cc     
-	source_files/edge/bot_think.cc      
-	source_files/edge/con_con.cc    
-	source_files/edge/con_main.cc   
-	source_files/edge/con_var.cc    
-	source_files/edge/e_input.cc    
-	source_files/edge/e_main.cc     
-	source_files/edge/e_player.cc   
-	source_files/edge/f_finale.cc   
-	source_files/edge/f_interm.cc   
-	source_files/edge/g_game.cc     
-	source_files/edge/hu_draw.cc    
-	source_files/edge/hu_font.cc    
-	source_files/edge/hu_stuff.cc   
-	source_files/edge/hu_style.cc
-	source_files/edge/i_system.cc 
-	source_files/edge/l_ajbsp.cc    
-	source_files/edge/l_deh.cc      
-	source_files/edge/m_argv.cc     
-	source_files/edge/m_bbox.cc     
-	source_files/edge/m_cheat.cc    
-	source_files/edge/m_math.cc     
-	source_files/edge/m_menu.cc     
-	source_files/edge/m_misc.cc     
-	source_files/edge/m_option.cc   
-	source_files/edge/m_netgame.cc  
-	source_files/edge/m_random.cc   
-	source_files/edge/n_bcast.cc    
-	source_files/edge/n_reliable.cc 
-	source_files/edge/n_network.cc  
-	source_files/edge/p_action.cc   
-	source_files/edge/p_blockmap.cc 
-	source_files/edge/p_enemy.cc    
-	source_files/edge/p_inter.cc    
-	source_files/edge/p_lights.cc   
-	source_files/edge/p_map.cc      
-	source_files/edge/p_maputl.cc   
-	source_files/edge/p_mobj.cc     
-	source_files/edge/p_plane.cc    
-	source_files/edge/p_setup.cc    
-	source_files/edge/p_sight.cc    
-	source_files/edge/p_spec.cc     
-	source_files/edge/p_switch.cc   
-	source_files/edge/p_tick.cc     
-	source_files/edge/p_user.cc     
-	source_files/edge/p_forces.cc   
-	source_files/edge/p_telept.cc   
-	source_files/edge/p_weapon.cc   
-	source_files/edge/rad_act.cc    
-	source_files/edge/rad_pars.cc   
-	source_files/edge/rad_trig.cc   
-	source_files/edge/r_draw.cc     
-	source_files/edge/r_shader.cc   
-	source_files/edge/r_render.cc   
-	source_files/edge/r_effects.cc  
-	source_files/edge/r_main.cc     
-	source_files/edge/r_occlude.cc   
-	source_files/edge/r_things.cc   
-	source_files/edge/r_units.cc    
-	source_files/edge/r_wipe.cc     
-	source_files/edge/r_misc.cc     
-	source_files/edge/r_sky.cc      
-	source_files/edge/r_colormap.cc 
-	source_files/edge/r_modes.cc
-	source_files/edge/r_mdl.cc    
-	source_files/edge/r_md2.cc
-	source_files/edge/r_voxel.cc     
-	source_files/edge/r_image.cc    
-	source_files/edge/r_doomtex.cc  
-	source_files/edge/r_texgl.cc
-	source_files/edge/s_blit.cc     
-	source_files/edge/s_cache.cc    
-	source_files/edge/s_sound.cc 
-	source_files/edge/s_mp3.cc   
-	source_files/edge/s_music.cc    
-	source_files/edge/s_ogg.cc      
-	source_files/edge/s_fluid.cc
-	source_files/edge/s_gme.cc
-	source_files/edge/s_m4p.cc
-	source_files/edge/s_opl.cc
-	source_files/edge/s_sid.cc
-	source_files/edge/s_vgm.cc
-	source_files/edge/s_wav.cc
-	source_files/edge/s_flac.cc 
-	source_files/edge/s_fmm.cc
-	source_files/edge/sv_chunk.cc   
-	source_files/edge/sv_glob.cc    
-	source_files/edge/sv_level.cc   
-	source_files/edge/sv_load.cc    
-	source_files/edge/sv_main.cc    
-	source_files/edge/sv_misc.cc    
-	source_files/edge/sv_mobj.cc    
-	source_files/edge/sv_play.cc    
-	source_files/edge/sv_save.cc    
-	source_files/edge/w_files.cc
-	source_files/edge/w_flat.cc
-	source_files/edge/w_model.cc
-	source_files/edge/w_pk3.cc
-	source_files/edge/w_sprite.cc
-	source_files/edge/w_texture.cc
-	source_files/edge/w_wad.cc 
-	source_files/edge/vm_coal.cc    
-	source_files/edge/vm_hud.cc     
-	source_files/edge/vm_player.cc  
-	source_files/edge/scanner.cc     
-	source_files/edge/umapinfo.cc  
-	source_files/edge/w32_res.rc # I think this is ok to leave in regardless of OS (silently ignored on *nix?)
-)
-
 find_package(SDL2 REQUIRED)
 find_package(OpenGL REQUIRED)
 
-target_include_directories(edge-classic PRIVATE source_files/ajbsp)
-target_include_directories(edge-classic PRIVATE source_files/coal)
-target_include_directories(edge-classic PRIVATE source_files/crsid)
-target_include_directories(edge-classic PRIVATE source_files/ddf)
-target_include_directories(edge-classic PRIVATE source_files/dehacked)
-target_include_directories(edge-classic PRIVATE source_files/dr_libs)
-target_include_directories(edge-classic PRIVATE source_files/ec_voxelib)
-target_include_directories(edge-classic PRIVATE source_files/epi)
-target_include_directories(edge-classic PRIVATE source_files/fluidlite/include)
-target_include_directories(edge-classic PRIVATE source_files/fmmidi)
-target_include_directories(edge-classic PRIVATE source_files/glad/include/glad)
-target_include_directories(edge-classic PRIVATE source_files/libgme/gme)
-target_include_directories(edge-classic PRIVATE source_files/libymfm)
-target_include_directories(edge-classic PRIVATE source_files/m4p)
-target_include_directories(edge-classic PRIVATE source_files/minimp3)
-target_include_directories(edge-classic PRIVATE source_files/minivorbis)
-target_include_directories(edge-classic PRIVATE source_files/miniz)
-if(WIN32 AND NOT MSYS AND NOT MINGW)
-  target_include_directories(edge-classic PRIVATE source_files/sdl2/include)
-endif()
-target_include_directories(edge-classic PRIVATE source_files/stb)
-target_include_directories(edge-classic PRIVATE source_files/ymfmidi)
-
-if(WIN32 OR MSYS OR MINGW)
-  target_compile_definitions(edge-classic PRIVATE WIN32)
-else()
-  target_compile_definitions(edge-classic PRIVATE UNIX)
-endif()
-
-# Copies executable to local install directory after build
-add_custom_command(
-TARGET edge-classic
-POST_BUILD
-COMMAND "${CMAKE_COMMAND}" -E copy "$<TARGET_FILE:edge-classic>"
-		"${CMAKE_CURRENT_LIST_DIR}"
-)
-
-# Copy appropriate SDL2.dll to local install directory when built with MSVC
-if(WIN32 AND NOT MSYS AND NOT MINGW)
-  if (${CMAKE_SIZEOF_VOID_P} MATCHES 8)
-    add_custom_command(
-	TARGET edge-classic
-	POST_BUILD
-	COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/source_files/sdl2/lib/x64/SDL2.dll"
-			"${CMAKE_CURRENT_LIST_DIR}"
-	)
-  else ()
-    add_custom_command(
-	TARGET edge-classic
-	POST_BUILD
-	COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/source_files/sdl2/lib/x86/SDL2.dll"
-			"${CMAKE_CURRENT_LIST_DIR}"
-	)
-  endif ()
-# Copy appropriate SDL2.dll to local install directory when built with MSYS2
-elseif(MSYS)
-	if (${CMAKE_SIZEOF_VOID_P} MATCHES 8)
-	add_custom_command(
-	TARGET edge-classic
-	POST_BUILD
-	COMMAND "${CMAKE_COMMAND}" -E copy "/mingw64/bin/SDL2.dll"
-			"${CMAKE_CURRENT_LIST_DIR}"
-	)
-	else ()
-	add_custom_command(
-	TARGET edge-classic
-	POST_BUILD
-	COMMAND "${CMAKE_COMMAND}" -E copy "/mingw32/bin/SDL2.dll"
-			"${CMAKE_CURRENT_LIST_DIR}"
-		COMMAND "${CMAKE_COMMAND}" -E copy "/mingw32/bin/libgcc_s_dw2-1.dll"
-			"${CMAKE_CURRENT_LIST_DIR}"
-		COMMAND "${CMAKE_COMMAND}" -E copy "/mingw32/bin/libstdc++-6.dll"
-			"${CMAKE_CURRENT_LIST_DIR}"
-		COMMAND "${CMAKE_COMMAND}" -E copy "/mingw32/bin/libwinpthread-1.dll"
-			"${CMAKE_CURRENT_LIST_DIR}"
-	)
-	endif ()
-endif()
-
-if(WIN32 OR MSYS OR MINGW)
-	target_link_libraries(
-	edge-classic
-	PRIVATE edge_ajbsp
-			edge_coal
-			edge_ddf
-			edge_deh
-			edge_epi
-			glad
-			${OPENGL_LIBRARIES}
-			${SDL2_LIBRARIES}
-			crsid
-			ec_voxelib
-			fmmidi
-			fluidlite
-			gme
-			m4p
-			miniz
-			libymfm
-			ymfmidi
-			wsock32
-	)
-else()
-	target_link_libraries(
-	edge-classic
-	PRIVATE edge_ajbsp
-			edge_coal
-			edge_ddf
-			edge_deh
-			edge_epi
-			${OPENGL_LIBRARIES}
-			glad
-			${SDL2_LIBRARIES}
-			crsid
-			ec_voxelib
-			fmmidi
-			fluidlite
-			gme
-			m4p
-			miniz
-			libymfm
-			ymfmidi
-	)
-endif()
+add_subdirectory(source_files/ajbsp)
+add_subdirectory(source_files/coal)
+add_subdirectory(source_files/crsid)
+add_subdirectory(source_files/ddf)
+add_subdirectory(source_files/dehacked)
+add_subdirectory(source_files/ec_voxelib)
+add_subdirectory(source_files/epi)
+add_subdirectory(source_files/fluidlite)
+add_subdirectory(source_files/fmmidi)
+add_subdirectory(source_files/glad)
+add_subdirectory(source_files/libgme)
+add_subdirectory(source_files/libymfm)
+add_subdirectory(source_files/m4p)
+add_subdirectory(source_files/miniz)
+add_subdirectory(source_files/ymfmidi)
+add_subdirectory(source_files/edge)

--- a/source_files/ajbsp/CMakeLists.txt
+++ b/source_files/ajbsp/CMakeLists.txt
@@ -1,15 +1,9 @@
-# AJBSP CMake Script
-cmake_minimum_required(VERSION 3.2.2)
+##########################################
+# AJBSP
+##########################################
 
-project(edge_ajbsp)
-
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED True)
-set(CMAKE_CXX_FLAGS "-O2 -fno-strict-aliasing -fwrapv -fno-rtti")
-if(WIN32 AND NOT MSYS AND NOT MINGW)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc /W4")
-else()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions -Wall")
+if (NOT MSVC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fwrapv -fno-rtti -fno-exceptions")
 endif()
 
 add_library(edge_ajbsp

--- a/source_files/coal/CMakeLists.txt
+++ b/source_files/coal/CMakeLists.txt
@@ -1,15 +1,6 @@
-project(
-  edge_coal
-  LANGUAGES CXX
-  VERSION 0.1.0
-)
-
-set(CMAKE_CXX_FLAGS "-O2 -Wall")
-if(WIN32 AND NOT MSYS AND NOT MINGW)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /fp:fast /EHs")
-else()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffast-math -fno-strict-aliasing")
-endif()
+##########################################
+# coal
+##########################################
 
 add_library(
   edge_coal

--- a/source_files/crsid/CMakeLists.txt
+++ b/source_files/crsid/CMakeLists.txt
@@ -1,12 +1,6 @@
-cmake_minimum_required(VERSION 3.2.2)
-
-project(
-  crsid
-  LANGUAGES C
-  VERSION 0.1.0
-)
-
-set(CMAKE_CC_FLAGS "-O2 -Wall")
+##########################################
+# crsid
+##########################################
 
 add_library(
   crsid

--- a/source_files/ddf/CMakeLists.txt
+++ b/source_files/ddf/CMakeLists.txt
@@ -1,17 +1,6 @@
-project(
-  edge_ddf
-  LANGUAGES CXX
-  VERSION 0.1.0
-)
-
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED True)
-set(CMAKE_CXX_FLAGS "-O2 -Wall")
-if(WIN32 AND NOT MSYS AND NOT MINGW)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /fp:fast /EHs")
-else()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffast-math -fno-strict-aliasing")
-endif()
+##########################################
+# ddf
+##########################################
 
 add_library(
   edge_ddf

--- a/source_files/dehacked/CMakeLists.txt
+++ b/source_files/dehacked/CMakeLists.txt
@@ -1,17 +1,6 @@
-project(
-  edge_deh
-  LANGUAGES CXX
-  VERSION 0.1.0
-)
-
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED True)
-set(CMAKE_CXX_FLAGS "-O2 -Wall")
-if(WIN32 AND NOT MSYS AND NOT MINGW)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /fp:fast /EHs")
-else()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffast-math -fno-strict-aliasing")
-endif()
+##########################################
+# dehacked
+##########################################
 
 add_library(
   edge_deh

--- a/source_files/ec_voxelib/CMakeLists.txt
+++ b/source_files/ec_voxelib/CMakeLists.txt
@@ -1,17 +1,6 @@
-project(
-  ec_voxelib
-  LANGUAGES CXX
-  VERSION 0.1.0
-)
-
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED True)
-set(CMAKE_CXX_FLAGS "-O2 -Wall")
-if(WIN32 AND NOT MSYS AND NOT MINGW)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /fp:fast /EHs")
-else()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffast-math -fno-strict-aliasing")
-endif()
+##########################################
+# ec_voxellib
+##########################################
 
 add_library(
   ec_voxelib

--- a/source_files/edge/CMakeLists.txt
+++ b/source_files/edge/CMakeLists.txt
@@ -1,0 +1,229 @@
+##########################################
+# edge
+##########################################
+
+set (EDGE_SOURCE_FILES
+  i_main.cc
+  i_ctrl.cc
+  i_video.cc
+  i_sound.cc
+  i_net.cc
+  am_map.cc
+  bot_nav.cc
+  bot_think.cc
+  con_con.cc
+  con_main.cc
+  con_var.cc
+  e_input.cc
+  e_main.cc
+  e_player.cc
+  f_finale.cc
+  f_interm.cc
+  g_game.cc
+  hu_draw.cc
+  hu_font.cc
+  hu_stuff.cc
+  hu_style.cc
+  i_system.cc
+  l_ajbsp.cc
+  l_deh.cc
+  m_argv.cc
+  m_bbox.cc
+  m_cheat.cc
+  m_math.cc
+  m_menu.cc
+  m_misc.cc
+  m_option.cc
+  m_netgame.cc
+  m_random.cc
+  n_bcast.cc
+  n_reliable.cc
+  n_network.cc
+  p_action.cc
+  p_blockmap.cc
+  p_enemy.cc
+  p_inter.cc
+  p_lights.cc
+  p_map.cc
+  p_maputl.cc
+  p_mobj.cc
+  p_plane.cc
+  p_setup.cc
+  p_sight.cc
+  p_spec.cc
+  p_switch.cc
+  p_tick.cc
+  p_user.cc
+  p_forces.cc
+  p_telept.cc
+  p_weapon.cc
+  rad_act.cc
+  rad_pars.cc
+  rad_trig.cc
+  r_draw.cc
+  r_shader.cc
+  r_render.cc
+  r_effects.cc
+  r_main.cc
+  r_occlude.cc
+  r_things.cc
+  r_units.cc
+  r_wipe.cc
+  r_misc.cc
+  r_sky.cc
+  r_colormap.cc
+  r_modes.cc
+  r_mdl.cc
+  r_md2.cc
+  r_voxel.cc
+  r_image.cc
+  r_doomtex.cc
+  r_texgl.cc
+  s_blit.cc
+  s_cache.cc
+  s_sound.cc
+  s_mp3.cc
+  s_music.cc
+  s_ogg.cc
+  s_fluid.cc
+  s_gme.cc
+  s_m4p.cc
+  s_opl.cc
+  s_sid.cc
+  s_vgm.cc
+  s_wav.cc
+  s_flac.cc
+  s_fmm.cc
+  sv_chunk.cc
+  sv_glob.cc
+  sv_level.cc
+  sv_load.cc
+  sv_main.cc
+  sv_misc.cc
+  sv_mobj.cc
+  sv_play.cc
+  sv_save.cc
+  w_files.cc
+  w_flat.cc
+  w_model.cc
+  w_pk3.cc
+  w_sprite.cc
+  w_texture.cc
+  w_wad.cc
+  vm_coal.cc
+  vm_hud.cc
+  vm_player.cc
+  scanner.cc
+  umapinfo.cc
+)
+
+set (EDGE_LINK_LIBRARIES
+  edge_ajbsp
+  edge_coal
+  edge_ddf
+  edge_deh
+  edge_epi
+  glad
+  ${OPENGL_LIBRARIES}
+  ${SDL2_LIBRARIES}
+  crsid
+  ec_voxelib
+  fmmidi
+  fluidlite
+  gme
+  m4p
+  miniz
+  libymfm
+  ymfmidi
+)
+
+if (MSVC OR MINGW OR MSYS)
+  set (EDGE_SOURCE_FILES ${EDGE_SOURCE_FILES} w32_res.rc)
+  set (EDGE_LINK_LIBRARIES ${EDGE_LINK_LIBRARIES} wsock32)
+endif()
+
+add_executable(
+  edge-classic
+  ${EDGE_SOURCE_FILES}
+)
+
+if(MSVC OR MSYS OR MINGW)
+  target_compile_definitions(edge-classic PRIVATE WIN32)
+else()
+  target_compile_definitions(edge-classic PRIVATE UNIX)
+endif()
+
+target_include_directories(edge-classic PRIVATE ../ajbsp)
+target_include_directories(edge-classic PRIVATE ../coal)
+target_include_directories(edge-classic PRIVATE ../crsid)
+target_include_directories(edge-classic PRIVATE ../ddf)
+target_include_directories(edge-classic PRIVATE ../dehacked)
+target_include_directories(edge-classic PRIVATE ../dr_libs)
+target_include_directories(edge-classic PRIVATE ../ec_voxelib)
+target_include_directories(edge-classic PRIVATE ../epi)
+target_include_directories(edge-classic PRIVATE ../fluidlite/include)
+target_include_directories(edge-classic PRIVATE ../fmmidi)
+target_include_directories(edge-classic PRIVATE ../glad/include/glad)
+target_include_directories(edge-classic PRIVATE ../libgme/gme)
+target_include_directories(edge-classic PRIVATE ../libymfm)
+target_include_directories(edge-classic PRIVATE ../m4p)
+target_include_directories(edge-classic PRIVATE ../minimp3)
+target_include_directories(edge-classic PRIVATE ../minivorbis)
+target_include_directories(edge-classic PRIVATE ../miniz)
+target_include_directories(edge-classic PRIVATE ../stb)
+target_include_directories(edge-classic PRIVATE ../ymfmidi)
+if(MSVC)
+  target_include_directories(edge-classic PRIVATE ../sdl2/include)
+endif()
+
+target_link_libraries(edge-classic PRIVATE ${EDGE_LINK_LIBRARIES})
+
+# Copies executable to local install directory after build
+add_custom_command(
+TARGET edge-classic
+POST_BUILD
+COMMAND "${CMAKE_COMMAND}" -E copy "$<TARGET_FILE:edge-classic>"
+		"${CMAKE_SOURCE_DIR}"
+)
+
+# Copy appropriate SDL2.dll to local install directory when built with MSVC
+if(MSVC)
+  if (${CMAKE_SIZEOF_VOID_P} MATCHES 8)
+    add_custom_command(
+	TARGET edge-classic
+	POST_BUILD
+	COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/source_files/sdl2/lib/x64/SDL2.dll"
+			"${CMAKE_SOURCE_DIR}"
+	)
+  else ()
+    add_custom_command(
+	TARGET edge-classic
+	POST_BUILD
+	COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/source_files/sdl2/lib/x86/SDL2.dll"
+			"${CMAKE_SOURCE_DIR}"
+	)
+  endif ()
+# Copy appropriate SDL2.dll to local install directory when built with MSYS2
+elseif(MSYS)
+	if (${CMAKE_SIZEOF_VOID_P} MATCHES 8)
+	add_custom_command(
+	TARGET edge-classic
+	POST_BUILD
+	COMMAND "${CMAKE_COMMAND}" -E copy "/mingw64/bin/SDL2.dll"
+			"${CMAKE_SOURCE_DIR}"
+	)
+	else ()
+	add_custom_command(
+	TARGET edge-classic
+	POST_BUILD
+	COMMAND "${CMAKE_COMMAND}" -E copy "/mingw32/bin/SDL2.dll"
+			"${CMAKE_SOURCE_DIR}"
+		COMMAND "${CMAKE_COMMAND}" -E copy "/mingw32/bin/libgcc_s_dw2-1.dll"
+			"${CMAKE_SOURCE_DIR}"
+		COMMAND "${CMAKE_COMMAND}" -E copy "/mingw32/bin/libstdc++-6.dll"
+			"${CMAKE_SOURCE_DIR}"
+		COMMAND "${CMAKE_COMMAND}" -E copy "/mingw32/bin/libwinpthread-1.dll"
+			"${CMAKE_SOURCE_DIR}"
+	)
+	endif ()
+endif()

--- a/source_files/edge/CMakeLists.txt
+++ b/source_files/edge/CMakeLists.txt
@@ -179,11 +179,13 @@ endif()
 target_link_libraries(edge-classic PRIVATE ${EDGE_LINK_LIBRARIES})
 
 # Copies executable to local install directory after build
+set (DEST_DIR "${CMAKE_CURRENT_LIST_DIR}/../../")
+
 add_custom_command(
 TARGET edge-classic
 POST_BUILD
 COMMAND "${CMAKE_COMMAND}" -E copy "$<TARGET_FILE:edge-classic>"
-		"${CMAKE_SOURCE_DIR}"
+		"${DEST_DIR}"
 )
 
 # Copy appropriate SDL2.dll to local install directory when built with MSVC
@@ -193,14 +195,14 @@ if(MSVC)
 	TARGET edge-classic
 	POST_BUILD
 	COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/source_files/sdl2/lib/x64/SDL2.dll"
-			"${CMAKE_SOURCE_DIR}"
+			"${DEST_DIR}"
 	)
   else ()
     add_custom_command(
 	TARGET edge-classic
 	POST_BUILD
 	COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/source_files/sdl2/lib/x86/SDL2.dll"
-			"${CMAKE_SOURCE_DIR}"
+			"${DEST_DIR}"
 	)
   endif ()
 # Copy appropriate SDL2.dll to local install directory when built with MSYS2
@@ -210,20 +212,20 @@ elseif(MSYS)
 	TARGET edge-classic
 	POST_BUILD
 	COMMAND "${CMAKE_COMMAND}" -E copy "/mingw64/bin/SDL2.dll"
-			"${CMAKE_SOURCE_DIR}"
+			"${DEST_DIR}"
 	)
 	else ()
 	add_custom_command(
 	TARGET edge-classic
 	POST_BUILD
 	COMMAND "${CMAKE_COMMAND}" -E copy "/mingw32/bin/SDL2.dll"
-			"${CMAKE_SOURCE_DIR}"
+			"${DEST_DIR}"
 		COMMAND "${CMAKE_COMMAND}" -E copy "/mingw32/bin/libgcc_s_dw2-1.dll"
-			"${CMAKE_SOURCE_DIR}"
+			"${DEST_DIR}"
 		COMMAND "${CMAKE_COMMAND}" -E copy "/mingw32/bin/libstdc++-6.dll"
-			"${CMAKE_SOURCE_DIR}"
+			"${DEST_DIR}"
 		COMMAND "${CMAKE_COMMAND}" -E copy "/mingw32/bin/libwinpthread-1.dll"
-			"${CMAKE_SOURCE_DIR}"
+			"${DEST_DIR}"
 	)
 	endif ()
 endif()

--- a/source_files/edge/CMakeLists.txt
+++ b/source_files/edge/CMakeLists.txt
@@ -179,7 +179,7 @@ endif()
 target_link_libraries(edge-classic PRIVATE ${EDGE_LINK_LIBRARIES})
 
 # Copies executable to local install directory after build
-set (DEST_DIR "${CMAKE_CURRENT_LIST_DIR}/../../")
+set (DEST_DIR "${CMAKE_SOURCE_DIR}")
 
 add_custom_command(
 TARGET edge-classic

--- a/source_files/epi/CMakeLists.txt
+++ b/source_files/epi/CMakeLists.txt
@@ -1,17 +1,6 @@
-project(
-  edge_epi
-  LANGUAGES CXX
-  VERSION 0.1.0
-)
-
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED True)
-set(CMAKE_CXX_FLAGS "-O2 -Wall")
-if(WIN32 AND NOT MSYS AND NOT MINGW)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /fp:fast /EHs")
-else()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffast-math -fno-strict-aliasing")
-endif()
+##########################################
+# epi
+##########################################
 
 add_library(
   edge_epi
@@ -38,6 +27,7 @@ add_library(
   str_lexer.cc
   str_util.cc
 )
+
 target_include_directories(edge_epi PRIVATE ../stb)
 target_include_directories(edge_epi PRIVATE ../libgme/gme)
 target_include_directories(edge_epi PRIVATE ../m4p)

--- a/source_files/fluidlite/CMakeLists.txt
+++ b/source_files/fluidlite/CMakeLists.txt
@@ -1,6 +1,6 @@
-cmake_minimum_required(VERSION 3.1)
-
-project(fluidlite)
+##########################################
+# fluidlite
+##########################################
 
 add_library(fluidlite
     src/fluid_chan.c

--- a/source_files/fmmidi/CMakeLists.txt
+++ b/source_files/fmmidi/CMakeLists.txt
@@ -1,11 +1,7 @@
-project(
-  fmmidi
-  LANGUAGES CXX
-  VERSION 0.1.0
-)
+##########################################
+# fmmidi
+##########################################
 
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED True)
 add_library(fmmidi
   filter.cpp
   midisynth.cpp

--- a/source_files/glad/CMakeLists.txt
+++ b/source_files/glad/CMakeLists.txt
@@ -1,17 +1,6 @@
-cmake_minimum_required(VERSION 3.2.2)
-
-project(
-  glad
-  LANGUAGES C
-  VERSION 0.1.0
-)
-
-set(CMAKE_CC_FLAGS "-O2 -Wall")
-if(WIN32 AND NOT MSYS AND NOT MINGW)
-  set(CMAKE_CC_FLAGS "${CMAKE_CXX_FLAGS} /fp:fast /EHs")
-else()
-  set(CMAKE_CC_FLAGS "${CMAKE_CXX_FLAGS} -ffast-math -fno-strict-aliasing")
-endif()
+##########################################
+# glad
+##########################################
 
 add_library(glad src/gl.c)
 

--- a/source_files/libymfm/CMakeLists.txt
+++ b/source_files/libymfm/CMakeLists.txt
@@ -1,17 +1,6 @@
-project(
-  libymfm
-  LANGUAGES CXX
-  VERSION 0.1.0
-)
-
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED True)
-set(CMAKE_CXX_FLAGS "-O2 -Wall")
-if(WIN32 AND NOT MSYS AND NOT MINGW)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /fp:fast /EHs")
-else()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffast-math -fno-strict-aliasing")
-endif()
+##########################################
+# libymfm
+##########################################
 
 add_library(
   libymfm

--- a/source_files/m4p/CMakeLists.txt
+++ b/source_files/m4p/CMakeLists.txt
@@ -1,12 +1,6 @@
-cmake_minimum_required(VERSION 3.2.2)
-
-project(
-  m4p
-  LANGUAGES C
-  VERSION 0.1.0
-)
-
-set(CMAKE_CC_FLAGS "-O2 -Wall")
+##########################################
+# m4p
+##########################################
 
 add_library(
   m4p

--- a/source_files/miniz/CMakeLists.txt
+++ b/source_files/miniz/CMakeLists.txt
@@ -1,17 +1,6 @@
-cmake_minimum_required(VERSION 3.2.2)
-
-project(
-  miniz
-  LANGUAGES C
-  VERSION 0.1.0
-)
-
-set(CMAKE_CC_FLAGS "-O2 -Wall")
-if(WIN32 AND NOT MSYS AND NOT MINGW)
-  set(CMAKE_CC_FLAGS "${CMAKE_CXX_FLAGS} /fp:fast /EHs")
-else()
-  set(CMAKE_CC_FLAGS "${CMAKE_CXX_FLAGS} -ffast-math -fno-strict-aliasing")
-endif()
+##########################################
+# miniz
+##########################################
 
 add_library(
   miniz

--- a/source_files/ymfmidi/CMakeLists.txt
+++ b/source_files/ymfmidi/CMakeLists.txt
@@ -1,11 +1,7 @@
-project(
-  ymfmidi
-  LANGUAGES CXX
-  VERSION 0.1.0
-)
+##########################################
+# ymfmidi
+##########################################
 
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED True)
 add_library(ymfmidi
   patches.cpp
   patchnames.cpp


### PR DESCRIPTION
Here are some improvements to the CMake scripts for review.  This PR addresses issues I ran into with the upcoming web build and is also a step towards making the build a bit more unified/configurable. 

The main changes being:

1) Use MSVC instead of WIN32 in conditionals, and silencing some of MSVC's more obnoxious warnings, at least until can get a better handle on the more significant ones. 

2)  Removing the number of conditionals in general by grouping them where possible 

3) Consolidate redundant compiler settings and remove optimization level settings which should be handled by the various **CMAKE_BUILD_TYPE** build types, such as **Debug**, **Release**, **RelWithDebInfo** and **MinSizeRel**.  There is still room for massaging these a bit, should really look into what CMake is specifying for these by default on various platforms 

4)  Adding a CMakeLists.txt to the edge folder for the executable

5) Remove the extra project definitions from the subdirectories, making one edge-classic project 

The delta looks more involved than it really is in the PR, might help to just checkout the branch and have a look.  I may have munged something.  I intend to setup MINGW and a linux VM to better be able to test, though only tested these changes under MSVC.  I guess will see what GitHub Actions thinks of the PR 

Don't be shy about requesting any changes, or landing and subsequently changing, want to ensure contributions I make are in line with the vision for the project 😄 