### PR TITLE
Legacy bug: map AMBUSH flag was being lost

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -22,4 +22,8 @@ Bugs fixed
 ----------
 - Weapon Kick will now work when Mouselook is disabled
 - Fixed CTD involving liquid swirl checks when debug_hom is set to 1
-- 
+- Old pre-EC legacy issue: map AMBUSH flag was being lost if mobj was being replaced during 
+  gameplay via BECOME. Was also now affecting new EC commands 
+  i.e. UNBECOME/MORPH/UNMORPH ddf commands or REPLACE_THING rts command.
+  
+  

--- a/source_files/edge/p_action.cc
+++ b/source_files/edge/p_action.cc
@@ -3822,9 +3822,10 @@ void P_ActBecome(struct mobj_s *mo)
 	P_UnsetThingPosition(mo);
 	{
 		mo->info = become->info;
-
+		
 		mo->morphtimeout = mo->info->morphtimeout;
 
+		// Note: health is not changed
 		mo->radius = mo->info->radius;
 		mo->height = mo->info->height;
 		// MBF21: Use explicit Fast speed if provided
@@ -3833,9 +3834,14 @@ void P_ActBecome(struct mobj_s *mo)
 		else
 			mo->speed  = mo->info->speed * (level_flags.fastparm ? mo->info->fast : 1);
 
-		// Note: health is not changed
+		if (mo->flags & MF_AMBUSH) //preserve map editor AMBUSH flag
+		{
+			mo->flags         = mo->info->flags;
+			mo->flags |= MF_AMBUSH;
+		}
+		else
+			mo->flags         = mo->info->flags;
 
-		mo->flags         = mo->info->flags;
 		mo->extendedflags = mo->info->extendedflags;
 		mo->hyperflags    = mo->info->hyperflags;
 
@@ -3904,8 +3910,14 @@ void P_ActUnBecome(struct mobj_s *mo)
 			mo->speed  = mo->info->speed * (level_flags.fastparm ? mo->info->fast : 1);
 
 		// Note: health is not changed
+		if (mo->flags & MF_AMBUSH) //preserve map editor AMBUSH flag
+		{
+			mo->flags         = mo->info->flags;
+			mo->flags |= MF_AMBUSH;
+		}
+		else
+			mo->flags         = mo->info->flags;
 
-		mo->flags         = mo->info->flags;
 		mo->extendedflags = mo->info->extendedflags;
 		mo->hyperflags    = mo->info->hyperflags;
 
@@ -3978,7 +3990,14 @@ void P_ActMorph(struct mobj_s *mo)
 		else
 			mo->speed  = mo->info->speed * (level_flags.fastparm ? mo->info->fast : 1);
 
-		mo->flags         = mo->info->flags;
+		if (mo->flags & MF_AMBUSH) //preserve map editor AMBUSH flag
+		{
+			mo->flags         = mo->info->flags;
+			mo->flags |= MF_AMBUSH;
+		}
+		else
+			mo->flags         = mo->info->flags;
+
 		mo->extendedflags = mo->info->extendedflags;
 		mo->hyperflags    = mo->info->hyperflags;
 
@@ -4050,7 +4069,14 @@ void P_ActUnMorph(struct mobj_s *mo)
 
 		// Note: health is not changed
 
-		mo->flags         = mo->info->flags;
+		if (mo->flags & MF_AMBUSH) //preserve map editor AMBUSH flag
+		{
+			mo->flags         = mo->info->flags;
+			mo->flags |= MF_AMBUSH;
+		}
+		else
+			mo->flags         = mo->info->flags;
+			
 		mo->extendedflags = mo->info->extendedflags;
 		mo->hyperflags    = mo->info->hyperflags;
 

--- a/source_files/edge/rad_act.cc
+++ b/source_files/edge/rad_act.cc
@@ -1343,7 +1343,15 @@ void P_ActReplace(struct mobj_s *mo, const mobjtype_c *newThing)
 			mo->speed  = mo->info->speed * (level_flags.fastparm ? mo->info->fast : 1);
 
 		mo->health        = mo->info->spawnhealth; // always top up health to full
-		mo->flags         = mo->info->flags;
+		
+		if (mo->flags & MF_AMBUSH) //preserve map editor AMBUSH flag
+		{
+			mo->flags         = mo->info->flags;
+			mo->flags |= MF_AMBUSH;
+		}
+		else
+			mo->flags         = mo->info->flags;
+
 		mo->extendedflags = mo->info->extendedflags;
 		mo->hyperflags    = mo->info->hyperflags;
 


### PR DESCRIPTION
Old pre-EC legacy issue: map AMBUSH flag was being lost if mobj was being replaced during gameplay via BECOME. Was also now affecting new EC commands i.e. UNBECOME/MORPH/UNMORPH ddf commands or REPLACE_THING rts command.