### PR TITLE
Improve cmake conditionals and post build file copying

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -66,7 +66,7 @@ jobs:
             cmake:p
             SDL2:p
       - name: Configure CMake
-        run: cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -G "MSYS Makefiles" #-G"Ninja"
+        run: cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -G"MSYS Makefiles"
       - name: Build
         run: cmake --build build --config ${{env.BUILD_TYPE}}
       - uses: actions/upload-artifact@v3
@@ -103,7 +103,7 @@ jobs:
             cmake:p
             SDL2:p
       - name: Configure CMake GLES2
-        run: cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DEDGE_GL_ES2=ON -G"Ninja"
+        run: cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DEDGE_GL_ES2=ON -G"MSYS Makefiles"
       - name: Build GLES2
         run: cmake --build build --config ${{env.BUILD_TYPE}}
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -66,7 +66,7 @@ jobs:
             cmake:p
             SDL2:p
       - name: Configure CMake
-        run: cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -G "MSYS Makefiles" #-G"Ninja"
+        run: cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -G "MSYS Makefiles" #-G"Ninja"
       - name: Build
         run: cmake --build build --config ${{env.BUILD_TYPE}}
       - uses: actions/upload-artifact@v3
@@ -103,7 +103,7 @@ jobs:
             cmake:p
             SDL2:p
       - name: Configure CMake GLES2
-        run: cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DEDGE_GL_ES2=ON -G"Ninja"
+        run: cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DEDGE_GL_ES2=ON -G"Ninja"
       - name: Build GLES2
         run: cmake --build build --config ${{env.BUILD_TYPE}}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,13 +57,9 @@ else()
 endif()
 
 
-if (MSVC OR MINGW OR MSYS OR WIN32_CLANG)
+if (WIN32)
   set(CMAKE_MODULE_PATH cmake)
-  if(MSVC OR MINGW OR WIN32_CLANG)
-    set(SDL2_DIR "${CMAKE_SOURCE_DIR}/source_files/sdl2")
-  else()
-    set(CMAKE_EXE_LINKER_FLAGS "-static -mwindows")
-  endif()
+  set(SDL2_DIR "${CMAKE_SOURCE_DIR}/source_files/sdl2")
 endif()
 
 if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm64" AND APPLE)

--- a/source_files/edge/CMakeLists.txt
+++ b/source_files/edge/CMakeLists.txt
@@ -326,6 +326,6 @@ if (WIN32)
 endif()
 
 if (COPY_FILES)
