### PR TITLE
Move windows debug to be first in VSCode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,17 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "(Windows) Launch",
+            "type": "cppvsdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/edge-classic.exe",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "console": "externalTerminal"
+        },         
+        {
             "name": "(gdb) Launch",
             "type": "cppdbg",
             "request": "launch",
@@ -27,17 +38,6 @@
                     "ignoreFailures": true
                 }
             ]
-        },
-    {
-        "name": "(Windows) Launch",
-        "type": "cppvsdbg",
-        "request": "launch",
-        "program": "${workspaceFolder}/edge-classic.exe",
-        "args": [],
-        "stopAtEntry": false,
-        "cwd": "${workspaceFolder}",
-        "environment": [],
-        "console": "externalTerminal"
-    }
-    ]
+        }
+   ]
 }


### PR DESCRIPTION
This just moves the windows debugger back to be first in list in VSCode, kinda wish it would detect which toolchain you are using and only show the relevant debugger.  Maybe there is a property setting for that...