### PR TITLE
Slider rework + sliders that can hold floating-point values

### DIFF
--- a/source_files/edge/defaults.h
+++ b/source_files/edge/defaults.h
@@ -59,7 +59,6 @@
 // Controls (Analogue)
 #define CFGDEF_MOUSE_XAXIS      (2*AXIS_TURN-1)
 #define CFGDEF_MOUSE_YAXIS      (2*AXIS_MLOOK-1)
-#define CFGDEF_MOUSESENSITIVITY (10)
 #define CFGDEF_TURNSPEED        (7)   // == 1.0 (the maximum)
 #define CFGDEF_MLOOKSPEED       (7)
 #define CFGDEF_FORWARDMOVESPEED (7)

--- a/source_files/edge/defaults.h
+++ b/source_files/edge/defaults.h
@@ -101,7 +101,6 @@
 #define CFGDEF_HAVE_EXTRA       (1)
 #define CFGDEF_TRUE3DGAMEPLAY   (1)
 #define CFGDEF_PASS_MISSILE     (1)
-#define CFGDEF_MENU_GRAV        (MENU_GRAV_NORMAL)
 #define CFGDEF_RES_RESPAWN      (1)       // Resurrect Mode 
 #define CFGDEF_ITEMRESPAWN      (0)
 #define CFGDEF_FASTPARM         (0)

--- a/source_files/edge/defaults.h
+++ b/source_files/edge/defaults.h
@@ -59,10 +59,6 @@
 // Controls (Analogue)
 #define CFGDEF_MOUSE_XAXIS      (2*AXIS_TURN-1)
 #define CFGDEF_MOUSE_YAXIS      (2*AXIS_MLOOK-1)
-#define CFGDEF_MLOOKSPEED       (7)
-#define CFGDEF_FORWARDMOVESPEED (7)
-#define CFGDEF_SIDEMOVESPEED    (7)
-#define CFGDEF_TRIGGERTHRESHOLD (3)
 
 #define CFGDEF_JOY_XAXIS        (2*AXIS_TURN-1)
 #define CFGDEF_JOY_YAXIS        (2*AXIS_FORWARD)

--- a/source_files/edge/defaults.h
+++ b/source_files/edge/defaults.h
@@ -68,8 +68,6 @@
 #define CFGDEF_SHOWMESSAGES     (1)
 
 // Sound and Music
-#define CFGDEF_SOUND_VOLUME     (8)
-#define CFGDEF_MUSIC_VOLUME     (8)
 #define CFGDEF_SOUND_STEREO     (1)  // Stereo
 #define CFGDEF_MIX_CHANNELS     (2)  // 32 channels
 

--- a/source_files/edge/defaults.h
+++ b/source_files/edge/defaults.h
@@ -59,7 +59,6 @@
 // Controls (Analogue)
 #define CFGDEF_MOUSE_XAXIS      (2*AXIS_TURN-1)
 #define CFGDEF_MOUSE_YAXIS      (2*AXIS_MLOOK-1)
-#define CFGDEF_TURNSPEED        (7)   // == 1.0 (the maximum)
 #define CFGDEF_MLOOKSPEED       (7)
 #define CFGDEF_FORWARDMOVESPEED (7)
 #define CFGDEF_SIDEMOVESPEED    (7)

--- a/source_files/edge/e_input.cc
+++ b/source_files/edge/e_input.cc
@@ -155,21 +155,12 @@ DEF_CVAR(debug_joyaxis, "0", 0)
 DEF_CVAR(mouse_xsens, "10.0", CVAR_ARCHIVE)
 DEF_CVAR(mouse_ysens, "10.0", CVAR_ARCHIVE)
 
-DEF_CVAR(turnspeed, "1.0", CVAR_ARCHIVE)
-
 // Speed controls