-  add_custom_command( TARGET edge-classic POST_BUILD COMMAND_EXPAND_LISTS COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${COPY_FILES}" "${DEST_DIR}")
+  add_custom_command( TARGET edge-classic POST_BUILD COMMAND_EXPAND_LISTS COMMAND ${CMAKE_COMMAND} -E copy_if_different ${COPY_FILES} ${DEST_DIR})
 endif()
 

--- a/source_files/edge/CMakeLists.txt
+++ b/source_files/edge/CMakeLists.txt
@@ -325,8 +325,7 @@ if (WIN32)
   endif()
 endif()
 
-foreach( src_file ${COPY_FILES})
-    add_custom_command( TARGET edge-classic POST_BUILD
-    COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${src_file}" "${DEST_DIR}")
-endforeach( src_file )
+if (COPY_FILES)
+  add_custom_command( TARGET edge-classic POST_BUILD COMMAND_EXPAND_LISTS COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${COPY_FILES}" "${DEST_DIR}")
+endif()
 

--- a/source_files/edge/CMakeLists.txt
+++ b/source_files/edge/CMakeLists.txt
@@ -320,8 +320,8 @@ else()
 endif()
 
 if (WIN32)
-  # Copy appropriate SDL2.dll to local install directory when built with MSVC
-  if(MSVC)
+  # Copy appropriate SDL2.dll to local install directory when built with MSVC/Clang
+  if(MSVC OR WIN32_CLANG)
     if (${CMAKE_SIZEOF_VOID_P} MATCHES 8)
       add_custom_command(
     TARGET edge-classic
@@ -337,8 +337,8 @@ if (WIN32)
         "${DEST_DIR}"
     )
     endif ()
-  # Copy appropriate SDL2.dll to local install directory when built with MinGW
-  elseif(MinGW)
+  # Copy appropriate SDL2.dll to local install directory when built with GNU/MinGW
+  else()
     if (${CMAKE_SIZEOF_VOID_P} MATCHES 8)
     add_custom_command(
     TARGET edge-classic

--- a/source_files/edge/CMakeLists.txt
+++ b/source_files/edge/CMakeLists.txt
@@ -2,7 +2,7 @@
 # edge
 ##########################################
 
-set (EDGE_SOURCE_FILES  
+set (EDGE_SOURCE_FILES
   i_ctrl.cc
   i_video.cc
   i_sound.cc
@@ -158,7 +158,7 @@ endif()
 if (NOT EDGE_GL_ES2)
   target_include_directories(edge-classic PRIVATE ../glad/include/glad)
 	set(EDGE_LINK_LIBRARIES ${EDGE_LINK_LIBRARIES} glad ${OPENGL_LIBRARIES})
-else()	
+else()
   target_include_directories(edge-classic PRIVATE ../gl4es/include ../gl4es/include/GL)
 	set(EDGE_LINK_LIBRARIES ${EDGE_LINK_LIBRARIES} gl4es)
 endif()
@@ -274,48 +274,36 @@ if (BUILD_EPKS)
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/edge_base/tnt"
     )
 endif()
-  
+
+set(COPY_FILES "")
 
 if (NOT EMSCRIPTEN)
-  
-  set (DEST_DIR "${CMAKE_SOURCE_DIR}")
 
-  # Copies executable to local install directory after build
-  add_custom_command(
-  TARGET edge-classic
-  POST_BUILD
-  COMMAND "${CMAKE_COMMAND}" -E copy "$<TARGET_FILE:edge-classic>"
-      "${DEST_DIR}"
-  )
+  set (DEST_DIR "${CMAKE_SOURCE_DIR}")
+  list(APPEND COPY_FILES "$<TARGET_FILE:edge-classic>")
+
 else()
+
   set (SOURCE_DIR "${CMAKE_SOURCE_DIR}/build/source_files/edge")
   set (DEST_DIR "${CMAKE_SOURCE_DIR}/web/site")
 
   target_link_options(edge-classic PRIVATE "--pre-js=${DEST_DIR}/edge-classic-data.js")
-  
-  add_custom_command(
-  TARGET edge-classic
-  POST_BUILD
-  COMMAND "${CMAKE_COMMAND}" -E copy 
-      "${SOURCE_DIR}/edge-classic.js"
-      "${SOURCE_DIR}/edge-classic.wasm"
-      "${SOURCE_DIR}/edge-classic.wasm.map"      
-      "${DEST_DIR}"
-  )
-  
+
+  list(APPEND COPY_FILES "${SOURCE_DIR}/edge-classic.js" "${SOURCE_DIR}/edge-classic.wasm" "${SOURCE_DIR}/edge-classic.wasm.map")
+
   add_custom_command(
   TARGET edge-classic
   PRE_BUILD
-  COMMAND python ${EMPACKAGER} ${DEST_DIR}/edge-classic.data --preload 
-    ${CMAKE_SOURCE_DIR}/web/preload@/ 
+  COMMAND python ${EMPACKAGER} ${DEST_DIR}/edge-classic.data --preload
+    ${CMAKE_SOURCE_DIR}/web/preload@/
     ${CMAKE_SOURCE_DIR}/edge_base@/edge_base
     ${CMAKE_SOURCE_DIR}/edge_defs@/edge_defs
     ${CMAKE_SOURCE_DIR}/soundfont@/soundfont
-    --js-output=${DEST_DIR}/edge-classic-data.js 
+    --js-output=${DEST_DIR}/edge-classic-data.js
     --use-preload-cache
     --no-node
     --lz4
-  )  
+  )
 
 endif()
 
@@ -323,43 +311,22 @@ if (WIN32)
   # Copy appropriate SDL2.dll to local install directory when built with MSVC/Clang
   if(MSVC OR WIN32_CLANG)
     if (${CMAKE_SIZEOF_VOID_P} MATCHES 8)
-      add_custom_command(
-    TARGET edge-classic
-    POST_BUILD
-    COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/source_files/sdl2/lib/x64/SDL2.dll"
-        "${DEST_DIR}"
-    )
+      list(APPEND COPY_FILES "${CMAKE_SOURCE_DIR}/source_files/sdl2/lib/x64/SDL2.dll")
     else ()
-      add_custom_command(
-    TARGET edge-classic
-    POST_BUILD
-    COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/source_files/sdl2/lib/x86/SDL2.dll"
-        "${DEST_DIR}"
-    )
+      list(APPEND COPY_FILES "${CMAKE_SOURCE_DIR}/source_files/sdl2/lib/x86/SDL2.dll")
     endif ()
   # Copy appropriate SDL2.dll to local install directory when built with GNU/MinGW
   else()
     if (${CMAKE_SIZEOF_VOID_P} MATCHES 8)
-    add_custom_command(
-    TARGET edge-classic
-    POST_BUILD
-    COMMAND "${CMAKE_COMMAND}" -E copy "/mingw64/bin/SDL2.dll"
-        "${DEST_DIR}"
-    )
+      list(APPEND COPY_FILES "/mingw64/bin/SDL2.dll")
     else ()
-    add_custom_command(
-    TARGET edge-classic
-    POST_BUILD
-    COMMAND "${CMAKE_COMMAND}" -E copy "/mingw32/bin/SDL2.dll"
-        "${DEST_DIR}"
-      COMMAND "${CMAKE_COMMAND}" -E copy "/mingw32/bin/libgcc_s_dw2-1.dll"
-        "${DEST_DIR}"
-      COMMAND "${CMAKE_COMMAND}" -E copy "/mingw32/bin/libstdc++-6.dll"
-        "${DEST_DIR}"
-      COMMAND "${CMAKE_COMMAND}" -E copy "/mingw32/bin/libwinpthread-1.dll"
-        "${DEST_DIR}"
-    )
-    endif ()
+      list(APPEND COPY_FILES "/mingw32/bin/SDL2.dll" "/mingw32/bin/libgcc_s_dw2-1.dll" "/mingw32/bin/libstdc++-6.dll" "/mingw32/bin/libwinpthread-1.dll")
+    endif()
   endif()
-
 endif()
+
+foreach( src_file ${COPY_FILES})
+    add_custom_command( TARGET edge-classic POST_BUILD
+    COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${src_file}" "${DEST_DIR}")
+endforeach( src_file )
+

--- a/source_files/edge/CMakeLists.txt
+++ b/source_files/edge/CMakeLists.txt
@@ -139,7 +139,7 @@ set (EDGE_LINK_LIBRARIES
   ymfmidi
 )
 
-if (MSVC OR MINGW OR MSYS OR WIN32_CLANG)
+if (WIN32)
   set (EDGE_SOURCE_FILES ${EDGE_SOURCE_FILES} w32_res.rc)
   set (EDGE_LINK_LIBRARIES ${EDGE_LINK_LIBRARIES} wsock32)
 endif()
@@ -149,7 +149,7 @@ add_executable(
   ${EDGE_SOURCE_FILES}
 )
 
-if(MSVC OR MSYS OR MINGW OR WIN32_CLANG)
+if(WIN32)
   target_compile_definitions(edge-classic PRIVATE WIN32)
 else()
   target_compile_definitions(edge-classic PRIVATE UNIX)
@@ -319,44 +319,47 @@ else()
 
 endif()
 
-# Copy appropriate SDL2.dll to local install directory when built with MSVC
-if(MSVC)
-  if (${CMAKE_SIZEOF_VOID_P} MATCHES 8)
+if (WIN32)
+  # Copy appropriate SDL2.dll to local install directory when built with MSVC
+  if(MSVC)
+    if (${CMAKE_SIZEOF_VOID_P} MATCHES 8)
+      add_custom_command(
+    TARGET edge-classic
+    POST_BUILD
+    COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/source_files/sdl2/lib/x64/SDL2.dll"
+        "${DEST_DIR}"
+    )
+    else ()
+      add_custom_command(
+    TARGET edge-classic
+    POST_BUILD
+    COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/source_files/sdl2/lib/x86/SDL2.dll"
+        "${DEST_DIR}"
+    )
+    endif ()
+  # Copy appropriate SDL2.dll to local install directory when built with MinGW
+  elseif(MinGW)
+    if (${CMAKE_SIZEOF_VOID_P} MATCHES 8)
     add_custom_command(
-	TARGET edge-classic
-	POST_BUILD
-	COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/source_files/sdl2/lib/x64/SDL2.dll"
-			"${DEST_DIR}"
-	)
-  else ()
+    TARGET edge-classic
+    POST_BUILD
+    COMMAND "${CMAKE_COMMAND}" -E copy "/mingw64/bin/SDL2.dll"
+        "${DEST_DIR}"
+    )
+    else ()
     add_custom_command(
-	TARGET edge-classic
-	POST_BUILD
-	COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/source_files/sdl2/lib/x86/SDL2.dll"
-			"${DEST_DIR}"
-	)
-  endif ()
-# Copy appropriate SDL2.dll to local install directory when built with MSYS2
-elseif(MSYS)
-	if (${CMAKE_SIZEOF_VOID_P} MATCHES 8)
-	add_custom_command(
-	TARGET edge-classic
-	POST_BUILD
-	COMMAND "${CMAKE_COMMAND}" -E copy "/mingw64/bin/SDL2.dll"
-			"${DEST_DIR}"
-	)
-	else ()
-	add_custom_command(
-	TARGET edge-classic
-	POST_BUILD
-	COMMAND "${CMAKE_COMMAND}" -E copy "/mingw32/bin/SDL2.dll"
-			"${DEST_DIR}"
-		COMMAND "${CMAKE_COMMAND}" -E copy "/mingw32/bin/libgcc_s_dw2-1.dll"
-			"${DEST_DIR}"
-		COMMAND "${CMAKE_COMMAND}" -E copy "/mingw32/bin/libstdc++-6.dll"
-			"${DEST_DIR}"
-		COMMAND "${CMAKE_COMMAND}" -E copy "/mingw32/bin/libwinpthread-1.dll"
-			"${DEST_DIR}"
-	)
-	endif ()
+    TARGET edge-classic
+    POST_BUILD
+    COMMAND "${CMAKE_COMMAND}" -E copy "/mingw32/bin/SDL2.dll"
+        "${DEST_DIR}"
+      COMMAND "${CMAKE_COMMAND}" -E copy "/mingw32/bin/libgcc_s_dw2-1.dll"
+        "${DEST_DIR}"
+      COMMAND "${CMAKE_COMMAND}" -E copy "/mingw32/bin/libstdc++-6.dll"
+        "${DEST_DIR}"
+      COMMAND "${CMAKE_COMMAND}" -E copy "/mingw32/bin/libwinpthread-1.dll"
+        "${DEST_DIR}"
+    )
+    endif ()
+  endif()
+
 endif()


### PR DESCRIPTION
This PR:

1) Removes generator specific conditionals in favor or platform/toolchain ones
2) Adds logging to cmake in actions so can better debug what is happening on Actions
3) Generates a list of files to copy post edge-classic build, and only copies them if different.  This also now uses a single custom command rather than multiple
4) Switches actions to use MSYS Makefiles generator for now, due to what I think is a weird quoting issue with the Ninja generator:

Ninja: 
```
cmd.exe /C "cd /D D:\a\EDGE-classic\EDGE-classic\build\source_files\edge && D:\a\_temp\msys64\mingw32\bin\cmake.exe -E copy_if_different D:/a/EDGE-classic/EDGE-classic/build/source_files/edge/edge-classic.exe /mingw32/bin/SDL2.dll /mingw32/bin/libgcc_s_dw2-1.dll /mingw32/bin/libstdc++-6.dll /mingw32/bin/libwinpthread-1.dll D:/a/EDGE-classic/EDGE-classic""
```

vs MSYS:

```
cd /D/a/EDGE-classic/EDGE-classic/build/source_files/edge && /D/a/_temp/msys64/mingw32/bin/cmake.exe -E copy_if_different D:/a/EDGE-classic/EDGE-classic/build/source_files/edge/edge-classic.exe /mingw32/bin/SDL2.dll /mingw32/bin/libgcc_s_dw2-1.dll /mingw32/bin/libstdc++-6.dll /mingw32/bin/libwinpthread-1.dll D:/a/EDGE-classic/EDGE-classic
```

This works fine with local Ninja binary, so think it might be something to do with the MSYS toolchain one.  I am not really liking MSYS, maybe we could cross compile for windows with Ubuntu image, would be easier to debug CIS issues locally too. 

I'll file a tracker for issue with Ninja on CIS, iterating on this and it taking 50%-100% longer to test is a bit painful... 

