### PR TITLE
New method: LookupDoorKey()

### DIFF
--- a/source_files/ddf/thing.cc
+++ b/source_files/ddf/thing.cc
@@ -2805,5 +2805,50 @@ const mobjtype_c* mobjtype_container_c::LookupPlayer(int playernum)
 	return NULL; /* NOT REACHED */
 }
 
+const mobjtype_c* mobjtype_container_c::LookupDoorKey(int theKey)
+{
+	// Find a key thing (needed by automap code).
+
+	epi::array_iterator_c it;
+
+/*
+	//run through the key flags to get the benefit name
+
+	std::string KeyName;
+	KeyName.clear();
+
+	for (int k = 0; keytype_names[k].name; k++)
+	{
+		if (keytype_names[k].flags == theKey)
+		{
+			std::string temp_ref = epi::STR_Format("%s", keytype_names[k].name);
+			KeyName = temp_ref;
+			break;
+		}
+	}
+*/
+
+	for (it = GetTailIterator(); it.IsValid(); it--)
+	{
+		mobjtype_c *m = ITERATOR_TO_TYPE(it, mobjtype_c*);
+		
+		benefit_t *list;
+		list = m->pickup_benefits;
+		for (; list != NULL; list=list->next)
+		{
+			if(list->type == BENEFIT_Key)
+			{
+				if (list->sub.type==theKey)
+				{
+					return m;
+				}
+			}
+		}
+	}
+
+	I_Error("Missing DDF entry for key %d\n", theKey);
+	return NULL; /* NOT REACHED */
+}
+
 //--- editor settings ---
 // vi:ts=4:sw=4:noexpandtab

--- a/source_files/ddf/thing.h
+++ b/source_files/ddf/thing.h
@@ -1076,6 +1076,7 @@ public:
 	// FIXME!!! Move to a more appropriate location
 	const mobjtype_c *LookupCastMember(int castpos);
 	const mobjtype_c *LookupPlayer(int playernum);
+	const mobjtype_c *LookupDoorKey(int theKey);
 };
 
 


### PR DESCRIPTION
Given a door key flag, returns the corresponding mobjtype. For cases were a  custom key thing has been created in DDF with a different name i.e. "Rune key" has a BLUE_SKULL pickup benefit.