### PR TITLE
Automap: Keyinfo error

### DIFF
--- a/source_files/ddf/thing.cc
+++ b/source_files/ddf/thing.cc
@@ -2862,8 +2862,8 @@ const mobjtype_c* mobjtype_container_c::LookupDoorKey(int theKey)
 		}
 	}
 
-	I_Error("Missing DDF entry for key %d\n", theKey);
-	return NULL; /* NOT REACHED */
+	I_Warning("Missing DDF entry for key %d\n", theKey);
+	return NULL;
 }
 
 //--- editor settings ---

--- a/source_files/edge/am_map.cc
+++ b/source_files/edge/am_map.cc
@@ -932,7 +932,12 @@ static void AM_WalkSeg(seg_t *seg)
 					else if(line->special->keys & KF_BlueCard || line->special->keys & KF_BlueSkull)
 					{
 						DrawMLineDoor(&l, T_BLUE); //blue
-						if(line->special->keys & KF_BlueCard)
+						if(line->special->keys & (KF_BlueSkull | KF_BlueCard))
+						{
+							DrawKeyOnLine(&l, KF_BlueCard);
+							DrawKeyOnLine(&l, KF_BlueSkull);
+						}
+						else if(line->special->keys & KF_BlueCard)
 							DrawKeyOnLine(&l, KF_BlueCard);
 						else
 							DrawKeyOnLine(&l, KF_BlueSkull);
@@ -940,7 +945,12 @@ static void AM_WalkSeg(seg_t *seg)
 					else if(line->special->keys & KF_YellowCard || line->special->keys & KF_YellowSkull)
 					{
 						DrawMLineDoor(&l, T_YELLOW); //yellow
-						if(line->special->keys & KF_YellowCard)
+						if(line->special->keys & (KF_YellowSkull | KF_YellowCard))
+						{
+							DrawKeyOnLine(&l, KF_YellowCard);
+							DrawKeyOnLine(&l, KF_YellowSkull);
+						}
+						else if(line->special->keys & KF_YellowCard)
 							DrawKeyOnLine(&l, KF_YellowCard);
 						else
 							DrawKeyOnLine(&l, KF_YellowSkull);
@@ -948,7 +958,12 @@ static void AM_WalkSeg(seg_t *seg)
 					else if(line->special->keys & KF_RedCard || line->special->keys & KF_RedSkull)
 					{
 						DrawMLineDoor(&l, T_RED); //red
-						if(line->special->keys & KF_RedCard)
+						if(line->special->keys & (KF_RedSkull | KF_RedCard))
+						{
+							DrawKeyOnLine(&l, KF_RedCard);
+							DrawKeyOnLine(&l, KF_RedSkull);
+						}
+						else if(line->special->keys & KF_RedCard)
 							DrawKeyOnLine(&l, KF_RedCard);
 						else
 							DrawKeyOnLine(&l, KF_RedSkull);
@@ -956,7 +971,12 @@ static void AM_WalkSeg(seg_t *seg)
 					else if(line->special->keys & KF_GreenCard || line->special->keys & KF_GreenSkull)
 					{
 						DrawMLineDoor(&l, T_GREEN); //green
-						if(line->special->keys & KF_GreenCard)
+						if(line->special->keys & (KF_GreenSkull | KF_GreenCard))
+						{
+							DrawKeyOnLine(&l, KF_GreenCard);
+							DrawKeyOnLine(&l, KF_GreenSkull);
+						}
+						else if(line->special->keys & KF_GreenCard)
 							DrawKeyOnLine(&l, KF_GreenCard);
 						else
 							DrawKeyOnLine(&l, KF_GreenSkull);

--- a/source_files/edge/am_map.cc
+++ b/source_files/edge/am_map.cc
@@ -715,6 +715,8 @@ static void DrawKeyOnLine(mline_t * ml, int theKey, rgbcol_t rgb = T_WHITE)
 	else
 	{
 		TheObject = mobjtypes.LookupDoorKey(theKey);
+		if(!TheObject)
+			return; //Very rare, only zombiesTC hits this so far
 		CleanName = Aux2StringReplaceAll(TheObject->name, std::string("_"), std::string(" "));
 	}
 		


### PR DESCRIPTION
Fix for missing DDF entry for key. Only ZombieTC causes this. Instead of erroring out, just log it and  gracefully show nothing.