### PR TITLE
COAL player.query_weapon() fix

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,6 @@
 https://github.com/dashodanger/EDGE-classic
 
-Current as of: February 2023
+Current as of: March 2023
 
 CHANGELOG for EDGE-Classic 1.34 (since EDGE-Classic 1.33)
 ====================================
@@ -11,6 +11,9 @@ Bugs fixed
 
 + Fixed autoload folder items paths being prepended with the autoload folder path itself
   (cleanup from prior method of using PATH_Join)
+  
++ COAL player.query_weapon() would not return ZOOM FACTOR in some cases.
+
 
 General Improvements
 --------------------

--- a/source_files/edge/vm_player.cc
+++ b/source_files/edge/vm_player.cc
@@ -1253,6 +1253,8 @@ std::string GetQueryInfoFromWeapon(mobj_t *obj, int whatinfo, bool secattackinfo
 
 	const damage_c *damtype;
 
+	float temp_num2;
+
 	switch (whatinfo)
 	{
 		case 1:  //name
@@ -1261,8 +1263,8 @@ std::string GetQueryInfoFromWeapon(mobj_t *obj, int whatinfo, bool secattackinfo
 			break;
 		
 		case 2:  //ZOOM_FACTOR
-			temp_num = objWep->zoom_factor;
-			temp_string = std::to_string(temp_num);
+			temp_num2 = 90.0f / objWep->zoom_fov;
+			temp_string = std::to_string(temp_num2);
 			break;
 
 		case 3: //AMMOTYPE


### PR DESCRIPTION
COAL player.query_weapon() would not return ZOOM FACTOR in some cases.