### PR TITLE
Allow EPKs and folders to act as IWADs/standalone content

### DIFF
--- a/source_files/edge/con_main.cc
+++ b/source_files/edge/con_main.cc
@@ -137,6 +137,16 @@ int CMD_Readme(char **argv, int argc)
 		}
 	}
 
+	// Check for an EDGEGAME lump or file and print (if it has text; these aren't required to)
+	if (!readme_file)
+	{
+		// Datafile at index 1 should always be either the IWAD or standalone EPK
+		if (data_files[1]->wad)
+			readme_file = W_OpenLump("EDGEGAME");
+		else
+			readme_file = W_OpenPackFile("EDGEGAME.txt");
+	}
+
 	if (!readme_file)
 	{
 		CON_Printf("No readme text files found in current load order!\n");

--- a/source_files/edge/dm_state.h
+++ b/source_files/edge/dm_state.h
@@ -109,10 +109,10 @@ extern int gametic;
 extern std::filesystem::path cfgfile;
 extern std::filesystem::path brandingfile;
 
-extern std::string iwad_base;
+extern std::string game_base;
 
 extern std::filesystem::path cache_dir;
-extern std::filesystem::path game_dir;
+extern std::filesystem::path app_dir;
 extern std::filesystem::path home_dir;
 extern std::filesystem::path save_dir;
 extern std::filesystem::path shot_dir;

--- a/source_files/edge/i_sound.cc
+++ b/source_files/edge/i_sound.cc
@@ -66,7 +66,7 @@ static bool audio_is_locked = false;
 
 std::vector<std::filesystem::path> available_soundfonts;
 std::vector<std::filesystem::path> available_genmidis;
-extern std::filesystem::path game_dir;
+extern std::filesystem::path app_dir;
 extern std::filesystem::path home_dir;
 extern cvar_c s_soundfont;
 
@@ -270,7 +270,7 @@ void I_StartupMusic(void)
 {
 	// Check for soundfonts and instrument banks
 	std::vector<epi::dir_entry_c> sfd;
-	std::filesystem::path soundfont_dir = epi::PATH_Join(game_dir, UTFSTR("soundfont"));
+	std::filesystem::path soundfont_dir = epi::PATH_Join(app_dir, UTFSTR("soundfont"));
 
 	// Always add the default/internal GENMIDI lump choice
 	available_genmidis.push_back(UTFSTR("GENMIDI"));

--- a/source_files/edge/m_menu.cc
+++ b/source_files/edge/m_menu.cc
@@ -2365,7 +2365,6 @@ void M_DrawFracThermo(int x, int y, float thermDot, float increment, int div, fl
 		// code.  It seems required to make the thermo bar tile properly.
 
 		int i=0;
-		float scale_step = 50.0f / ((max-min) / increment);
 
 		HUD_StretchImage(x, y, step+1, IM_HEIGHT(therm_l)/div, therm_l, 0.0, 0.0);
 

--- a/source_files/edge/m_option.cc
+++ b/source_files/edge/m_option.cc
@@ -314,11 +314,15 @@ static style_c *opt_def_style;
 
 static void M_ChangeMusVol(int keypressed, cvar_c *cvar)
 {
+	SYS_ASSERT(cvar);
+	cvar->operator=(cvar->f);
 	S_ChangeMusicVolume();
 }
 
 static void M_ChangeSfxVol(int keypressed, cvar_c *cvar)
 {
+	SYS_ASSERT(cvar);
+	cvar->operator=(cvar->f);
 	S_ChangeSoundVolume();
 }
 
@@ -2096,7 +2100,7 @@ static void M_ChangeSoundfont(int keypressed, cvar_c *cvar)
 	if (sf_pos < 0)
 	{
 		I_Warning("M_ChangeSoundfont: Could not read list of available soundfonts. Falling back to default!\n");
-		s_soundfont = epi::PATH_Join(game_dir, UTFSTR("soundfont/default.sf2")).generic_u8string();
+		s_soundfont = epi::PATH_Join(app_dir, UTFSTR("soundfont/default.sf2")).generic_u8string();
 		return;
 	}
 

--- a/source_files/edge/r_doomtex.cc
+++ b/source_files/edge/r_doomtex.cc
@@ -482,8 +482,8 @@ epi::file_c *OpenUserFileOrLump(imagedef_c *def)
 	switch (def->type)
 	{
 		case IMGDT_File:
-			// -AJA- 2005/01/15: filenames in DDF relative to GAMEDIR
-			return M_OpenComposedEPIFile(game_dir.c_str(), def->info.c_str());
+			// -AJA- 2005/01/15: filenames in DDF relative to APPDIR
+			return M_OpenComposedEPIFile(app_dir.c_str(), def->info.c_str());
 
 		case IMGDT_Package:
 			return W_OpenPackFile(def->info);

--- a/source_files/edge/s_cache.cc
+++ b/source_files/edge/s_cache.cc
@@ -42,7 +42,7 @@
 #include "s_mp3.h"
 #include "s_wav.h"
 
-#include "dm_state.h"  // game_dir
+#include "dm_state.h"  // app_dir
 #include "m_argv.h"
 #include "m_misc.h"
 #include "m_random.h"
@@ -147,7 +147,7 @@ static bool DoCacheLoad(sfxdef_c *def, epi::sound_data_c *buf)
 		{
 			F = W_OpenPackFile(def->pc_speaker_sound);
 			if (!F)
-				F = epi::FS_Open(M_ComposeFileName(game_dir, UTFSTR(def->pc_speaker_sound)),
+				F = epi::FS_Open(M_ComposeFileName(app_dir, UTFSTR(def->pc_speaker_sound)),
 					epi::file_c::ACCESS_READ | epi::file_c::ACCESS_BINARY);
 			if (!F)
 			{
@@ -185,8 +185,8 @@ static bool DoCacheLoad(sfxdef_c *def, epi::sound_data_c *buf)
 		else if (def->file_name != "")
 		{
 			std::filesystem::path fn;
-			// Why is this composed with the game dir? - Dasho
-			fn = M_ComposeFileName(game_dir, UTFSTR(def->file_name));
+			// Why is this composed with the app dir? - Dasho
+			fn = M_ComposeFileName(app_dir, UTFSTR(def->file_name));
 			F = epi::FS_Open(fn, epi::file_c::ACCESS_READ | epi::file_c::ACCESS_BINARY);
 			if (! F)
 			{

--- a/source_files/edge/s_fluid.cc
+++ b/source_files/edge/s_fluid.cc
@@ -89,7 +89,7 @@ bool S_StartupFluid(void)
 	if (!cvar_good)
 	{
 		I_Warning("Cannot find previously used soundfont %s, falling back to default!\n", s_soundfont.c_str());
-		s_soundfont = epi::PATH_Join(epi::PATH_Join(game_dir, UTFSTR("soundfont")), UTFSTR("default.sf2")).generic_u8string();
+		s_soundfont = epi::PATH_Join(epi::PATH_Join(app_dir, UTFSTR("soundfont")), UTFSTR("default.sf2")).generic_u8string();
 	}
 
 	edge_fluid_settings = new_fluid_settings();
@@ -103,11 +103,11 @@ bool S_StartupFluid(void)
 	fluid_synth_set_sample_rate(edge_fluid, dev_freq);
 	fluid_synth_set_gain(edge_fluid, s_fluidgain.f);
 	
-	if (fluid_synth_sfload(edge_fluid, var_pc_speaker_mode ? epi::PATH_Join(epi::PATH_Join(game_dir, UTFSTR("soundfont")), UTFSTR("bonkers_for_bits.sf2")).generic_u8string().c_str() :
+	if (fluid_synth_sfload(edge_fluid, var_pc_speaker_mode ? epi::PATH_Join(epi::PATH_Join(app_dir, UTFSTR("soundfont")), UTFSTR("bonkers_for_bits.sf2")).generic_u8string().c_str() :
 		s_soundfont.c_str(), 1) == -1)
 	{
 		I_Warning("FluidLite: Could not load requested soundfont %s! Falling back to default soundfont!\n", s_soundfont.c_str());
-		if (fluid_synth_sfload(edge_fluid, epi::PATH_Join(epi::PATH_Join(game_dir, UTFSTR("soundfont")), UTFSTR("default.sf2")).generic_u8string().c_str(), 1) == -1) 
+		if (fluid_synth_sfload(edge_fluid, epi::PATH_Join(epi::PATH_Join(app_dir, UTFSTR("soundfont")), UTFSTR("default.sf2")).generic_u8string().c_str(), 1) == -1) 
 		{
 			I_Warning("Could not load any soundfont! Ensure that default.sf2 is present in the soundfont directory!\n");
 			delete_fluid_synth(edge_fluid);

--- a/source_files/edge/s_music.cc
+++ b/source_files/edge/s_music.cc
@@ -99,7 +99,7 @@ void S_ChangeMusic(int entrynum, bool loop)
 	{
 		case MUSINF_FILE:
 		{
-			std::filesystem::path fn = M_ComposeFileName(game_dir, UTFSTR(play->info));
+			std::filesystem::path fn = M_ComposeFileName(app_dir, UTFSTR(play->info));
 
 			F = epi::FS_Open(fn, epi::file_c::ACCESS_READ | epi::file_c::ACCESS_BINARY);
 			if (! F)

--- a/source_files/edge/w_epk.h
+++ b/source_files/edge/w_epk.h
@@ -24,6 +24,8 @@
 // EPI
 #include "file.h"
 
+class data_file_c;
+
 class pack_file_c;
 
 epi::file_c * Pack_OpenFile(pack_file_c *pack, const std::string& name);
@@ -44,6 +46,15 @@ void Pack_ProcessHiresSubstitutions(pack_file_c *pack, int pack_index);
 
 // Check /sprites directory for sprites to automatically add during W_InitSprites
 std::vector<std::string> Pack_GetSpriteList(pack_file_c *pack);
+
+// Only populate the pack directory; used for ad-hoc folder/EPK checks
+void Pack_PopulateOnly(data_file_c *df);
+
+// Check pack for valid IWADs. Return associated game_base string if found and set score if provided
+std::string Pack_CheckForIWADs(data_file_c *df, int *score);
+
+// Populate pack directory and process appropriate files (COAL, DDF, etc)
+void Pack_ProcessAll(data_file_c *df, size_t file_index);
 
 #endif /* __W_PK3__ */
 

--- a/source_files/edge/w_files.h
+++ b/source_files/edge/w_files.h
@@ -40,9 +40,12 @@ typedef enum
 
 	FLKIND_Folder,    // a folder somewhere
 	FLKIND_EFolder,   // edge folder, priority loading
-	FLKIND_EPK,       // epk (zip) package
+	FLKIND_EPK,       // edge package (.epk)
 	FLKIND_EEPK,	  // edge epks, priority loading (same extension as epk)
 	FLKIND_PackWAD,   // WADs within pack files; should only be used for maps
+	FLKIND_IPK,       // standalone game EPK (same extension as epk)
+	FLKIND_IFolder,   // standalone game folder
+	FLKIND_IPackWAD,  // IWADs within pack files :/
 
 	FLKIND_DDF,       // .ddf or .ldf file
 	FLKIND_RTS,       // .rts script  file

--- a/source_files/edge/w_wad.cc
+++ b/source_files/edge/w_wad.cc
@@ -75,6 +75,43 @@
 
 #include "p_umapinfo.h" //Lobo 2022
 
+typedef struct
+{
+	// used to determine IWAD priority if no -iwad parameter provided 
+	// and multiple IWADs are detected in various paths
+	u8_t score;
+
+	// game_base to set if this IWAD is used
+	const std::string base;
+
+	// (usually) unique lumps to check for in a potential IWAD
+	const std::string unique_lumps[2];
+}
+game_check_t;
+
+// Combination of unique lumps needed to best identify an IWAD
+static const std::vector<game_check_t> game_checker =
+{
+	{
+		{ 15,  "CUSTOM",    {"EDGEIWAD", "EDGEIWAD"} },
+		{ 1,  "BLASPHEMER", {"BLASPHEM", "E1M1"}     },
+		{ 7,  "FREEDOOM1",  {"FREEDOOM", "E1M1"}     },
+		{ 12, "FREEDOOM2",  {"FREEDOOM", "MAP01"}    },
+		{ 5,  "REKKR",      {"REKCREDS", "E1M1"}     },
+		{ 4,  "HACX",       {"HACX-R",   "MAP01"}    },
+		{ 3,  "HARMONY",    {"0HAWK01",  "MAP01"}    },
+		{ 2,  "HERETIC",    {"MUS_E1M1", "E1M1"}     },
+		{ 10, "PLUTONIA",   {"CAMO1",    "MAP01"}    },
+		{ 11, "TNT",        {"REDTNT2",  "MAP01"}    },
+		{ 9,  "DOOM",       {"BFGGA0",   "E2M1"}     },
+		{ 8,  "DOOM",       {"DMENUPIC", "M_MULTI"}  }, // BFG Edition
+		{ 6,  "DOOM1",      {"SHOTA0",   "E1M1"}     },
+		{ 14, "DOOM2",      {"BFGGA0",   "MAP01"}    },
+		{ 13, "DOOM2",   	{"DMENUPIC", "MAP33"}    }, // BFG Edition
+		//{ 0, "STRIFE",    {"VELLOGO",  "RGELOGO"}  }// Dev/internal use - Definitely nowhwere near playable
+	}
+};
+
 class wad_file_c
 {
 public:
@@ -823,81 +860,90 @@ static void CheckForLevel(wad_file_c *wad, int lump, const char *name,
 	}
 }
 
-bool W_CheckForUniqueLumps(epi::file_c *file, const char *lumpname1, const char *lumpname2)
+std::string W_CheckForUniqueLumps(epi::file_c *file, int *score)
 {
 	int length;
-	bool lump1_found = false;
-	bool lump2_found = false;
-
 	raw_wad_header_t header;
 
-	if (file == NULL)
+	if (!file)
 	{
 		I_Warning("W_CheckForUniqueLumps: Received null file_c pointer!\n");
-		return false;
+		return "";
 	}
 
 	// WAD file
 	// TODO: handle Read failure
     file->Read(&header, sizeof(raw_wad_header_t));
-
- 	// Do not require IWAD header if loading Harmony, REKKR, BFG Edition WADs or a custom standalone IWAD
-	if (epi::prefix_cmp(header.identification, "IWAD") != 0 &&
-		epi::case_cmp(lumpname1, "DMENUPIC") != 0 &&
-		epi::case_cmp(lumpname1, "REKCREDS") != 0 && 
-		epi::case_cmp(lumpname1, "0HAWK01" ) != 0 &&
-		epi::case_cmp(lumpname1, "EDGEIWAD") != 0)
-	{
-		file->Seek(0, epi::file_c::SEEKPOINT_START);
-		return false;
-	}
-
 	header.num_entries = EPI_LE_S32(header.num_entries);
 	header.dir_start   = EPI_LE_S32(header.dir_start);
-
 	length = header.num_entries * sizeof(raw_wad_entry_t);
-
     raw_wad_entry_t *raw_info = new raw_wad_entry_t[header.num_entries];
-
     file->Seek(header.dir_start, epi::file_c::SEEKPOINT_START);
-	// TODO: handle Read failure
     file->Read(raw_info, length);
 
-	unsigned int i;
-	for (i=0 ; i < header.num_entries ; i++)
+	for (auto check : game_checker)
 	{
-		raw_wad_entry_t& entry = raw_info[i];
-
-		if (strncmp(lumpname1, entry.name, strlen(lumpname1) < 8 ? strlen(lumpname1) : 8) == 0)
+		// Do not require IWAD header if loading Harmony, REKKR, BFG Edition WADs or a custom standalone IWAD
+		if (epi::prefix_cmp(header.identification, "IWAD") != 0 &&
+			epi::case_cmp(check.unique_lumps[0], "DMENUPIC") != 0 &&
+			epi::case_cmp(check.unique_lumps[0], "REKCREDS") != 0 && 
+			epi::case_cmp(check.unique_lumps[0], "0HAWK01" ) != 0 &&
+			epi::case_cmp(check.unique_lumps[0], "EDGEGAME") != 0)
 		{
-			// EDGEIWAD is the only wad needed for custom standalones
-			if (epi::case_cmp(lumpname1, "EDGEIWAD") == 0)
-			{
-				delete[] raw_info;
-				file->Seek(0, epi::file_c::SEEKPOINT_START);
-				return true;
-			}
-			else
-				lump1_found = true;
+			continue;
 		}
-		if (strncmp(lumpname2, entry.name, strlen(lumpname2) < 8 ? strlen(lumpname2) : 8) == 0)
-			lump2_found = true;
+
+		bool lump1_found = false;
+		bool lump2_found = false;
+
+		for (size_t i=0 ; i < header.num_entries ; i++)
+		{
+			raw_wad_entry_t& entry = raw_info[i];
+
+			if (epi::strncmp(check.unique_lumps[0], entry.name, check.unique_lumps[0].size() < 8 ? check.unique_lumps[0].size() : 8) == 0)
+			{
+				// EDGEGAME is the only lump needed for custom standalones
+				if (epi::case_cmp(check.unique_lumps[0], "EDGEGAME") == 0)
+				{
+					delete[] raw_info;
+					file->Seek(0, epi::file_c::SEEKPOINT_START);
+					if (score)
+						*score = check.score;
+					return check.base;
+				}
+				else
+					lump1_found = true;
+			}
+			if (epi::strncmp(check.unique_lumps[1], entry.name, check.unique_lumps[1].size() < 8 ? check.unique_lumps[1].size() : 8) == 0)
+				lump2_found = true;
+		}
+
+		if (lump1_found && lump2_found)
+		{
+			delete[] raw_info;
+			file->Seek(0, epi::file_c::SEEKPOINT_START);
+			if (score)
+				*score = check.score;
+			return check.base;
+		}
 	}
 
 	delete[] raw_info;
 	file->Seek(0, epi::file_c::SEEKPOINT_START);
-	return (lump1_found && lump2_found);
+	if (score)
+		*score = 0;
+	return "";
 }
 
 
 void ProcessFixersForWad(data_file_c *df)
 {
 	// Special handling for Doom 2 BFG Edition
-	if (df->kind == FLKIND_IWad)
+	if (df->kind == FLKIND_IWad || df->kind == FLKIND_IPackWAD)
 	{
 		if (W_CheckNumForName("MAP33") > -1 && W_CheckNumForName("DMENUPIC") > -1)
 		{
-			std::filesystem::path fix_path = epi::PATH_Join(game_dir, UTFSTR("edge_fixes"));
+			std::filesystem::path fix_path = epi::PATH_Join(app_dir, UTFSTR("edge_fixes"));
 			fix_path = epi::PATH_Join(fix_path, UTFSTR("doom2_bfg.wad"));
 			if (epi::FS_Access(fix_path, epi::file_c::ACCESS_READ))
 			{
@@ -922,7 +968,7 @@ void ProcessFixersForWad(data_file_c *df)
 	{
 		if (epi::case_cmp(fix_checker, fixdefs[i]->md5_string) == 0)
 		{
-			std::filesystem::path fix_path = epi::PATH_Join(game_dir, UTFSTR("edge_fixes"));
+			std::filesystem::path fix_path = epi::PATH_Join(app_dir, UTFSTR("edge_fixes"));
 			fix_path = epi::PATH_Join(fix_path, UTFSTR(fix_checker.append(".wad")));
 			if (epi::FS_Access(fix_path, epi::file_c::ACCESS_READ))
 			{
@@ -1092,7 +1138,8 @@ void ProcessWad(data_file_c *df, size_t file_index)
 		raw_wad_entry_t& entry = raw_info[i];
 
 		bool allow_ddf = (df->kind == FLKIND_EWad || (df->kind == FLKIND_IWad && 
-			epi::strcmp(iwad_base, "CUSTOM") == 0) || df->kind == FLKIND_PWad || df->kind == FLKIND_PackWAD);
+			epi::strcmp(game_base, "CUSTOM") == 0) || df->kind == FLKIND_PWad || df->kind == FLKIND_PackWAD
+			|| df->kind == FLKIND_IPK || df->kind == FLKIND_IFolder);
 
 		AddLump(df, entry.name, EPI_LE_S32(entry.pos), EPI_LE_S32(entry.size),
 				(int)file_index, allow_ddf);
@@ -2346,7 +2393,8 @@ bool W_IsLumpInAnyWad(const char *name)
 		for (int i = 0 ; i < (int)data_files.size() - 1 ; i++)
 		{
 			data_file_c *df = data_files[i];
-			if (df->kind == FLKIND_Folder || df->kind == FLKIND_EFolder || df->kind == FLKIND_EPK || df->kind == FLKIND_EEPK)
+			if (df->kind == FLKIND_Folder || df->kind == FLKIND_EFolder || df->kind == FLKIND_EPK || df->kind == FLKIND_EEPK
+				|| df->kind == FLKIND_IFolder || df->kind == FLKIND_IPK)
 			{
 				if (Pack_FindStem(df->pack, name))
 				{

--- a/source_files/edge/w_wad.h
+++ b/source_files/edge/w_wad.h
@@ -88,7 +88,7 @@ bool W_IsLumpInPwad(const char *name);
 
 bool W_IsLumpInAnyWad(const char *name);
 
-bool W_CheckForUniqueLumps(epi::file_c *file, const char *lumpname1, const char *lumpname2);
+std::string W_CheckForUniqueLumps(epi::file_c *file, int *score);
 
 void W_CheckWADFixes(void);
 


### PR DESCRIPTION
- EDGEIWAD lump to identify standalone content has been renamed to EDGEGAME
  - EDGEGAME.txt is the pack file equivalent
- Renamed -game parameter to -app; functionality remains the same
- -game parameter is now equivalent to the "-iwad" parameter
- -game and -iwad will now accept directories and EPKs as valid options
  - Directories/EPKs will be scanned for either EDGEGAME.txt or an IWAD