### PR TITLE
Fix debug gcc build with xxhash.hpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,11 +23,6 @@ if (WIN32)
   endif()
 endif()
 
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DEDGE_DEBUG=1")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DEDGE_DEBUG=1")
-endif()
-
 if (EMSCRIPTEN)
   include("cmake/Emscripten.cmake")  
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,11 @@ if (WIN32)
   endif()
 endif()
 
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DEDGE_DEBUG=1")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DEDGE_DEBUG=1")
+endif()
+
 if (EMSCRIPTEN)
   include("cmake/Emscripten.cmake")  
 endif()

--- a/source_files/xxhash/xxhash.hpp
+++ b/source_files/xxhash/xxhash.hpp
@@ -189,7 +189,11 @@ namespace xxh
 #	define XXH_NO_INLINE static __declspec(noinline)
 #	include <intrin.h>
 #elif defined(__GNUC__)  /* Clang / GCC */
-#	define XXH_FORCE_INLINE static inline __attribute__((always_inline))
+	#ifndef EDGE_DEBUG
+		#define XXH_FORCE_INLINE static inline __attribute__((always_inline))
+	#else
+		#define XXH_FORCE_INLINE static 
+	#endif
 #	define XXH_NO_INLINE static __attribute__((noinline))
 #	include <mmintrin.h>
 #else

--- a/source_files/xxhash/xxhash.hpp
+++ b/source_files/xxhash/xxhash.hpp
@@ -189,7 +189,7 @@ namespace xxh
 #	define XXH_NO_INLINE static __declspec(noinline)
 #	include <intrin.h>
 #elif defined(__GNUC__)  /* Clang / GCC */
-	#ifndef EDGE_DEBUG
+	#ifdef NDEBUG
 		#define XXH_FORCE_INLINE static inline __attribute__((always_inline))
 	#else
 		#define XXH_FORCE_INLINE static 


### PR DESCRIPTION
Fixes xxhash.hpp when compiling under gcc in debug.  Introduces an "EDGE_DEBUG" preprocessor which can be used to detect debug builds across platforms