### PR TITLE
Fix: Ignore STBAR and BARBACK offsets

### DIFF
--- a/edge_base/blasphemer/scripts/coal_hud.ec
+++ b/edge_base/blasphemer/scripts/coal_hud.ec
@@ -63,7 +63,7 @@ function heretic_status_bar() =
 	
 	//order is important because some of them overlap
 	//hud.draw_image(0, 158, "BARBACK")
-	hud.draw_image(  160 - centerOffsetX, 158, "BARBACK")
+	hud.draw_image(  160 - centerOffsetX, 158, "BARBACK",1)
 	hud.draw_image(34, 160, "LIFEBAR")
 	hud.draw_image(-1, 190, "CHAINBAC")	
 	hud.draw_image(0, 190, "CHAIN")	

--- a/edge_base/heretic/scripts/coal_hud.ec
+++ b/edge_base/heretic/scripts/coal_hud.ec
@@ -59,7 +59,7 @@ function heretic_status_bar() =
 	
 	//order is important because some of them overlap
 	//hud.draw_image(0, 158, "BARBACK")
-	hud.draw_image(  160 - centerOffsetX, 158, "BARBACK")
+	hud.draw_image(  160 - centerOffsetX, 158, "BARBACK",1)
 	hud.draw_image(  -120, 158, "STBARL") // Widescreen border
     hud.draw_image(  355, 158, "STBARR") // Widescreen border
 	hud.draw_image(34, 160, "LIFEBAR")

--- a/edge_defs/scripts/coal_hud.ec
+++ b/edge_defs/scripts/coal_hud.ec
@@ -235,7 +235,7 @@ function doom_status_bar() =
 	centerOffsetX = tempwidth / 2;
 	
 	//hud.draw_image(  0, 168, "STBAR")
-	hud.draw_image(  160 - centerOffsetX, 168, "STBAR")
+	hud.draw_image(  160 - centerOffsetX, 168, "STBAR",1)
 	
     hud.draw_image( 90, 171, "STTPRCNT")
     hud.draw_image(221, 171, "STTPRCNT")


### PR DESCRIPTION
Some widescreen statusbars were displaying wrong.