### PR TITLE
COAL tweak: player.on_ground()

### DIFF
--- a/source_files/edge/vm_player.cc
+++ b/source_files/edge/vm_player.cc
@@ -202,7 +202,34 @@ static void PL_under_water(coal::vm_c *vm, int argc)
 //
 static void PL_on_ground(coal::vm_c *vm, int argc)
 {
-	vm->ReturnFloat((ui_player_who->mo->z <= ui_player_who->mo->floorz) ? 1 : 0);
+	//vm->ReturnFloat((ui_player_who->mo->z <= ui_player_who->mo->floorz) ? 1 : 0);
+
+	// not a 3D floor?
+	if (ui_player_who->mo->subsector->sector->exfloor_used == 0)
+	{
+		// on the edge above water/lava/etc? Handles edge walker case
+		if (ui_player_who->mo->floorz != ui_player_who->mo->subsector->sector->f_h)
+			vm->ReturnFloat(0);
+		else
+		{
+			// touching the floor? Handles jumping or flying
+			if (ui_player_who->mo->z <= ui_player_who->mo->floorz)
+				vm->ReturnFloat(1);
+			else
+				vm->ReturnFloat(0);
+		}
+	}
+	else 
+	{
+		if (ui_player_who->mo->z <= ui_player_who->mo->floorz)
+			vm->ReturnFloat(1);
+		else
+			vm->ReturnFloat(0);
+	}
+
+
+	
+
 }
 
 


### PR DESCRIPTION
Made it so that a player slightly over the edge of a drop off, or between 2 raised floors, is not considered on the ground.