### PR TITLE
Bug fix: crushed monsters never entered their GIB states

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -29,9 +29,8 @@ Bugs fixed
 - Weapon Kick will now work when Mouselook is disabled
 - Fixed CTD involving liquid swirl checks when debug_hom is set to 1
 - Old pre-EC legacy issue: map AMBUSH flag was being lost if mobj was being replaced during 
-  gameplay via BECOME. Was also now affecting new EC commands 
-  i.e. UNBECOME/MORPH/UNMORPH ddf commands or REPLACE_THING rts command.
+  gameplay via BECOME
 - RTS scripts using ON_DEATH conditions would not work from a load game.
 - Automap key display shows Boom style locks
 - Change draw order of "Entering" and "you are here" intermission graphics 
-  
+- Old pre-EC legacy issue: crushed monsters never entered their GIB states 

--- a/source_files/edge/p_map.cc
+++ b/source_files/edge/p_map.cc
@@ -2764,7 +2764,8 @@ static bool PIT_ChangeSector(mobj_t * thing, bool widening)
 		if (thing->info->gib_state && !(thing->extendedflags & EF_GIBBED))
 		{
 			thing->extendedflags |= EF_GIBBED;
-			P_SetMobjStateDeferred(thing, thing->info->gib_state, 0);
+			//P_SetMobjStateDeferred(thing, thing->info->gib_state, 0);
+			P_SetMobjState(thing, thing->info->gib_state);
 		}
 
 		if (thing->player)


### PR DESCRIPTION
pre-EC legacy issue: crushed monsters never entered their GIB states