### PR TITLE
Display message box before shutting down system

### DIFF
--- a/source_files/edge/i_system.cc
+++ b/source_files/edge/i_system.cc
@@ -89,9 +89,9 @@ void I_Error(const char *error,...)
 		fflush(debugfile);
 	}
 
-	I_SystemShutdown();
-
 	I_MessageBox(msgbuf, "EDGE-Classic Error");
+
+	I_SystemShutdown();
 
 	I_CloseProgram(EXIT_FAILURE);
 }


### PR DESCRIPTION
Fixes an issue at exit where SDL_Quit is called before creating message box, leading to an odd hang at exit and no message box