### PR TITLE
Use default of internalConsole when debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,8 +12,7 @@
             "args": [],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}",
-            "environment": [],
-            "console": "externalTerminal"
+            "environment": []
         },         
         {
             "name": "(gdb) Launch",


### PR DESCRIPTION
Use the default of "internalConsole" when debugging in VSCode, which is consistent with Linux setting in json, and avoids leaving a bunch of terminal windows with "Press any key to continue..."