### PR TITLE
Auto-aim now targets "fuzzy" monsters

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -22,6 +22,7 @@ General Improvements/Changes
 
 - Gameplay option "Blood" can be set to "None"
 - For standalone games, EDGEIWAD has been changed to EDGEGAME
+- Auto-aim now targets "fuzzy" monsters i.e. Specters
  
 
 Bugs fixed

--- a/source_files/edge/p_action.cc
+++ b/source_files/edge/p_action.cc
@@ -1192,7 +1192,7 @@ static mobj_t *DoLaunchProjectile(mobj_t * source, float tx, float ty, float tz,
 
 		if (! (attack->flags & AF_Player))
 		{
-			if (target->flags & MF_FUZZY)
+			if (target->flags & MF_FUZZY && !source->player)
 				angle += P_RandomNegPos() << (ANGLEBITS - 12);
 
 			if (target->visibility < VISIBLE)


### PR DESCRIPTION
Auto-aim now targets "fuzzy" monsters i.e. Specters.

"Fixed" against my will ;)