-int var_mlookspeed;
-int var_forwardspeed;
-int var_sidespeed;
-int var_flyspeed;
-
-static float speed_factors[12] =
-{
-	0.15, 0.25, 0.33, 0.42,
-	0.50, 0.66, 0.83, 1.00,
-	1.50, 2.00, 2.80, 4.00
-};
-
+DEF_CVAR(turnspeed, "1.0", CVAR_ARCHIVE)
+DEF_CVAR(vlookspeed, "1.0", CVAR_ARCHIVE)
+DEF_CVAR(forwardspeed, "1.0", CVAR_ARCHIVE)
+DEF_CVAR(sidespeed, "1.0", CVAR_ARCHIVE)
+DEF_CVAR(flyspeed, "1.0", CVAR_ARCHIVE)
 
 float JoyAxisFromRaw(int raw)
 {
@@ -374,7 +365,7 @@ void E_BuildTiccmd(ticcmd_t * cmd)
 		// -ACB- 1998/07/02 Use VertAngle for Look/up down.
 		float mlook = mlookturn[m_speed] * joy_forces[AXIS_MLOOK];
 
-		mlook *= speed_factors[var_mlookspeed];
+		mlook *= vlookspeed.f;
 
 		mlook += mlookturn[m_speed] * ball_deltas[AXIS_MLOOK] / 64.0;
 
@@ -385,7 +376,7 @@ void E_BuildTiccmd(ticcmd_t * cmd)
 	{
 		float forward = forwardmove[speed] * joy_forces[AXIS_FORWARD];
 
-		forward *= speed_factors[var_forwardspeed];
+		forward *= forwardspeed.f;
 
 		// -ACB- 1998/09/06 Forward Move Speed Control
 		forward += forwardmove[speed] * ball_deltas[AXIS_FORWARD] / 64.0;
@@ -402,7 +393,7 @@ void E_BuildTiccmd(ticcmd_t * cmd)
 		if (strafe)
 			side += sidemove[speed] * joy_forces[AXIS_TURN];
 
-		side *= speed_factors[var_sidespeed];
+		side *= sidespeed.f;
 
 		// -ACB- 1998/09/06 Side Move Speed Control
 		side += sidemove[speed] * ball_deltas[AXIS_STRAFE] / 64.0;
@@ -419,7 +410,7 @@ void E_BuildTiccmd(ticcmd_t * cmd)
 	{
 		float upward = upwardmove[speed] * joy_forces[AXIS_FLY];
 
-		upward *= speed_factors[var_flyspeed];
+		upward *= flyspeed.f;
 
 		upward += upwardmove[speed] * ball_deltas[AXIS_FLY] / 64.0;
 

--- a/source_files/edge/e_input.cc
+++ b/source_files/edge/e_input.cc
@@ -155,8 +155,9 @@ DEF_CVAR(debug_joyaxis, "0", 0)
 DEF_CVAR(mouse_xsens, "10.0", CVAR_ARCHIVE)
 DEF_CVAR(mouse_ysens, "10.0", CVAR_ARCHIVE)
 
+DEF_CVAR(turnspeed, "1.0", CVAR_ARCHIVE)
+
 // Speed controls
-int var_turnspeed;
 int var_mlookspeed;
 int var_forwardspeed;
 int var_sidespeed;
@@ -360,7 +361,7 @@ void E_BuildTiccmd(ticcmd_t * cmd)
 	{
 		float turn = angleturn[t_speed]/(r_doubleframes.d ? 2 : 1) * joy_forces[AXIS_TURN];
 		
-		turn *= speed_factors[var_turnspeed];
+		turn *= turnspeed.f;
 
 		// -ACB- 1998/09/06 Angle Turn Speed Control
 		turn += angleturn[t_speed] * ball_deltas[AXIS_TURN] / 64.0;

--- a/source_files/edge/e_input.cc
+++ b/source_files/edge/e_input.cc
@@ -134,9 +134,6 @@ static int mlookheld;  // for accelerative mlooking
 int mouse_xaxis;
 int mouse_yaxis;
 
-int mouse_xsens;
-int mouse_ysens;
-
 int joy_axis[6] = { 0, 0, 0, 0, 0, 0 };
 
 static int joy_last_raw[6];
@@ -155,21 +152,15 @@ DEF_CVAR(in_stageturn, "1", CVAR_ARCHIVE)
 DEF_CVAR(debug_mouse,   "0", 0)
 DEF_CVAR(debug_joyaxis, "0", 0)
 
+DEF_CVAR(mouse_xsens, "10.0", CVAR_ARCHIVE)
+DEF_CVAR(mouse_ysens, "10.0", CVAR_ARCHIVE)
+
 // Speed controls
 int var_turnspeed;
 int var_mlookspeed;
 int var_forwardspeed;
 int var_sidespeed;
 int var_flyspeed;
-
-
-static float sensitivities[16] =
-{
-	0.10, 0.25, 0.35, 0.50,
-	0.75, 1.00, 1.56, 2.21,
-	3.13, 4.42, 6.26, 8.84,
-	12.5, 17.7, 25.0, 35.4
-};
 
 static float speed_factors[12] =
 {
@@ -591,8 +582,8 @@ bool INP_Responder(event_t * ev)
 			if ((mouse_xaxis+1) & 1) dx = -dx;
 			if ((mouse_yaxis+1) & 1) dy = -dy;
 
-			dx *= sensitivities[mouse_xsens];
-			dy *= sensitivities[mouse_ysens];
+			dx *= mouse_xsens.f;
+			dy *= mouse_ysens.f;
 
 			if (debug_mouse.d)
 				I_Printf("Mouse %+04d %+04d --> %+7.2f %+7.2f\n",

--- a/source_files/edge/e_input.h
+++ b/source_files/edge/e_input.h
@@ -60,10 +60,10 @@ extern int joy_axis[6];
 //                   strafemovediv;
 //
 extern cvar_c turnspeed;
-extern int var_mlookspeed;
-extern int var_forwardspeed;
-extern int var_sidespeed;
-extern int var_flyspeed;
+extern cvar_c vlookspeed;
+extern cvar_c forwardspeed;
+extern cvar_c sidespeed;
+extern cvar_c flyspeed;
 
 
 /* keyboard stuff */

--- a/source_files/edge/e_input.h
+++ b/source_files/edge/e_input.h
@@ -59,7 +59,7 @@ extern int joy_axis[6];
 //                   horzmovement control, vertmovement control
 //                   strafemovediv;
 //
-extern int var_turnspeed;
+extern cvar_c turnspeed;
 extern int var_mlookspeed;
 extern int var_forwardspeed;
 extern int var_sidespeed;

--- a/source_files/edge/e_input.h
+++ b/source_files/edge/e_input.h
@@ -49,8 +49,8 @@ bool INP_Responder(event_t * ev);
 extern int mouse_xaxis;
 extern int mouse_yaxis;
 
-extern int mouse_xsens;
-extern int mouse_ysens;
+extern cvar_c mouse_xsens;
+extern cvar_c mouse_ysens;
 
 extern int joy_axis[6];
 //

--- a/source_files/edge/e_main.cc
+++ b/source_files/edge/e_main.cc
@@ -274,18 +274,18 @@ public:
 					SCREENHEIGHT / IM_HEIGHT(overlay));
 		}
 
-	if (v_gamma.d < 10)
+	if (v_gamma.f < 0)
 	{
-		int col = (1.0f - (0.1f * (10 - v_gamma.d))) * 255;
+		int col = (1.0f + v_gamma.f) * 255;
 		glEnable(GL_BLEND);
 		glBlendFunc(GL_ZERO, GL_SRC_COLOR);
 		HUD_SolidBox(hud_x_left, 0, hud_x_right, 200, RGB_MAKE(col, col, col));
 		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 		glDisable(GL_BLEND);
 	}
-	else if (v_gamma.d > 10)
+	else if (v_gamma.f > 0)
 	{
-		int col = (0.1f * -(10 - v_gamma.d)) * 255;
+		int col = v_gamma.f * 255;
 		glEnable(GL_BLEND);
 		glBlendFunc(GL_DST_COLOR, GL_ONE);
 		HUD_SolidBox(hud_x_left, 0, hud_x_right, 200, RGB_MAKE(col, col, col));
@@ -675,18 +675,18 @@ void E_Display(void)
 				SCREENHEIGHT / IM_HEIGHT(overlay));
 	}
 
-	if (v_gamma.d < 10)
+	if (v_gamma.f < 0)
 	{
-		int col = (1.0f - (0.1f * (10 - v_gamma.d))) * 255;
+		int col = (1.0f + v_gamma.f) * 255;
 		glEnable(GL_BLEND);
 		glBlendFunc(GL_ZERO, GL_SRC_COLOR);
 		HUD_SolidBox(hud_x_left, 0, hud_x_right, 200, RGB_MAKE(col, col, col));
 		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 		glDisable(GL_BLEND);
 	}
-	else if (v_gamma.d > 10)
+	else if (v_gamma.f > 0)
 	{
-		int col = (0.1f * -(10 - v_gamma.d)) * 255;
+		int col = v_gamma.f * 255;
 		glEnable(GL_BLEND);
 		glBlendFunc(GL_DST_COLOR, GL_ONE);
 		HUD_SolidBox(hud_x_left, 0, hud_x_right, 200, RGB_MAKE(col, col, col));

--- a/source_files/edge/e_main.cc
+++ b/source_files/edge/e_main.cc
@@ -163,7 +163,7 @@ gameflags_t default_gameflags =
 	false,  // item respawn
 
 	false,  // true 3d gameplay
-	GRAVITY, // gravity
+	8, // gravity
 	false,  // more blood
 
 	true,   // jump

--- a/source_files/edge/e_main.cc
+++ b/source_files/edge/e_main.cc
@@ -163,7 +163,7 @@ gameflags_t default_gameflags =
 	false,  // item respawn
 
 	false,  // true 3d gameplay
-	MENU_GRAV_NORMAL, // gravity
+	GRAVITY, // gravity
 	false,  // more blood
 
 	true,   // jump

--- a/source_files/edge/i_ctrl.cc
+++ b/source_files/edge/i_ctrl.cc
@@ -58,16 +58,11 @@ static int joy_num_balls;
 
 Uint8 last_hat; // Track last dpad input
 
-int var_triggerthreshold;
+DEF_CVAR(triggerthreshold, "0", CVAR_ARCHIVE)
 
 // Track trigger state to avoid pushing multiple unnecessary trigger events
 bool right_trigger_pulled = false;
 bool left_trigger_pulled = false;
-
-s16_t trigger_thresholds[7] = 
-{
-	30000, 20000, 10000, 0, -10000, -20000, -30000
-};
 
 //
 // Translates a key from SDL -> EDGE
@@ -411,7 +406,7 @@ void HandleJoystickTriggerEvent(SDL_Event * ev)
 	if (joy_axis[current_axis] == AXIS_LEFT_TRIGGER) 
 	{
 		event.value.key.sym = KEYD_TRIGGER_LEFT;
-		if (ev->jaxis.value < trigger_thresholds[var_triggerthreshold])
+		if (ev->jaxis.value < -triggerthreshold.d)
 		{
 			if (!left_trigger_pulled) return;
 			event.type = ev_keyup;
@@ -427,7 +422,7 @@ void HandleJoystickTriggerEvent(SDL_Event * ev)
 	else
 	{
 		event.value.key.sym = KEYD_TRIGGER_RIGHT;
-		if (ev->jaxis.value < trigger_thresholds[var_triggerthreshold])
+		if (ev->jaxis.value < -triggerthreshold.d)
 		{
 			if (!right_trigger_pulled) return;
 			event.type = ev_keyup;

--- a/source_files/edge/i_ctrl.h
+++ b/source_files/edge/i_ctrl.h
@@ -1,5 +1,5 @@
 // Small header to expose the analog trigger threshold and joystick axes to the misc/option menus - Dasho
 
-extern int var_triggerthreshold;
+extern cvar_c triggerthreshold;
 
 int I_JoyGetAxis(int n);

--- a/source_files/edge/i_video.cc
+++ b/source_files/edge/i_video.cc
@@ -35,7 +35,7 @@ int graphics_shutdown = 0;
 
 DEF_CVAR(in_grab, "1", CVAR_ARCHIVE)
 DEF_CVAR(v_sync,  "0", CVAR_ARCHIVE)
-DEF_CVAR(v_gamma, "10", CVAR_ARCHIVE)
+DEF_CVAR(v_gamma, "0", CVAR_ARCHIVE)
 
 // this is the Monitor Size setting, really an aspect ratio.
 // it defaults to 16:9, as that is the most common monitor size nowadays.

--- a/source_files/edge/i_video.cc
+++ b/source_files/edge/i_video.cc
@@ -393,7 +393,7 @@ void I_StartFrame(void)
 	glClearColor(0, 0, 0, 0);
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 	if (r_culling.d)
-		r_farclip.f = 1500.0f + (r_culldist.d * 1000.0f);
+		r_farclip.f = r_culldist.f;
 	else
 		r_farclip.f = 64000.0;
 }

--- a/source_files/edge/m_menu.cc
+++ b/source_files/edge/m_menu.cc
@@ -2336,7 +2336,7 @@ void M_DrawFracThermo(int x, int y, float thermDot, float increment, int div, fl
 
 	thermDot = CLAMP(min, thermDot, max);
 
-	thermDot = thermDot - (std::fmodf(thermDot, increment));
+	thermDot = thermDot - (fmodf(thermDot, increment));
 
 	style_c *opt_style = hu_styles.Lookup(styledefs.Lookup("OPTIONS"));
 

--- a/source_files/edge/m_menu.cc
+++ b/source_files/edge/m_menu.cc
@@ -67,6 +67,8 @@
 
 #include "i_sdlinc.h"
 
+#include <cmath>
+
 // Menu navigation stuff
 int key_menu_open;
 int key_menu_up;
@@ -2288,23 +2290,23 @@ void M_DrawThermo(int x, int y, int thermWidth, int thermDot, int div)
 {
 	int i, basex = x;
 	int step = (8 / div);
-	int pos = 254;
 
 	style_c *opt_style = hu_styles.Lookup(styledefs.Lookup("OPTIONS"));
 
-	// If using an IMAGE or TRUETYPE type font for the menu, use symbols for the slider instead
+	// If using an IMAGE or TRUETYPE type font for the menu, use a COALHUDs-style bar for the slider instead
 	if (opt_style->fonts[styledef_c::T_ALT]->def->type == FNTYP_Image || opt_style->fonts[styledef_c::T_ALT]->def->type == FNTYP_TrueType)
 	{
-		// Quick solid box code if a background is desired for the slider in the future
-		// HUD_SolidBox(x, y, x+(thermWidth*step), y+opt_style->fonts[styledef_c::T_ALT]->im_char_height, RGB_MAKE(100,100,100));
-		for (i=0; i < thermDot; i++, x += step)
-		{
-			HL_WriteText(opt_style, styledef_c::T_ALT, x, y, (const char *)&pos);
-		}
-		for (i=1; i < thermWidth - thermDot; i++, x += step)
-		{
-			HL_WriteText(opt_style, styledef_c::T_ALT, x, y-2, "-", 1.5);
-		}
+		rgbcol_t slider_color = RGB_MAKE(255,255,255);
+
+		const colourmap_c *colmap = opt_style->def->text[styledef_c::T_ALT].colmap;
+
+		if (colmap)
+			slider_color = V_GetFontColor(colmap);
+
+		HUD_ThinBox(x, y + (opt_style->fonts[styledef_c::T_ALT]->def->type == FNTYP_TrueType ? opt_style->fonts[styledef_c::T_ALT]->ttf_ref_yshift : 0), 
+			x+(thermWidth*step)-step, y+opt_style->fonts[styledef_c::T_ALT]->NominalHeight(), slider_color);
+		HUD_SolidBox(x, y + (opt_style->fonts[styledef_c::T_ALT]->def->type == FNTYP_TrueType ? opt_style->fonts[styledef_c::T_ALT]->ttf_ref_yshift : 0), 
+			x+(thermDot*step), y+opt_style->fonts[styledef_c::T_ALT]->NominalHeight(), slider_color);
 	}
 	else
 	{
@@ -2328,28 +2330,30 @@ void M_DrawThermo(int x, int y, int thermWidth, int thermDot, int div)
 
 void M_DrawFracThermo(int x, int y, float thermDot, float increment, int div, float min, float max)
 {
-	int basex = x;
+	float basex = x;
 	int step = (8 / div);
-	int pos = 254;
 	float i = 0.0f;
 
 	thermDot = CLAMP(min, thermDot, max);
 
+	thermDot = thermDot - (std::fmodf(thermDot, increment));
+
 	style_c *opt_style = hu_styles.Lookup(styledefs.Lookup("OPTIONS"));
 
-	// If using an IMAGE or TRUETYPE type font for the menu, use symbols for the slider instead
+	// If using an IMAGE or TRUETYPE type font for the menu, use a COALHUDs-style bar for the slider instead
 	if (opt_style->fonts[styledef_c::T_ALT]->def->type == FNTYP_Image || opt_style->fonts[styledef_c::T_ALT]->def->type == FNTYP_TrueType)
 	{
-		// Quick solid box code if a background is desired for the slider in the future
-		// HUD_SolidBox(x, y, x+(thermWidth*step), y+opt_style->fonts[styledef_c::T_ALT]->im_char_height, RGB_MAKE(100,100,100));
-		for (i=min; i < thermDot; i+=increment, x += step)
-		{
-			HL_WriteText(opt_style, styledef_c::T_ALT, x, y, (const char *)&pos);
-		}
-		for (i=thermDot; i < max; i+=increment, x += step)
-		{
-			HL_WriteText(opt_style, styledef_c::T_ALT, x, y-2, "-", 1.5);
-		}
+		rgbcol_t slider_color = RGB_MAKE(255,255,255);
+
+		const colourmap_c *colmap = opt_style->def->text[styledef_c::T_ALT].colmap;
+
+		if (colmap)
+			slider_color = V_GetFontColor(colmap);
+
+		HUD_ThinBox(x, y + (opt_style->fonts[styledef_c::T_ALT]->def->type == FNTYP_TrueType ? opt_style->fonts[styledef_c::T_ALT]->ttf_ref_yshift : 0), 
+			x+(((max-min)/increment)*(step * increment)), y+opt_style->fonts[styledef_c::T_ALT]->NominalHeight(), slider_color);
+		HUD_SolidBox(x, y + (opt_style->fonts[styledef_c::T_ALT]->def->type == FNTYP_TrueType ? opt_style->fonts[styledef_c::T_ALT]->ttf_ref_yshift : 0), 
+			x+(((thermDot-min)/increment)*(step * increment)), y+opt_style->fonts[styledef_c::T_ALT]->NominalHeight(), slider_color);
 	}
 	else
 	{
@@ -2358,7 +2362,7 @@ void M_DrawFracThermo(int x, int y, float thermDot, float increment, int div, fl
 
 		HUD_StretchImage(x, y, step+1, IM_HEIGHT(therm_l)/div, therm_l, 0.0, 0.0);
 
-		for (i=min, x += step; i < max; i+=increment, x += step)
+		for (i=min, x += step; i < max; i+=increment, x += (step*increment))
 		{
 			HUD_StretchImage(x, y, step+1, IM_HEIGHT(therm_m)/div, therm_m, 0.0, 0.0);
 		}

--- a/source_files/edge/m_menu.cc
+++ b/source_files/edge/m_menu.cc
@@ -285,7 +285,7 @@ extern void M_F4SoundOptions(int choice);
 static void M_LoadSavePage(int choice);
 static void M_ReadThis(int choice);
 static void M_ReadThis2(int choice);
-void M_EndGame(int choice);
+void M_EndGame(int choice, cvar_c *cvar);
 
 static void M_ChangeMessages(int choice);
 
@@ -2110,7 +2110,7 @@ static void EndGameResponse(int ch)
 	M_ClearMenus();
 }
 
-void M_EndGame(int choice)
+void M_EndGame(int choice, cvar_c *cvar)
 {
 	if (gamestate != GS_LEVEL)
 	{
@@ -2321,6 +2321,51 @@ void M_DrawThermo(int x, int y, int thermWidth, int thermDot, int div)
 		HUD_StretchImage(x, y, step+1, IM_HEIGHT(therm_r)/div, therm_r, 0.0, 0.0);
 
 		x = basex + step + thermDot * step;
+
+		HUD_StretchImage(x, y, step+1, IM_HEIGHT(therm_o)/div, therm_o, 0.0, 0.0);
+	}
+}
+
+void M_DrawFracThermo(int x, int y, float thermDot, float increment, int div, float min, float max)
+{
+	int basex = x;
+	int step = (8 / div);
+	int pos = 254;
+	float i = 0.0f;
+
+	thermDot = CLAMP(min, thermDot, max);
+
+	style_c *opt_style = hu_styles.Lookup(styledefs.Lookup("OPTIONS"));
+
+	// If using an IMAGE or TRUETYPE type font for the menu, use symbols for the slider instead
+	if (opt_style->fonts[styledef_c::T_ALT]->def->type == FNTYP_Image || opt_style->fonts[styledef_c::T_ALT]->def->type == FNTYP_TrueType)
+	{
+		// Quick solid box code if a background is desired for the slider in the future
+		// HUD_SolidBox(x, y, x+(thermWidth*step), y+opt_style->fonts[styledef_c::T_ALT]->im_char_height, RGB_MAKE(100,100,100));
+		for (i=min; i < thermDot; i+=increment, x += step)
+		{
+			HL_WriteText(opt_style, styledef_c::T_ALT, x, y, (const char *)&pos);
+		}
+		for (i=thermDot; i < max; i+=increment, x += step)
+		{
+			HL_WriteText(opt_style, styledef_c::T_ALT, x, y-2, "-", 1.5);
+		}
+	}
+	else
+	{
+		// Note: the (step+1) here is for compatibility with the original
+		// code.  It seems required to make the thermo bar tile properly.
+
+		HUD_StretchImage(x, y, step+1, IM_HEIGHT(therm_l)/div, therm_l, 0.0, 0.0);
+
+		for (i=min, x += step; i < max; i+=increment, x += step)
+		{
+			HUD_StretchImage(x, y, step+1, IM_HEIGHT(therm_m)/div, therm_m, 0.0, 0.0);
+		}
+
+		HUD_StretchImage(x, y, step+1, IM_HEIGHT(therm_r)/div, therm_r, 0.0, 0.0);
+
+		x = basex + thermDot * step-1;
 
 		HUD_StretchImage(x, y, step+1, IM_HEIGHT(therm_o)/div, therm_o, 0.0, 0.0);
 	}

--- a/source_files/edge/m_menu.cc
+++ b/source_files/edge/m_menu.cc
@@ -2333,6 +2333,8 @@ void M_DrawFracThermo(int x, int y, float thermDot, float increment, int div, fl
 	float basex = x;
 	int step = (8 / div);
 	float i = 0.0f;
+	// Capture actual value first since it will be aligned to the slider increment
+	std::string actual_val = epi::STR_Format("%0.2f", thermDot);	
 
 	thermDot = CLAMP(min, thermDot, max);
 
@@ -2354,6 +2356,7 @@ void M_DrawFracThermo(int x, int y, float thermDot, float increment, int div, fl
 			x+(((max-min)/increment)*(step * increment)), y+opt_style->fonts[styledef_c::T_ALT]->NominalHeight(), slider_color);
 		HUD_SolidBox(x, y + (opt_style->fonts[styledef_c::T_ALT]->def->type == FNTYP_TrueType ? opt_style->fonts[styledef_c::T_ALT]->ttf_ref_yshift : 0), 
 			x+(((thermDot-min)/increment)*(step * increment)), y+opt_style->fonts[styledef_c::T_ALT]->NominalHeight(), slider_color);
+		HL_WriteText(opt_style, styledef_c::T_ALT, x+(((max-min)/increment)*(step * increment)) + step, y, actual_val.c_str());
 	}
 	else
 	{
@@ -2372,6 +2375,8 @@ void M_DrawFracThermo(int x, int y, float thermDot, float increment, int div, fl
 		x = basex + thermDot * step-1;
 
 		HUD_StretchImage(x, y, step+1, IM_HEIGHT(therm_o)/div, therm_o, 0.0, 0.0);
+
+		HL_WriteText(opt_style, styledef_c::T_ALT, basex+(((max-min)/increment)*(step * increment)) + (step*2+2), y, actual_val.c_str());
 	}
 }
 

--- a/source_files/edge/m_menu.cc
+++ b/source_files/edge/m_menu.cc
@@ -2332,13 +2332,14 @@ void M_DrawFracThermo(int x, int y, float thermDot, float increment, int div, fl
 {
 	float basex = x;
 	int step = (8 / div);
-	float i = 0.0f;
+	float scale_step = 50.0f / ((max-min) / increment);
+
 	// Capture actual value first since it will be aligned to the slider increment
 	std::string actual_val = epi::STR_Format("%0.2f", thermDot);	
 
 	thermDot = CLAMP(min, thermDot, max);
 
-	thermDot = thermDot - (fmodf(thermDot, increment));
+	thermDot = thermDot - remainderf(thermDot, increment);
 
 	style_c *opt_style = hu_styles.Lookup(styledefs.Lookup("OPTIONS"));
 
@@ -2353,30 +2354,31 @@ void M_DrawFracThermo(int x, int y, float thermDot, float increment, int div, fl
 			slider_color = V_GetFontColor(colmap);
 
 		HUD_ThinBox(x, y + (opt_style->fonts[styledef_c::T_ALT]->def->type == FNTYP_TrueType ? opt_style->fonts[styledef_c::T_ALT]->ttf_ref_yshift : 0), 
-			x+(((max-min)/increment)*(step * increment)), y+opt_style->fonts[styledef_c::T_ALT]->NominalHeight(), slider_color);
+			x+50.0f, y+opt_style->fonts[styledef_c::T_ALT]->NominalHeight(), slider_color);
 		HUD_SolidBox(x, y + (opt_style->fonts[styledef_c::T_ALT]->def->type == FNTYP_TrueType ? opt_style->fonts[styledef_c::T_ALT]->ttf_ref_yshift : 0), 
-			x+(((thermDot-min)/increment)*(step * increment)), y+opt_style->fonts[styledef_c::T_ALT]->NominalHeight(), slider_color);
-		HL_WriteText(opt_style, styledef_c::T_ALT, x+(((max-min)/increment)*(step * increment)) + step, y, actual_val.c_str());
+			x+(((thermDot-min)/increment)*scale_step), y+opt_style->fonts[styledef_c::T_ALT]->NominalHeight(), slider_color);
+		HL_WriteText(opt_style, styledef_c::T_ALT, x+50.0f + step, y, actual_val.c_str());
 	}
 	else
 	{
 		// Note: the (step+1) here is for compatibility with the original
 		// code.  It seems required to make the thermo bar tile properly.
 
+		int i=0;
+		float scale_step = 50.0f / ((max-min) / increment);
+
 		HUD_StretchImage(x, y, step+1, IM_HEIGHT(therm_l)/div, therm_l, 0.0, 0.0);
 
-		for (i=min, x += step; i < max; i+=increment, x += (step*increment))
+		for (i, x += step; i < (50/step); i++, x += step)
 		{
 			HUD_StretchImage(x, y, step+1, IM_HEIGHT(therm_m)/div, therm_m, 0.0, 0.0);
 		}
 
 		HUD_StretchImage(x, y, step+1, IM_HEIGHT(therm_r)/div, therm_r, 0.0, 0.0);
 
-		x = basex + thermDot * step-1;
+		HUD_StretchImage(basex + ((thermDot-min)/increment) * scale_step-1, y, step+1, IM_HEIGHT(therm_o)/div, therm_o, 0.0, 0.0);
 
-		HUD_StretchImage(x, y, step+1, IM_HEIGHT(therm_o)/div, therm_o, 0.0, 0.0);
-
-		HL_WriteText(opt_style, styledef_c::T_ALT, basex+(((max-min)/increment)*(step * increment)) + (step*2+2), y, actual_val.c_str());
+		HL_WriteText(opt_style, styledef_c::T_ALT, basex+(((max-min)/increment)*scale_step) + (step*2+2), y, actual_val.c_str());
 	}
 }
 

--- a/source_files/edge/m_menu.h
+++ b/source_files/edge/m_menu.h
@@ -101,10 +101,12 @@ void M_StartMessage(const char *string, void (* routine)(int response),
 void M_StartMessageInput(const char *string, 
     void (* routine)(const char *response));
 
-void M_EndGame(int choice);
+void M_EndGame(int choice, cvar_c *cvar = nullptr);
 void M_QuitEDGE(int choice);
 void M_ImmediateQuit(void);
 void M_DrawThermo(int x, int y, int thermWidth, int thermDot, int div);
+void M_DrawFracThermo(int x, int y, float thermDot, float increment, int div,
+    float min, float max);
 void M_ClearMenus(void);
 
 #endif // __M_MENU__

--- a/source_files/edge/m_misc.cc
+++ b/source_files/edge/m_misc.cc
@@ -149,13 +149,6 @@ static default_t defaults[] =
     {CFGT_Int,      "mouse_axis_x",      &mouse_xaxis,  CFGDEF_MOUSE_XAXIS},
     {CFGT_Int,      "mouse_axis_y",      &mouse_yaxis,  CFGDEF_MOUSE_YAXIS},
 
-    // -ACB- 1998/09/06 Two-stage turning & Speed controls added
-    {CFGT_Int,      "var_mlookspeed",    &var_mlookspeed,   CFGDEF_MLOOKSPEED},
-    {CFGT_Int,      "var_forwardspeed",  &var_forwardspeed, CFGDEF_FORWARDMOVESPEED},
-    {CFGT_Int,      "var_sidespeed",     &var_sidespeed,    CFGDEF_SIDEMOVESPEED},
-    {CFGT_Int,      "var_flyspeed",      &var_flyspeed,     CFGDEF_SIDEMOVESPEED},
-	{CFGT_Int, 		"var_triggerthreshold", &var_triggerthreshold, CFGDEF_TRIGGERTHRESHOLD},
-
     {CFGT_Int,      "joystick_device",   &joystick_device, 1},
     {CFGT_Int,      "joy_axis1",         &joy_axis[0],    7},
     {CFGT_Int,      "joy_axis2",         &joy_axis[1],    6},

--- a/source_files/edge/m_misc.cc
+++ b/source_files/edge/m_misc.cc
@@ -148,8 +148,6 @@ static default_t defaults[] =
     //                 analogue binding added
     {CFGT_Int,      "mouse_axis_x",      &mouse_xaxis,  CFGDEF_MOUSE_XAXIS},
     {CFGT_Int,      "mouse_axis_y",      &mouse_yaxis,  CFGDEF_MOUSE_YAXIS},
-    {CFGT_Int,      "mouse_sens_x",      &mouse_xsens,  CFGDEF_MOUSESENSITIVITY},
-    {CFGT_Int,      "mouse_sens_y",      &mouse_ysens,  CFGDEF_MOUSESENSITIVITY},
 
     // -ACB- 1998/09/06 Two-stage turning & Speed controls added
     {CFGT_Int,      "var_turnspeed",     &var_turnspeed,    CFGDEF_TURNSPEED},
@@ -326,7 +324,7 @@ static void SetToBaseValue(default_t *def)
 	}
 }
 
-void M_ResetDefaults(int _dummy)
+void M_ResetDefaults(int _dummy, cvar_c *_dummy_cvar)
 {
 	
 	for (int i = 0; i < numdefaults; i++)

--- a/source_files/edge/m_misc.cc
+++ b/source_files/edge/m_misc.cc
@@ -117,7 +117,6 @@ static default_t defaults[] =
     {CFGT_Boolean,  "itemrespawn",       &global_flags.itemrespawn, CFGDEF_ITEMRESPAWN},
     {CFGT_Boolean,  "respawn",           &global_flags.respawn, CFGDEF_RESPAWN},
     {CFGT_Boolean,  "fastparm",          &global_flags.fastparm, CFGDEF_FASTPARM},
-    {CFGT_Int,      "grav",              &global_flags.menu_grav, CFGDEF_MENU_GRAV},
     {CFGT_Boolean,  "true3dgameplay",    &global_flags.true3dgameplay, CFGDEF_TRUE3DGAMEPLAY},
     {CFGT_Enum,     "autoaim",           &global_flags.autoaim, CFGDEF_AUTOAIM},
     {CFGT_Int,      "doom_fading",       &doom_fading,    CFGDEF_DOOM_FADING},

--- a/source_files/edge/m_misc.cc
+++ b/source_files/edge/m_misc.cc
@@ -56,7 +56,6 @@
 #include "p_spec.h"
 #include "r_gldefs.h"
 #include "s_blit.h"
-#include "s_music.h"  // mus_volume
 #include "s_sound.h"
 #include "am_map.h"
 #include "r_colormap.h"
@@ -98,8 +97,6 @@ static default_t defaults[] =
     {CFGT_Boolean,	"directx",			 &force_directx,  0},
     {CFGT_Boolean,	"waveout",			 &force_waveout,  0},
  
-    {CFGT_Int,      "sfx_volume",        &sfx_volume,     CFGDEF_SOUND_VOLUME},
-    {CFGT_Int,      "music_volume",      &mus_volume,     CFGDEF_MUSIC_VOLUME},
     {CFGT_Int,      "sound_stereo",      &var_sound_stereo, CFGDEF_SOUND_STEREO},
     {CFGT_Boolean,	"pc_speaker_mode",	 &var_pc_speaker_mode,  0},
     {CFGT_Int,		"midi_player",		 &var_midi_player,   0},

--- a/source_files/edge/m_misc.cc
+++ b/source_files/edge/m_misc.cc
@@ -150,7 +150,6 @@ static default_t defaults[] =
     {CFGT_Int,      "mouse_axis_y",      &mouse_yaxis,  CFGDEF_MOUSE_YAXIS},
 
     // -ACB- 1998/09/06 Two-stage turning & Speed controls added
-    {CFGT_Int,      "var_turnspeed",     &var_turnspeed,    CFGDEF_TURNSPEED},
     {CFGT_Int,      "var_mlookspeed",    &var_mlookspeed,   CFGDEF_MLOOKSPEED},
     {CFGT_Int,      "var_forwardspeed",  &var_forwardspeed, CFGDEF_FORWARDMOVESPEED},
     {CFGT_Int,      "var_sidespeed",     &var_sidespeed,    CFGDEF_SIDEMOVESPEED},

--- a/source_files/edge/m_misc.h
+++ b/source_files/edge/m_misc.h
@@ -54,7 +54,7 @@ typedef struct
 }
 default_t;
 
-void M_ResetDefaults(int _dummy);
+void M_ResetDefaults(int _dummy, cvar_c *_dummy_cvar = nullptr);
 void M_LoadDefaults(void);
 void M_LoadBranding(void);
 void M_SaveDefaults(void);

--- a/source_files/edge/m_option.cc
+++ b/source_files/edge/m_option.cc
@@ -487,11 +487,11 @@ static optmenuitem_t analogueoptions[] =
 	{OPT_Switch,   "Sixth Axis",         Axis, 13, &joy_axis[5], NULL, NULL},
 
 	{OPT_Plain,    "",                   NULL, 0,  NULL, NULL, NULL},
-	{OPT_FracSlider, "Turning Speed",  NULL, 0, &turnspeed.f, M_UpdateCVARFromFloat, NULL, &turnspeed, 0.10f, 0.10f, 3.0f},
-	{OPT_Slider,   "MLook Speed",        NULL, 12, &var_mlookspeed,   NULL, NULL},
-	{OPT_Slider,   "Forward Move Speed", NULL, 8,  &var_forwardspeed, NULL, NULL},
-	{OPT_Slider,   "Side Move Speed",    NULL, 8,  &var_sidespeed,    NULL, NULL},
-	{OPT_Slider,   "Trigger Sensitivity",    NULL, 7,  &var_triggerthreshold,    NULL, NULL},
+	{OPT_FracSlider, "Turning Speed",  NULL, 0, &turnspeed.f,  M_UpdateCVARFromFloat, NULL, &turnspeed, 0.10f, 0.10f, 3.0f},
+	{OPT_FracSlider, "Vertical Look Speed",    NULL, 0, &vlookspeed.f, M_UpdateCVARFromFloat, NULL, &vlookspeed, 0.10f, 0.10f, 3.0f},
+	{OPT_FracSlider, "Forward Move Speed",    NULL, 0, &forwardspeed.f, M_UpdateCVARFromFloat, NULL, &forwardspeed, 0.10f, 0.10f, 3.0f},
+	{OPT_FracSlider, "Side Move Speed",    NULL, 0, &sidespeed.f, M_UpdateCVARFromFloat, NULL, &sidespeed, 0.10f, 0.10f, 3.0f},
+	{OPT_FracSlider, "Trigger Sensitivity",    NULL, 0, &triggerthreshold.d, M_UpdateCVARFromInt, NULL, &triggerthreshold, 1000, -30000, 30000},
 };
 
 static menuinfo_t analogue_optmenu = 

--- a/source_files/edge/m_option.cc
+++ b/source_files/edge/m_option.cc
@@ -474,8 +474,8 @@ static optmenuitem_t analogueoptions[] =
 {
 	{OPT_Switch,   "Mouse X Axis",       Axis, 11, &mouse_xaxis, NULL, NULL},
 	{OPT_Switch,   "Mouse Y Axis",       Axis, 11, &mouse_yaxis, NULL, NULL},
-	{OPT_FracSlider,   "X Sensitivity",      NULL, 0, &mouse_xsens.f, M_UpdateCVARFromFloat, NULL, &mouse_xsens, 1.0f, 1.0f, 15.0f},
-	{OPT_FracSlider,   "Y Sensitivity",      NULL, 0, &mouse_ysens.f, M_UpdateCVARFromFloat, NULL, &mouse_ysens, 1.0f, 1.0f, 15.0f},
+	{OPT_FracSlider,   "X Sensitivity",      NULL, 0, &mouse_xsens.f, M_UpdateCVARFromFloat, NULL, &mouse_xsens, 0.25f, 1.0f, 15.0f},
+	{OPT_FracSlider,   "Y Sensitivity",      NULL, 0, &mouse_ysens.f, M_UpdateCVARFromFloat, NULL, &mouse_ysens, 0.25f, 1.0f, 15.0f},
 	{OPT_Plain,    "",                   NULL, 0,  NULL, NULL, NULL},
 
 	{OPT_Switch,   "Joystick Device", JoyDevs, 7,  &joystick_device, NULL, NULL},
@@ -1560,6 +1560,8 @@ bool M_OptResponder(event_t * ev, int ch)
 				{
 					float *val_ptr = (float*)curr_item->switchvar;
 
+					*val_ptr = *val_ptr - (std::fmodf(*val_ptr, curr_item->increment));
+
 					if (*val_ptr > curr_item->min)
 					{
 						*val_ptr = *val_ptr - curr_item->increment;
@@ -1658,6 +1660,8 @@ bool M_OptResponder(event_t * ev, int ch)
 				case OPT_FracSlider:
 				{
 					float *val_ptr = (float*)curr_item->switchvar;
+
+					*val_ptr = *val_ptr - (std::fmodf(*val_ptr, curr_item->increment));
 
 					if (*val_ptr < curr_item->max)
 					{

--- a/source_files/edge/m_option.cc
+++ b/source_files/edge/m_option.cc
@@ -592,8 +592,8 @@ static optmenuitem_t playoptions[] =
 	{OPT_Boolean, "Erraticism",   YesNo, 2, 
      &g_erraticism.d, M_UpdateCVARFromInt, "Time only advances when you move or fire", &g_erraticism},
 
-	{OPT_Slider,  "Gravity",            NULL, 20, 
-     &global_flags.menu_grav, NULL, "Gravity"},
+	{OPT_FracSlider,  "Gravity",            NULL, 0, 
+     &g_gravity.f, M_UpdateCVARFromFloat, "Gravity", &g_gravity, 0.10f, 0.0f, 2.0f},
 
     {OPT_Boolean, "Respawn Enemies",            YesNo, 2, 
      &global_flags.respawn, M_ChangeRespawn, NULL},
@@ -622,8 +622,8 @@ static optmenuitem_t perfoptions[] =
 {
 	{OPT_Boolean, "Draw Distance Culling", YesNo, 2, 
      &r_culling.d, M_UpdateCVARFromInt, NULL, &r_culling},
-	{OPT_Switch, "Maximum Draw Distance", "2000/3000/4000/5000/6000/7000/8000", 7, 
-     &r_culldist.d, M_UpdateCVARFromInt, "Only effective when Draw Distance Culling is On", &r_culldist},
+	{OPT_FracSlider, "Maximum Draw Distance", NULL, 0, 
+     &r_culldist.f, M_UpdateCVARFromFloat, "Only effective when Draw Distance Culling is On", &r_culldist, 200.0f, 1000.0f, 8000.0f},
 	{OPT_Switch, "Outdoor Culling Fog Color", "Match Sky/White/Grey/Black", 4, 
      &r_cullfog.d, M_UpdateCVARFromInt, "Only effective when Draw Distance Culling is On", &r_cullfog},
 	{OPT_Boolean, "Slow Thinkers Over Distance", YesNo, 2, 

--- a/source_files/edge/m_option.cc
+++ b/source_files/edge/m_option.cc
@@ -1560,7 +1560,7 @@ bool M_OptResponder(event_t * ev, int ch)
 				{
 					float *val_ptr = (float*)curr_item->switchvar;
 
-					*val_ptr = *val_ptr - (std::fmodf(*val_ptr, curr_item->increment));
+					*val_ptr = *val_ptr - (fmodf(*val_ptr, curr_item->increment));
 
 					if (*val_ptr > curr_item->min)
 					{
@@ -1661,7 +1661,7 @@ bool M_OptResponder(event_t * ev, int ch)
 				{
 					float *val_ptr = (float*)curr_item->switchvar;
 
-					*val_ptr = *val_ptr - (std::fmodf(*val_ptr, curr_item->increment));
+					*val_ptr = *val_ptr - (fmodf(*val_ptr, curr_item->increment));
 
 					if (*val_ptr < curr_item->max)
 					{

--- a/source_files/edge/m_option.cc
+++ b/source_files/edge/m_option.cc
@@ -117,6 +117,7 @@
 
 #include "defaults.h"
 
+#include <cmath>
 
 int option_menuon = 0;
 bool fkey_menu = false;
@@ -151,69 +152,60 @@ extern int joystick_device;
 extern int entry_playing;
 
 //submenus
-static void M_KeyboardOptions(int keypressed);
-static void M_VideoOptions(int keypressed);
-static void M_GameplayOptions(int keypressed);
-static void M_PerformanceOptions(int keypressed);
-static void M_AnalogueOptions(int keypressed);
-static void M_SoundOptions(int keypressed);
+static void M_KeyboardOptions(int keypressed, cvar_c *cvar = nullptr);
+static void M_VideoOptions(int keypressed, cvar_c *cvar = nullptr);
+static void M_GameplayOptions(int keypressed, cvar_c *cvar = nullptr);
+static void M_PerformanceOptions(int keypressed, cvar_c *cvar = nullptr);
+static void M_AnalogueOptions(int keypressed, cvar_c *cvar = nullptr);
+static void M_SoundOptions(int keypressed, cvar_c *cvar = nullptr);
 
 static void M_Key2String(int key, char *deststring);
 
-// -ACB- 1998/08/09 "Does Map allow these changes?" procedures.
-static void M_ChangeMonsterRespawn(int keypressed);
-static void M_ChangeItemRespawn(int keypressed);
-static void M_ChangeTrue3d(int keypressed);
-static void M_ChangeAutoAim(int keypressed);
-static void M_ChangeFastparm(int keypressed);
-static void M_ChangeRespawn(int keypressed);
-static void M_ChangePassMissile(int keypressed);
-static void M_ChangeCrossHair(int keypressed);
-static void M_ChangeCrossColor(int keypressed);
-static void M_ChangeCrossSize(int keypressed);
+// Use these when a menu option does nothing special other than update a value
+static void M_UpdateCVARFromFloat(int keypressed, cvar_c *cvar = nullptr);
+static void M_UpdateCVARFromInt(int keypressed, cvar_c *cvar = nullptr);
 
-static void M_ChangeMaxDLights(int keypressed);
-static void M_ChangeCulling(int keypressed);
-static void M_ChangeCullDist(int keypressed);
-static void M_ChangeCullFog(int keypressed);
-static void M_ChangeThinkerCulling(int keypressed);
-static void M_ChangeMBF21Compat(int keypressed);
-static void M_ChangeBobbing(int keypressed);
-static void M_ChangeBlood(int keypressed);
-static void M_ChangeMLook(int keypressed);
-static void M_ChangeJumping(int keypressed);
-static void M_ChangeCrouching(int keypressed);
-static void M_ChangeExtra(int keypressed);
-static void M_ChangeSecBright(int keypressed);
-static void M_ChangeGamma(int keypressed);
-static void M_ChangeMonitorSize(int keypressed);
-static void M_ChangeKicking(int keypressed);
-static void M_ChangeWeaponSwitch(int keypressed);
-static void M_ChangeMipMap(int keypressed);
-static void M_SaveOverlay(int keypressed);
-static void M_ChangeDLights(int keypressed);
-static void M_ChangePCSpeakerMode(int keypressed);
+// -ACB- 1998/08/09 "Does Map allow these changes?" procedures.
+static void M_ChangeMonsterRespawn(int keypressed, cvar_c *cvar = nullptr);
+static void M_ChangeItemRespawn(int keypressed, cvar_c *cvar = nullptr);
+static void M_ChangeTrue3d(int keypressed, cvar_c *cvar = nullptr);
+static void M_ChangeAutoAim(int keypressed, cvar_c *cvar = nullptr);
+static void M_ChangeFastparm(int keypressed, cvar_c *cvar = nullptr);
+static void M_ChangeRespawn(int keypressed, cvar_c *cvar = nullptr);
+static void M_ChangePassMissile(int keypressed, cvar_c *cvar = nullptr);
+static void M_ChangeCrossHair(int keypressed, cvar_c *cvar = nullptr);
+static void M_ChangeCrossColor(int keypressed, cvar_c *cvar = nullptr);
+static void M_ChangeCrossSize(int keypressed, cvar_c *cvar = nullptr);
+static void M_ChangeBobbing(int keypressed, cvar_c *cvar = nullptr);
+static void M_ChangeBlood(int keypressed, cvar_c *cvar = nullptr);
+static void M_ChangeMLook(int keypressed, cvar_c *cvar = nullptr);
+static void M_ChangeJumping(int keypressed, cvar_c *cvar = nullptr);
+static void M_ChangeCrouching(int keypressed, cvar_c *cvar = nullptr);
+static void M_ChangeExtra(int keypressed, cvar_c *cvar = nullptr);
+static void M_ChangeMonitorSize(int keypressed, cvar_c *cvar = nullptr);
+static void M_ChangeKicking(int keypressed, cvar_c *cvar = nullptr);
+static void M_ChangeWeaponSwitch(int keypressed, cvar_c *cvar = nullptr);
+static void M_ChangeMipMap(int keypressed, cvar_c *cvar = nullptr);
+static void M_ChangeDLights(int keypressed, cvar_c *cvar = nullptr);
+static void M_ChangePCSpeakerMode(int keypressed, cvar_c *cvar = nullptr);
 
 // -ES- 1998/08/20 Added resolution options
 // -ACB- 1998/08/29 Moved to top and tried different system
 
 static void M_ResOptDrawer(style_c *style, int topy, int bottomy, int dy, int centrex);
-static void M_ResolutionOptions(int keypressed);
-static void M_OptionSetResolution(int keypressed);
-static void M_ChangeResSize(int keypressed);
-static void M_ChangeResFull(int keypressed);
+static void M_ResolutionOptions(int keypressed, cvar_c *cvar = nullptr);
+static void M_OptionSetResolution(int keypressed, cvar_c *cvar = nullptr);
+static void M_ChangeResSize(int keypressed, cvar_c *cvar = nullptr);
+static void M_ChangeResFull(int keypressed, cvar_c *cvar = nullptr);
 
- void M_HostNetGame(int keypressed);
-void M_JoinNetGame(int keypressed);
+ void M_HostNetGame(int keypressed, cvar_c *cvar = nullptr);
+void M_JoinNetGame(int keypressed, cvar_c *cvar = nullptr);
 
 static void M_LanguageDrawer(int x, int y, int deltay);
-static void M_ChangeLanguage(int keypressed);
-static void M_ChangeMIDIPlayer(int keypressed);
-static void M_ChangeSoundfont(int keypressed);
-static void M_ChangeGENMIDI(int keypressed);
-static void M_ChangeErraticism(int keypressed);
-static void M_ChangeDoubleFrames(int keypressed);
-static void M_ChangeVSync(int keypressed);
+static void M_ChangeLanguage(int keypressed, cvar_c *cvar = nullptr);
+static void M_ChangeMIDIPlayer(int keypressed, cvar_c *cvar = nullptr);
+static void M_ChangeSoundfont(int keypressed, cvar_c *cvar = nullptr);
+static void M_ChangeGENMIDI(int keypressed, cvar_c *cvar = nullptr);
 static void InitMonitorSize();
 
 static char YesNo[]     = "Off/On";  // basic on/off
@@ -251,22 +243,19 @@ bool splash_screen;
 extern std::vector<std::filesystem::path> available_soundfonts;
 extern std::vector<std::filesystem::path> available_genmidis;
 
-// -ES- 1998/11/28 Wipe and Faded teleportation options
-//static char FadeT[] = "Off/On, flash/On, no flash";
-
-
 //
 //  OPTION STRUCTURES
 //
 
 typedef enum
 {
-	OPT_Plain     = 0,  // 0 means plain text,
-	OPT_Switch    = 1,  // 1 is change a switch,
-	OPT_Function  = 2,  // 2 is call a function,
-	OPT_Slider    = 3,  // 3 is a slider,
-	OPT_KeyConfig = 4,  // 4 is a key config,
-	OPT_Boolean   = 5,  // 5 is change a boolean switch
+	OPT_Plain      = 0,  // 0 means plain text,
+	OPT_Switch     = 1,  // 1 is change a switch,
+	OPT_Function   = 2,  // 2 is call a function,
+	OPT_Slider     = 3,  // 3 is a slider,
+	OPT_KeyConfig  = 4,  // 4 is a key config,
+	OPT_Boolean    = 5,  // 5 is change a boolean switch
+	OPT_FracSlider = 6,	 // 6 is a slider tied to a float
 	OPT_NumTypes
 }
 opt_type_e;
@@ -281,9 +270,16 @@ typedef struct optmenuitem_s
 	int numtypes;
 	void *switchvar;
   
-	void (*routine)(int keypressed);
+	void (*routine)(int keypressed, cvar_c *cvar);
 
 	const char *help;
+
+	cvar_c *cvar_to_change;
+
+	// For options tracking a floating point variable/range
+	float increment;
+	float min;
+	float max;
 }
 optmenuitem_t;
 
@@ -322,25 +318,18 @@ static int curr_key_menu;
 static int keyscan;
 
 static style_c *opt_def_style;
-//static style_c *keyboard_style;
-//static style_c *mouse_style;
-//static style_c *gameplay_style;
-//static style_c *video_style;
-//static style_c *setres_style;
 
-
-
-static void M_ChangeMusVol(int keypressed)
+static void M_ChangeMusVol(int keypressed, cvar_c *cvar)
 {
 	S_ChangeMusicVolume();
 }
 
-static void M_ChangeSfxVol(int keypressed)
+static void M_ChangeSfxVol(int keypressed, cvar_c *cvar)
 {
 	S_ChangeSoundVolume();
 }
 
-static void M_ChangeMixChan(int keypressed)
+static void M_ChangeMixChan(int keypressed, cvar_c *cvar)
 {
 	S_ChangeChannelNum();
 }
@@ -413,15 +402,15 @@ static menuinfo_t main_optmenu =
 
 static optmenuitem_t vidoptions[] =
 {
-	{OPT_Slider,  "Gamma Adjustment",    NULL,  21,  &v_gamma.d, M_ChangeGamma, NULL},
-	{OPT_Switch,  "Sector Brightness",    SecBrights,  11,  &v_secbright.d, M_ChangeSecBright, NULL},
-	{OPT_Switch,  "Framerate Target", "35 FPS/70 FPS", 2, &r_doubleframes.d, M_ChangeDoubleFrames, NULL},
+	{OPT_Slider,  "Gamma Adjustment",    NULL,  21,  &v_gamma.d, M_UpdateCVARFromInt, NULL, &v_gamma},
+	{OPT_Switch,  "Sector Brightness",    SecBrights,  11,  &v_secbright.d, M_UpdateCVARFromInt, NULL, &v_secbright},
+	{OPT_Switch,  "Framerate Target", "35 FPS/70 FPS", 2, &r_doubleframes.d, M_UpdateCVARFromInt, NULL, &r_doubleframes},
 	{OPT_Switch,  "Smoothing",         YesNo, 2, &var_smoothing, M_ChangeMipMap, NULL},
 	{OPT_Switch,  "H.Q.2x Scaling", Hq2xMode, 4, &hq2x_scaling, M_ChangeMipMap, NULL},
 	{OPT_Switch,  "Dynamic Lighting", DLMode, 2, &use_dlights, M_ChangeDLights, NULL},
 	{OPT_Switch,  "Detail Level",   Details,  3, &detail_level, M_ChangeMipMap, NULL},
 	{OPT_Switch,  "Mipmapping",     MipMaps,  3, &var_mipmapping, M_ChangeMipMap, NULL},
-	{OPT_Switch,  "Overlay",  		VidOverlays, 6, &r_overlay.d, M_SaveOverlay, NULL},
+	{OPT_Switch,  "Overlay",  		VidOverlays, 6, &r_overlay.d, M_UpdateCVARFromInt, NULL, &r_overlay},
 	{OPT_Switch,  "Crosshair",       CrossH, 10, &menu_crosshair, M_ChangeCrossHair, NULL},
 	{OPT_Switch,  "Crosshair Color", CrosshairColor,  8, &menu_crosscolor, M_ChangeCrossColor, NULL},
 	{OPT_Slider,  "Crosshair Size",    NULL,  6,  &menu_crosssize, M_ChangeCrossSize, NULL},
@@ -457,7 +446,7 @@ static menuinfo_t video_optmenu =
 static optmenuitem_t resoptions[] =
 {
 	{OPT_Plain,    "",          NULL, 0, NULL, NULL, NULL},
-	{OPT_Switch,  "V-Sync", "Off/Standard/Adaptive", 3, &v_sync.d, M_ChangeVSync, "Will fallback to Standard if Adaptive is not supported"},
+	{OPT_Switch,  "V-Sync", "Off/Standard/Adaptive", 3, &v_sync.d, M_UpdateCVARFromInt, "Will fallback to Standard if Adaptive is not supported", &v_sync},
 	{OPT_Switch,  "Aspect Ratio",  MonitSiz,  6, &monitor_size, M_ChangeMonitorSize, "Only applies to Fullscreen/Borderless Fullscreen Modes"},
 	{OPT_Function, "New Mode",  NULL, 0, NULL, M_ChangeResFull, NULL},
 	{OPT_Function, "New Resolution",  NULL, 0, NULL, M_ChangeResSize, NULL},
@@ -480,12 +469,13 @@ static menuinfo_t res_optmenu =
 // -KM- 1998/09/01 Changed to an analogue menu.  Must change those names
 // -ACB- 1998/07/15 Altered menu structure
 //
+
 static optmenuitem_t analogueoptions[] =
 {
 	{OPT_Switch,   "Mouse X Axis",       Axis, 11, &mouse_xaxis, NULL, NULL},
 	{OPT_Switch,   "Mouse Y Axis",       Axis, 11, &mouse_yaxis, NULL, NULL},
-	{OPT_Slider,   "X Sensitivity",      NULL, 16, &mouse_xsens, NULL, NULL},
-	{OPT_Slider,   "Y Sensitivity",      NULL, 16, &mouse_ysens, NULL, NULL},
+	{OPT_FracSlider,   "X Sensitivity",      NULL, 0, &mouse_xsens.f, M_UpdateCVARFromFloat, NULL, &mouse_xsens, 1.0f, 1.0f, 15.0f},
+	{OPT_FracSlider,   "Y Sensitivity",      NULL, 0, &mouse_ysens.f, M_UpdateCVARFromFloat, NULL, &mouse_ysens, 1.0f, 1.0f, 15.0f},
 	{OPT_Plain,    "",                   NULL, 0,  NULL, NULL, NULL},
 
 	{OPT_Switch,   "Joystick Device", JoyDevs, 7,  &joystick_device, NULL, NULL},
@@ -565,7 +555,7 @@ static menuinfo_t f4sound_optmenu =
 static optmenuitem_t playoptions[] =
 {
 	{OPT_Boolean, "MBF21 Map Compatibility", YesNo, 2, 
-     &g_mbf21compat.d, M_ChangeMBF21Compat, "Toggle support for MBF21 lines and sectors"},
+     &g_mbf21compat.d, M_UpdateCVARFromInt, "Toggle support for MBF21 lines and sectors", &g_mbf21compat},
 
 	{OPT_Boolean, "Pistol Starts",         YesNo, 2, 
      &pistol_starts, NULL, NULL},
@@ -607,7 +597,7 @@ static optmenuitem_t playoptions[] =
      &global_flags.pass_missile, M_ChangePassMissile, NULL},
 
 	{OPT_Boolean, "Erraticism",   YesNo, 2, 
-     &g_erraticism.d, M_ChangeErraticism, "Time only advances when you move or fire"},
+     &g_erraticism.d, M_UpdateCVARFromInt, "Time only advances when you move or fire", &g_erraticism},
 
 	{OPT_Slider,  "Gravity",            NULL, 20, 
      &global_flags.menu_grav, NULL, "Gravity"},
@@ -638,15 +628,15 @@ static menuinfo_t gameplay_optmenu =
 static optmenuitem_t perfoptions[] =
 {
 	{OPT_Boolean, "Draw Distance Culling", YesNo, 2, 
-     &r_culling.d, M_ChangeCulling, NULL},
+     &r_culling.d, M_UpdateCVARFromInt, NULL, &r_culling},
 	{OPT_Switch, "Maximum Draw Distance", "2000/3000/4000/5000/6000/7000/8000", 7, 
-     &r_culldist.d, M_ChangeCullDist, "Only effective when Draw Distance Culling is On"},
+     &r_culldist.d, M_UpdateCVARFromInt, "Only effective when Draw Distance Culling is On", &r_culldist},
 	{OPT_Switch, "Outdoor Culling Fog Color", "Match Sky/White/Grey/Black", 4, 
-     &r_cullfog.d, M_ChangeCullFog, "Only effective when Draw Distance Culling is On"},
+     &r_cullfog.d, M_UpdateCVARFromInt, "Only effective when Draw Distance Culling is On", &r_cullfog},
 	{OPT_Boolean, "Slow Thinkers Over Distance", YesNo, 2, 
-     &g_cullthinkers.d, M_ChangeThinkerCulling, "Only recommended for extreme monster/projectile counts"},
+     &g_cullthinkers.d, M_UpdateCVARFromInt, "Only recommended for extreme monster/projectile counts", &g_cullthinkers},
 	{OPT_Switch, "Maximum Dynamic Lights", DLightMax, 6, 
-     &r_maxdlights.d, M_ChangeMaxDLights, "Control how many dynamic lights are rendered per tick"},
+     &r_maxdlights.d, M_UpdateCVARFromInt, "Control how many dynamic lights are rendered per tick", &r_maxdlights},
 };
 
 static menuinfo_t perf_optmenu = 
@@ -1208,6 +1198,16 @@ void M_OptDrawer()
 				break;
 			}
 
+			case OPT_FracSlider:
+			{
+				M_DrawFracThermo(curr_menu->menu_center + 15, curry,
+							  *(float*)curr_menu->items[i].switchvar,
+							  curr_menu->items[i].increment, 2, curr_menu->items[i].min,
+							  curr_menu->items[i].max);
+              
+				break;
+			}
+
 			case OPT_KeyConfig:
 			{
 				k = *(int*)(curr_menu->items[i].switchvar);
@@ -1508,7 +1508,7 @@ bool M_OptResponder(event_t * ev, int ch)
 					S_StartFX(sfx_pistol);
 
 					if (curr_item->routine != NULL)
-						curr_item->routine(ch);
+						curr_item->routine(ch, curr_item->cvar_to_change);
 
 					return true;
 				}
@@ -1525,7 +1525,7 @@ bool M_OptResponder(event_t * ev, int ch)
 					S_StartFX(sfx_pistol);
 
 					if (curr_item->routine != NULL)
-						curr_item->routine(ch);
+						curr_item->routine(ch, curr_item->cvar_to_change);
 
 					return true;
 				}
@@ -1533,7 +1533,7 @@ bool M_OptResponder(event_t * ev, int ch)
 				case OPT_Function:
 				{
 					if (curr_item->routine != NULL)
-						curr_item->routine(ch);
+						curr_item->routine(ch, curr_item->cvar_to_change);
 
 					S_StartFX(sfx_pistol);
 					return true;
@@ -1551,7 +1551,24 @@ bool M_OptResponder(event_t * ev, int ch)
 					}
 
 					if (curr_item->routine != NULL)
-						curr_item->routine(ch);
+						curr_item->routine(ch, curr_item->cvar_to_change);
+
+					return true;
+				}
+
+				case OPT_FracSlider:
+				{
+					float *val_ptr = (float*)curr_item->switchvar;
+
+					if (*val_ptr > curr_item->min)
+					{
+						*val_ptr = *val_ptr - curr_item->increment;
+
+						S_StartFX(sfx_stnmov);
+					}
+
+					if (curr_item->routine != NULL)
+						curr_item->routine(ch, curr_item->cvar_to_change);
 
 					return true;
 				}
@@ -1590,7 +1607,7 @@ bool M_OptResponder(event_t * ev, int ch)
 					S_StartFX(sfx_pistol);
 
 					if (curr_item->routine != NULL)
-						curr_item->routine(ch);
+						curr_item->routine(ch, curr_item->cvar_to_change);
 
 					return true;
 				}
@@ -1607,7 +1624,7 @@ bool M_OptResponder(event_t * ev, int ch)
 					S_StartFX(sfx_pistol);
 
 					if (curr_item->routine != NULL)
-						curr_item->routine(ch);
+						curr_item->routine(ch, curr_item->cvar_to_change);
 
 					return true;
 				}
@@ -1615,7 +1632,7 @@ bool M_OptResponder(event_t * ev, int ch)
 				case OPT_Function:
 				{
 					if (curr_item->routine != NULL)
-						curr_item->routine(ch);
+						curr_item->routine(ch, curr_item->cvar_to_change);
 
 					S_StartFX(sfx_pistol);
 					return true;
@@ -1633,7 +1650,24 @@ bool M_OptResponder(event_t * ev, int ch)
 					}
 
 					if (curr_item->routine != NULL)
-						curr_item->routine(ch);
+						curr_item->routine(ch, curr_item->cvar_to_change);
+
+					return true;
+				}
+
+				case OPT_FracSlider:
+				{
+					float *val_ptr = (float*)curr_item->switchvar;
+
+					if (*val_ptr < curr_item->max)
+					{
+						*val_ptr = *val_ptr + curr_item->increment;
+
+						S_StartFX(sfx_stnmov);
+					}
+
+					if (curr_item->routine != NULL)
+						curr_item->routine(ch, curr_item->cvar_to_change);
 
 					return true;
 				}
@@ -1683,7 +1717,7 @@ bool M_OptResponder(event_t * ev, int ch)
 //
 // M_VideoOptions
 //
-static void M_VideoOptions(int keypressed)
+static void M_VideoOptions(int keypressed, cvar_c *cvar)
 {
 	curr_menu = &video_optmenu;
 	curr_item = curr_menu->items + curr_menu->pos;
@@ -1698,7 +1732,7 @@ static void M_VideoOptions(int keypressed)
 // -ES- 1998/08/20 Added
 // -ACB 1999/10/03 rewrote to Use scrmodes array.
 //
-static void M_ResolutionOptions(int keypressed)
+static void M_ResolutionOptions(int keypressed, cvar_c *cvar)
 {
 	new_scrmode.width  = SCREENWIDTH;
 	new_scrmode.height = SCREENHEIGHT;
@@ -1712,7 +1746,7 @@ static void M_ResolutionOptions(int keypressed)
 //
 // M_AnalogueOptions
 //
-static void M_AnalogueOptions(int keypressed)
+static void M_AnalogueOptions(int keypressed, cvar_c *cvar)
 {
 	curr_menu = &analogue_optmenu;
 	curr_item = curr_menu->items + curr_menu->pos;
@@ -1721,7 +1755,7 @@ static void M_AnalogueOptions(int keypressed)
 //
 // M_SoundOptions
 //
-static void M_SoundOptions(int keypressed)
+static void M_SoundOptions(int keypressed, cvar_c *cvar)
 {
 	curr_menu = &sound_optmenu;
 	curr_item = curr_menu->items + curr_menu->pos;
@@ -1740,7 +1774,7 @@ void M_F4SoundOptions(int choice)
 //
 // M_GameplayOptions
 //
-static void M_GameplayOptions(int keypressed)
+static void M_GameplayOptions(int keypressed, cvar_c *cvar)
 {
 	// not allowed in netgames (changing most of these options would
 	// break synchronisation with the other machines).
@@ -1754,7 +1788,7 @@ static void M_GameplayOptions(int keypressed)
 //
 // M_PerformanceOptions
 //
-static void M_PerformanceOptions(int keypressed)
+static void M_PerformanceOptions(int keypressed, cvar_c *cvar)
 {
 	// not allowed in netgames (changing most of these options would
 	// break synchronisation with the other machines).
@@ -1768,7 +1802,7 @@ static void M_PerformanceOptions(int keypressed)
 //
 // M_KeyboardOptions
 //
-static void M_KeyboardOptions(int keypressed)
+static void M_KeyboardOptions(int keypressed, cvar_c *cvar)
 {
 	curr_menu = all_key_menus[curr_key_menu];
 
@@ -1812,7 +1846,7 @@ static void InitMonitorSize()
 }
 
 
-static void M_ChangeMonitorSize(int key)
+static void M_ChangeMonitorSize(int key, cvar_c *cvar)
 {
 	static const float ratios[6] =
 	{
@@ -1832,7 +1866,7 @@ static void M_ChangeMonitorSize(int key)
 // -KM- 1998/07/21 Change blood to a bool
 // -ACB- 1998/08/09 Check map setting allows this
 //
-static void M_ChangeBlood(int keypressed)
+static void M_ChangeBlood(int keypressed, cvar_c *cvar)
 {
 	if (currmap && ((currmap->force_on | currmap->force_off) & MPF_MoreBlood))
 		return;
@@ -1840,7 +1874,7 @@ static void M_ChangeBlood(int keypressed)
 	level_flags.more_blood = global_flags.more_blood;
 }
 
-static void M_ChangeMLook(int keypressed)
+static void M_ChangeMLook(int keypressed, cvar_c *cvar)
 {
 	if (currmap && ((currmap->force_on | currmap->force_off) & MPF_Mlook))
 		return;
@@ -1848,7 +1882,7 @@ static void M_ChangeMLook(int keypressed)
 	level_flags.mlook = global_flags.mlook;
 }
 
-static void M_ChangeJumping(int keypressed)
+static void M_ChangeJumping(int keypressed, cvar_c *cvar)
 {
 	if (currmap && ((currmap->force_on | currmap->force_off) & MPF_Jumping))
 		return;
@@ -1856,7 +1890,7 @@ static void M_ChangeJumping(int keypressed)
 	level_flags.jump = global_flags.jump;
 }
 
-static void M_ChangeCrouching(int keypressed)
+static void M_ChangeCrouching(int keypressed, cvar_c *cvar)
 {
 	if (currmap && ((currmap->force_on | currmap->force_off) & MPF_Crouching))
 		return;
@@ -1864,7 +1898,7 @@ static void M_ChangeCrouching(int keypressed)
 	level_flags.crouch = global_flags.crouch;
 }
 
-static void M_ChangeExtra(int keypressed)
+static void M_ChangeExtra(int keypressed, cvar_c *cvar)
 {
 	if (currmap && ((currmap->force_on | currmap->force_off) & MPF_Extras))
 		return;
@@ -1877,7 +1911,7 @@ static void M_ChangeExtra(int keypressed)
 //
 // -ACB- 1998/08/09 New DDF settings, check that map allows the settings
 //
-static void M_ChangeMonsterRespawn(int keypressed)
+static void M_ChangeMonsterRespawn(int keypressed, cvar_c *cvar)
 {
 	if (currmap && ((currmap->force_on | currmap->force_off) & MPF_ResRespawn))
 		return;
@@ -1885,7 +1919,7 @@ static void M_ChangeMonsterRespawn(int keypressed)
 	level_flags.res_respawn = global_flags.res_respawn;
 }
 
-static void M_ChangeItemRespawn(int keypressed)
+static void M_ChangeItemRespawn(int keypressed, cvar_c *cvar)
 {
 	if (currmap && ((currmap->force_on | currmap->force_off) & MPF_ItemRespawn))
 		return;
@@ -1893,7 +1927,7 @@ static void M_ChangeItemRespawn(int keypressed)
 	level_flags.itemrespawn = global_flags.itemrespawn;
 }
 
-static void M_ChangeTrue3d(int keypressed)
+static void M_ChangeTrue3d(int keypressed, cvar_c *cvar)
 {
 	if (currmap && ((currmap->force_on | currmap->force_off) & MPF_True3D))
 		return;
@@ -1901,7 +1935,7 @@ static void M_ChangeTrue3d(int keypressed)
 	level_flags.true3dgameplay = global_flags.true3dgameplay;
 }
 
-static void M_ChangeAutoAim(int keypressed)
+static void M_ChangeAutoAim(int keypressed, cvar_c *cvar)
 {
 	if (currmap && ((currmap->force_on | currmap->force_off) & MPF_AutoAim))
 		return;
@@ -1909,7 +1943,7 @@ static void M_ChangeAutoAim(int keypressed)
 	level_flags.autoaim = global_flags.autoaim;
 }
 
-static void M_ChangeRespawn(int keypressed)
+static void M_ChangeRespawn(int keypressed, cvar_c *cvar)
 {
 	if (gameskill == sk_nightmare)
 		return;
@@ -1920,7 +1954,7 @@ static void M_ChangeRespawn(int keypressed)
 	level_flags.respawn = global_flags.respawn;
 }
 
-static void M_ChangeFastparm(int keypressed)
+static void M_ChangeFastparm(int keypressed, cvar_c *cvar)
 {
 	if (gameskill == sk_nightmare)
 		return;
@@ -1931,79 +1965,18 @@ static void M_ChangeFastparm(int keypressed)
 	level_flags.fastparm = global_flags.fastparm;
 }
 
-static void M_ChangePassMissile(int keypressed)
+static void M_ChangePassMissile(int keypressed, cvar_c *cvar)
 {
 	level_flags.pass_missile = global_flags.pass_missile;
 }
 
 // this used by both MIPMIP, SMOOTHING and DETAIL options
-static void M_ChangeMipMap(int keypressed)
+static void M_ChangeMipMap(int keypressed, cvar_c *cvar)
 {
 	W_DeleteAllImages();
 }
 
-// Need to make a generic CVAR save function
-static void M_SaveOverlay(int keypressed)
-{
-	r_overlay = r_overlay.d;
-}
-
-// See above
-static void M_ChangeErraticism(int keypressed)
-{
-	g_erraticism = g_erraticism.d;
-}
-
-// See above the above
-static void M_ChangeDoubleFrames(int keypressed)
-{
-	r_doubleframes = r_doubleframes.d;
-}
-
-// See above the above the above
-static void M_ChangeMBF21Compat(int keypressed)
-{
-	g_mbf21compat = g_mbf21compat.d;
-}
-
-// See above the above the above the above
-static void M_ChangeCulling(int keypressed)
-{
-	r_culling = r_culling.d;
-}
-
-// See above the above the above the above the above
-static void M_ChangeCullDist(int keypressed)
-{
-	r_culldist = r_culldist.d;
-}
-
-// See above the above the above the above the above the above
-static void M_ChangeCullFog(int keypressed)
-{
-	r_cullfog = r_cullfog.d;
-}
-
-// See above the above the above the above the above the above the above
-static void M_ChangeThinkerCulling(int keypressed)
-{
-	g_cullthinkers = g_cullthinkers.d;
-}
-
-// See above the above the above the above the above the above the above the above
-static void M_ChangeMaxDLights(int keypressed)
-{
-	r_maxdlights = r_maxdlights.d;
-}
-
-// See above the above the above the above the above the above the above the above the above
-static void M_ChangeVSync(int keypressed)
-{
-	v_sync = v_sync.d;
-}
-
-// See above the above the above the above the above the above the above the above the above the above
-static void M_ChangeBobbing(int keypressed)
+static void M_ChangeBobbing(int keypressed, cvar_c *cvar)
 {
 	g_bobbing = g_bobbing.d;
 	player_t *player = players[consoleplayer];
@@ -2019,19 +1992,19 @@ static void M_ChangeBobbing(int keypressed)
 	}
 }
 
-// See above the above the above the above the above the above the above the above the above the above the above
-static void M_ChangeSecBright(int keypressed)
+static void M_UpdateCVARFromFloat(int keypressed, cvar_c *cvar)
 {
-	v_secbright = v_secbright.d;
+	SYS_ASSERT(cvar);
+	cvar->operator=(cvar->f);
 }
 
-// See above the above the above the above the above the above the above the above the above the above the above the above
-static void M_ChangeGamma(int keypressed)
+static void M_UpdateCVARFromInt(int keypressed, cvar_c *cvar)
 {
-	v_gamma = v_gamma.d;
+	SYS_ASSERT(cvar);
+	cvar->operator=(cvar->d);
 }
 
-static void M_ChangeKicking(int keypressed)
+static void M_ChangeKicking(int keypressed, cvar_c *cvar)
 {
 	if (currmap && ((currmap->force_on | currmap->force_off) & MPF_Kicking))
 		return;
@@ -2039,7 +2012,7 @@ static void M_ChangeKicking(int keypressed)
 	level_flags.kicking = global_flags.kicking;
 }
 
-static void M_ChangeWeaponSwitch(int keypressed)
+static void M_ChangeWeaponSwitch(int keypressed, cvar_c *cvar)
 {
 	if (currmap && ((currmap->force_on | currmap->force_off) & MPF_WeaponSwitch))
 		return;
@@ -2047,27 +2020,27 @@ static void M_ChangeWeaponSwitch(int keypressed)
 	level_flags.weapon_switch = global_flags.weapon_switch;
 }
 
-static void M_ChangeDLights(int keypressed)
+static void M_ChangeDLights(int keypressed, cvar_c *cvar)
 {
 	/* nothing to do */
 }
 
-static void M_ChangeCrossHair(int keypressed)
+static void M_ChangeCrossHair(int keypressed, cvar_c *cvar)
 {
 	r_crosshair = menu_crosshair;
 }
 
-static void M_ChangeCrossColor(int keypressed)
+static void M_ChangeCrossColor(int keypressed, cvar_c *cvar)
 {
 	r_crosscolor = menu_crosscolor;
 }
 
-static void M_ChangeCrossSize(int keypressed)
+static void M_ChangeCrossSize(int keypressed, cvar_c *cvar)
 {
 	r_crosssize = 8 + (menu_crosssize * 8);
 }
 
-static void M_ChangePCSpeakerMode(int keypressed)
+static void M_ChangePCSpeakerMode(int keypressed, cvar_c *cvar)
 {
 	// Clear SFX cache and restart music
 	S_StopAllFX();
@@ -2080,7 +2053,7 @@ static void M_ChangePCSpeakerMode(int keypressed)
 //
 // -AJA- 2000/04/16 Run-time language changing...
 //
-static void M_ChangeLanguage(int keypressed)
+static void M_ChangeLanguage(int keypressed, cvar_c *cvar)
 {
 	if (keypressed == KEYD_LEFTARROW || keypressed == KEYD_DPAD_LEFT || keypressed == KEYD_MENU_LEFT)
 	{
@@ -2115,7 +2088,7 @@ static void M_ChangeLanguage(int keypressed)
 // M_ChangeMIDIPlayer
 //
 //
-static void M_ChangeMIDIPlayer(int keypressed)
+static void M_ChangeMIDIPlayer(int keypressed, cvar_c *cvar)
 {
 	pl_entry_c *playing = playlist.Find(entry_playing);
 	if (!var_pc_speaker_mode && (var_midi_player == 1 || (playing && 
@@ -2131,7 +2104,7 @@ static void M_ChangeMIDIPlayer(int keypressed)
 // M_ChangeSoundfont
 //
 //
-static void M_ChangeSoundfont(int keypressed)
+static void M_ChangeSoundfont(int keypressed, cvar_c *cvar)
 {
 	int sf_pos = -1;
 	for(int i=0; i < (int)available_soundfonts.size(); i++)
@@ -2174,7 +2147,7 @@ static void M_ChangeSoundfont(int keypressed)
 // M_ChangeGENMIDI
 //
 //
-static void M_ChangeGENMIDI(int keypressed)
+static void M_ChangeGENMIDI(int keypressed, cvar_c *cvar)
 {
 	int op2_pos = -1;
 	for(int i=0; i < (int)available_genmidis.size(); i++)
@@ -2218,7 +2191,7 @@ static void M_ChangeGENMIDI(int keypressed)
 //
 // -ACB- 1998/08/29 Resolution Changes...
 //
-static void M_ChangeResSize(int keypressed)
+static void M_ChangeResSize(int keypressed, cvar_c *cvar)
 {
 	if (keypressed == KEYD_LEFTARROW || keypressed == KEYD_DPAD_LEFT || keypressed == KEYD_MENU_LEFT)
 	{
@@ -2235,7 +2208,7 @@ static void M_ChangeResSize(int keypressed)
 //
 // -AJA- 2005/01/02: Windowed vs Fullscreen
 //
-static void M_ChangeResFull(int keypressed)
+static void M_ChangeResFull(int keypressed, cvar_c *cvar)
 {
 	if (keypressed == KEYD_LEFTARROW || keypressed == KEYD_DPAD_LEFT || keypressed == KEYD_MENU_LEFT)
 	{
@@ -2250,7 +2223,7 @@ static void M_ChangeResFull(int keypressed)
 //
 // M_OptionSetResolution
 //
-static void M_OptionSetResolution(int keypressed)
+static void M_OptionSetResolution(int keypressed, cvar_c *cvar)
 {
 	if (R_ChangeResolution(&new_scrmode))
 	{
@@ -2273,7 +2246,7 @@ static void M_OptionSetResolution(int keypressed)
 ///--  //
 ///--  // M_OptionTestResolution
 ///--  //
-///--  static void M_OptionTestResolution(int keypressed)
+///--  static void M_OptionTestResolution(int keypressed, cvar_c *cvar)
 ///--  {
 ///--      R_ChangeResolution(selectedscrmode);
 ///--  	testticker = TICRATE * 3;
@@ -2282,7 +2255,7 @@ static void M_OptionSetResolution(int keypressed)
 ///--  //
 ///--  // M_RestoreResSettings
 ///--  //
-///--  static void M_RestoreResSettings(int keypressed)
+///--  static void M_RestoreResSettings(int keypressed, cvar_c *cvar)
 ///--  {
 ///--      R_ChangeResolution(prevscrmode);
 ///--  }
@@ -2290,7 +2263,7 @@ static void M_OptionSetResolution(int keypressed)
 extern void M_NetHostBegun(void);
 extern void M_NetJoinBegun(void);
 
-void M_HostNetGame(int keypressed)
+void M_HostNetGame(int keypressed, cvar_c *cvar)
 {
 	option_menuon  = 0;
 	netgame_menuon = 1;
@@ -2298,7 +2271,7 @@ void M_HostNetGame(int keypressed)
 	M_NetHostBegun();
 }
 
-void M_JoinNetGame(int keypressed)
+void M_JoinNetGame(int keypressed, cvar_c *cvar)
 {
 #if 0
 	option_menuon  = 0;

--- a/source_files/edge/m_option.cc
+++ b/source_files/edge/m_option.cc
@@ -142,9 +142,7 @@ extern cvar_c g_bobbing;
 extern cvar_c v_secbright;
 extern cvar_c v_gamma;
 
-static int menu_crosshair;
 static int menu_crosscolor;
-static int menu_crosssize;
 static int monitor_size;
 
 extern int joystick_device;
@@ -173,9 +171,7 @@ static void M_ChangeAutoAim(int keypressed, cvar_c *cvar = nullptr);
 static void M_ChangeFastparm(int keypressed, cvar_c *cvar = nullptr);
 static void M_ChangeRespawn(int keypressed, cvar_c *cvar = nullptr);
 static void M_ChangePassMissile(int keypressed, cvar_c *cvar = nullptr);
-static void M_ChangeCrossHair(int keypressed, cvar_c *cvar = nullptr);
 static void M_ChangeCrossColor(int keypressed, cvar_c *cvar = nullptr);
-static void M_ChangeCrossSize(int keypressed, cvar_c *cvar = nullptr);
 static void M_ChangeBobbing(int keypressed, cvar_c *cvar = nullptr);
 static void M_ChangeBlood(int keypressed, cvar_c *cvar = nullptr);
 static void M_ChangeMLook(int keypressed, cvar_c *cvar = nullptr);
@@ -402,7 +398,7 @@ static menuinfo_t main_optmenu =
 
 static optmenuitem_t vidoptions[] =
 {
-	{OPT_Slider,  "Gamma Adjustment",    NULL,  21,  &v_gamma.d, M_UpdateCVARFromInt, NULL, &v_gamma},
+	{OPT_FracSlider,  "Gamma Adjustment",    NULL,  0,  &v_gamma.f, M_UpdateCVARFromFloat, NULL, &v_gamma, 0.10f, -1.0f, 1.0f},
 	{OPT_Switch,  "Sector Brightness",    SecBrights,  11,  &v_secbright.d, M_UpdateCVARFromInt, NULL, &v_secbright},
 	{OPT_Switch,  "Framerate Target", "35 FPS/70 FPS", 2, &r_doubleframes.d, M_UpdateCVARFromInt, NULL, &r_doubleframes},
 	{OPT_Switch,  "Smoothing",         YesNo, 2, &var_smoothing, M_ChangeMipMap, NULL},
@@ -411,9 +407,9 @@ static optmenuitem_t vidoptions[] =
 	{OPT_Switch,  "Detail Level",   Details,  3, &detail_level, M_ChangeMipMap, NULL},
 	{OPT_Switch,  "Mipmapping",     MipMaps,  3, &var_mipmapping, M_ChangeMipMap, NULL},
 	{OPT_Switch,  "Overlay",  		VidOverlays, 6, &r_overlay.d, M_UpdateCVARFromInt, NULL, &r_overlay},
-	{OPT_Switch,  "Crosshair",       CrossH, 10, &menu_crosshair, M_ChangeCrossHair, NULL},
+	{OPT_Switch,  "Crosshair",       CrossH, 10, &r_crosshair.d, M_UpdateCVARFromInt, NULL, &r_crosshair},
 	{OPT_Switch,  "Crosshair Color", CrosshairColor,  8, &menu_crosscolor, M_ChangeCrossColor, NULL},
-	{OPT_Slider,  "Crosshair Size",    NULL,  6,  &menu_crosssize, M_ChangeCrossSize, NULL},
+	{OPT_FracSlider,  "Crosshair Size",  NULL,  0,  &r_crosssize.f, M_UpdateCVARFromFloat, NULL, &r_crosssize, 1.0f, 2.0f, 64.0f},
 	{OPT_Boolean, "Map Rotation",    YesNo,   2, &rotatemap, NULL, NULL},
 	{OPT_Switch,  "Teleport Flash",  YesNo,   2, &telept_flash, NULL, NULL},
 	{OPT_Switch,  "Invulnerability", Invuls, NUM_INVULFX,  &var_invul_fx, NULL, NULL},
@@ -2029,19 +2025,9 @@ static void M_ChangeDLights(int keypressed, cvar_c *cvar)
 	/* nothing to do */
 }
 
-static void M_ChangeCrossHair(int keypressed, cvar_c *cvar)
-{
-	r_crosshair = menu_crosshair;
-}
-
 static void M_ChangeCrossColor(int keypressed, cvar_c *cvar)
 {
 	r_crosscolor = menu_crosscolor;
-}
-
-static void M_ChangeCrossSize(int keypressed, cvar_c *cvar)
-{
-	r_crosssize = 8 + (menu_crosssize * 8);
 }
 
 static void M_ChangePCSpeakerMode(int keypressed, cvar_c *cvar)
@@ -2290,9 +2276,7 @@ void M_Options(int choice)
 	option_menuon = 1;
 	fkey_menu = (choice == 1);
 	// hack
-	menu_crosshair = CLAMP(0, r_crosshair.d, 9);
 	menu_crosscolor = CLAMP(0, r_crosscolor.d, 7);
-	menu_crosssize = CLAMP(0, (r_crosssize.d / 8 - 1), 5);
 }
 
 

--- a/source_files/edge/m_option.cc
+++ b/source_files/edge/m_option.cc
@@ -487,7 +487,7 @@ static optmenuitem_t analogueoptions[] =
 	{OPT_Switch,   "Sixth Axis",         Axis, 13, &joy_axis[5], NULL, NULL},
 
 	{OPT_Plain,    "",                   NULL, 0,  NULL, NULL, NULL},
-	{OPT_Slider,   "Turning Speed",      NULL, 12, &var_turnspeed,    NULL, NULL},
+	{OPT_FracSlider, "Turning Speed",  NULL, 0, &turnspeed.f, M_UpdateCVARFromFloat, NULL, &turnspeed, 0.10f, 0.10f, 3.0f},
 	{OPT_Slider,   "MLook Speed",        NULL, 12, &var_mlookspeed,   NULL, NULL},
 	{OPT_Slider,   "Forward Move Speed", NULL, 8,  &var_forwardspeed, NULL, NULL},
 	{OPT_Slider,   "Side Move Speed",    NULL, 8,  &var_sidespeed,    NULL, NULL},
@@ -1560,7 +1560,7 @@ bool M_OptResponder(event_t * ev, int ch)
 				{
 					float *val_ptr = (float*)curr_item->switchvar;
 
-					*val_ptr = *val_ptr - (fmodf(*val_ptr, curr_item->increment));
+					*val_ptr = *val_ptr - (remainderf(*val_ptr, curr_item->increment));
 
 					if (*val_ptr > curr_item->min)
 					{
@@ -1661,7 +1661,7 @@ bool M_OptResponder(event_t * ev, int ch)
 				{
 					float *val_ptr = (float*)curr_item->switchvar;
 
-					*val_ptr = *val_ptr - (fmodf(*val_ptr, curr_item->increment));
+					*val_ptr = *val_ptr - (remainderf(*val_ptr, curr_item->increment));
 
 					if (*val_ptr < curr_item->max)
 					{

--- a/source_files/edge/p_mobj.cc
+++ b/source_files/edge/p_mobj.cc
@@ -78,6 +78,8 @@ extern cvar_c g_mbf21compat;
 
 DEF_CVAR(g_cullthinkers, "0", CVAR_ARCHIVE)
 
+DEF_CVAR(g_gravity, "1.0", CVAR_ARCHIVE)
+
 // List of all objects in map.
 mobj_t *mobjlisthead;
 
@@ -1058,7 +1060,8 @@ static void P_ZMovement(mobj_t * mo, const region_properties_t *props, bool extr
 	// -KM- 1998/11/25 Gravity is now not precalculated so that
 	//  menu changes affect instantly.
 	float gravity = props->gravity / 8.0f * 
-		(float)level_flags.menu_grav / (float)MENU_GRAV_NORMAL;
+		(float)level_flags.menu_grav / GRAVITY
+		* g_gravity.f; // New global gravity menu item
 
 	// check for smooth step up
 	if (mo->player && mo->player->mo == mo && mo->z < mo->floorz)

--- a/source_files/edge/p_mobj.h
+++ b/source_files/edge/p_mobj.h
@@ -55,6 +55,8 @@ extern std::unordered_set<const mobjtype_c *> seen_monsters;
 
 extern bool time_stop_active;
 
+extern cvar_c g_gravity;
+
 #define STOPSPEED   		0.07f
 #define OOF_SPEED   		9.0f //Lobo: original value 20.0f too high, almost never played oof
 

--- a/source_files/edge/p_spec.h
+++ b/source_files/edge/p_spec.h
@@ -35,9 +35,6 @@
 #include "r_defs.h"
 #include "r_image.h"
 
-#define MENU_GRAV_NORMAL  8
-
-
 typedef struct light_s
 {
 	// type of light effect

--- a/source_files/edge/r_main.cc
+++ b/source_files/edge/r_main.cc
@@ -40,7 +40,7 @@ int glmax_tex_units;
 DEF_CVAR(r_nearclip, "4",      CVAR_ARCHIVE)
 DEF_CVAR(r_farclip,  "64000",  CVAR_ARCHIVE)
 DEF_CVAR(r_culling, "0", CVAR_ARCHIVE)
-DEF_CVAR(r_culldist, "1", CVAR_ARCHIVE)
+DEF_CVAR(r_culldist, "3000", CVAR_ARCHIVE)
 DEF_CVAR(r_cullfog, "0", CVAR_ARCHIVE)
 
 DEF_CVAR(r_fogofwar, "0", CVAR_ARCHIVE)

--- a/source_files/edge/r_things.cc
+++ b/source_files/edge/r_things.cc
@@ -68,7 +68,7 @@ extern bool erraticism_active;
 
 DEF_CVAR(r_crosshair,   "0",   CVAR_ARCHIVE)  // shape
 DEF_CVAR(r_crosscolor,  "0",   CVAR_ARCHIVE)  // 0 .. 7
-DEF_CVAR(r_crosssize,   "16",  CVAR_ARCHIVE)  // pixels on a 320x200 screen
+DEF_CVAR(r_crosssize,   "16.0",  CVAR_ARCHIVE)  // pixels on a 320x200 screen
 DEF_CVAR(r_crossbright, "1.0", CVAR_ARCHIVE)  // 1.0 is normal
 
 

--- a/source_files/edge/s_blit.cc
+++ b/source_files/edge/s_blit.cc
@@ -78,8 +78,7 @@ static std::list<epi::sound_data_c *> playing_qbufs;
 
 static mix_channel_c *queue_chan;
 
-
-int sfx_volume = 0;
+DEF_CVAR(sfx_volume, "0.15", CVAR_ARCHIVE)
 
 static bool sfxpaused = false;
 
@@ -88,18 +87,6 @@ float listen_x;
 float listen_y;
 float listen_z;
 angle_t listen_angle;
-
-// -AJA- 2005/02/26: table to convert slider position to GAIN.
-//       Curve was hand-crafted to give useful distinctions of
-//       volume levels at the quiet end.  Entry zero always
-//       means total silence (in the table for completeness).
-float slider_to_gain[SND_SLIDER_NUM] =
-{
-	0.00000, 0.00200, 0.00400, 0.00800, 0.01600,
-	0.03196, 0.05620, 0.08886, 0.12894, 0.17584,
-	0.22855, 0.28459, 0.34761, 0.41788, 0.49553,
-	0.58075, 0.67369, 0.77451, 0.88329, 1.00000
-};
 
 // FIXME: extern == hack
 extern int dev_freq;
@@ -160,7 +147,7 @@ void mix_channel_c::ComputeVolume()
 
 	float MAX_VOL = (1 << (16 - SAFE_BITS)) - 3;
 
-	MAX_VOL = (boss ? MAX_VOL : MAX_VOL / dist) * slider_to_gain[sfx_volume];
+	MAX_VOL = (boss ? MAX_VOL : MAX_VOL / dist) * sfx_volume.f;
 
 	if (def)
 		MAX_VOL *= PERCENT_2_FLOAT(def->volume);
@@ -181,7 +168,7 @@ void mix_channel_c::ComputeMusicVolume()
 {
 	float MAX_VOL = (1 << (16 - SAFE_BITS)) - 3;
 
- 	MAX_VOL = MAX_VOL * slider_to_gain[mus_volume];
+ 	MAX_VOL = MAX_VOL * mus_volume.f;
 
 	volume_L = (int) MAX_VOL;
 	volume_R = (int) MAX_VOL;

--- a/source_files/edge/s_blit.h
+++ b/source_files/edge/s_blit.h
@@ -78,6 +78,7 @@ public:
 	void ComputeMusicVolume();
 };
 
+extern cvar_c sfx_volume;
 
 extern mix_channel_c *mix_chan[];
 extern int num_chan;

--- a/source_files/edge/s_music.cc
+++ b/source_files/edge/s_music.cc
@@ -50,7 +50,7 @@
 extern bool var_pc_speaker_mode;
 
 // music slider value
-int mus_volume;
+DEF_CVAR(mus_volume, "0.15", CVAR_ARCHIVE)
 
 bool nomusic = false;
 
@@ -90,7 +90,7 @@ void S_ChangeMusic(int entrynum, bool loop)
 		return;
 	}
 
-	float volume = slider_to_gain[mus_volume];
+	float volume = mus_volume.f;
 
 	// open the file or lump, and read it into memory
 	epi::file_c *F;
@@ -292,7 +292,7 @@ void S_MusicTicker(void)
 void S_ChangeMusicVolume(void)
 {
 	if (music_player)
-		music_player->Volume(slider_to_gain[mus_volume]);
+		music_player->Volume(mus_volume.f);
 }
 
 

--- a/source_files/edge/s_music.h
+++ b/source_files/edge/s_music.h
@@ -47,7 +47,7 @@ public:
 
 /* VARIABLES */
 
-extern int mus_volume;  // 0 .. SND_SLIDER_NUM-1
+extern cvar_c mus_volume;
 extern int entry_playing;
 
 /* FUNCTIONS */

--- a/source_files/edge/s_sound.h
+++ b/source_files/edge/s_sound.h
@@ -86,10 +86,6 @@ typedef enum
 }
 fx_flag_e;
 
-
-// Vars
-extern int sfx_volume;  // 0 .. SND_SLIDER_NUM-1
-
 // Init/Shutdown
 void S_Init(void);
 void S_Shutdown(void);


### PR DESCRIPTION
The idea is to have more flexibility for things like (in this first case) mouse sensitivity. The previous implementation had an integer value which was an index into a preset array of floating-point values. I've also added generic functions for updating a CVAR value from an options menu item, thereby reducing the amount of redundant functions whose only purpose was to update a certain CVAR.