### PR TITLE
Fix for Weapon clip/ammo

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -38,6 +38,9 @@ General Improvements
 
 + "PC Speaker Mode" Sound Option no longer requires a restart to toggle; when On it will always use Fluidlite + the Bonkers for Bits soundfont when playing MIDI music
 
++ For the rts REPLACE_WEAPON command and the weapon.ddf BECOME() action: If current ammo is bigger than the new clip size, reduce current ammo to new clip size.
+
+
 New Features
 ------------
 + Added WebGL platform support

--- a/source_files/edge/p_local.h
+++ b/source_files/edge/p_local.h
@@ -111,6 +111,7 @@ void P_SelectNewWeapon(player_t * player, int priority, ammotype_e ammo);
 void P_TrySwitchNewWeapon(player_t *p, int new_weap, ammotype_e new_ammo);
 bool P_TryFillNewWeapon(player_t *p, int idx, ammotype_e ammo, int *qty);
 void P_FillWeapon(player_t *p, int slot);
+void P_FixWeaponClip(player_t *p, int slot);
 
 //
 // P_USER

--- a/source_files/edge/rad_act.cc
+++ b/source_files/edge/rad_act.cc
@@ -1273,7 +1273,7 @@ void RAD_ActReplaceWeapon(rad_trigger_t *R, void *param)
 	{
 	 	RAD_SetPspriteDeferred(p,ps_weapon,p->weapons[p->ready_wp].info->ready_state);
 
-		P_FillWeapon(p, p->ready_wp); //handle the potential clip_size difference
+		P_FixWeaponClip(p, p->ready_wp); //handle the potential clip_size difference
 		P_UpdateAvailWeapons(p);
 	} 	
 		 


### PR DESCRIPTION
For the rts REPLACE_WEAPON command and the weapon.ddf BECOME() action: If current ammo is bigger than the new clip size, reduce current ammo to new clip size.