### PR TITLE
Detail Level Updates

### DIFF
--- a/source_files/edge/defaults.h
+++ b/source_files/edge/defaults.h
@@ -75,7 +75,6 @@
 #define CFGDEF_USE_SMOOTHING    (1)
 #define CFGDEF_USE_DLIGHTS      (1)
 #define CFGDEF_DETAIL_LEVEL     (2)
-#define CFGDEF_USE_MIPMAPPING   (2)
 #define CFGDEF_HQ2X_SCALING     (3)
 #define CFGDEF_SCREEN_HUD       (0)
 #define CFGDEF_CROSSHAIR        (0)

--- a/source_files/edge/m_misc.cc
+++ b/source_files/edge/m_misc.cc
@@ -120,7 +120,6 @@ static default_t defaults[] =
     {CFGT_Boolean,  "mlook",             &global_flags.mlook, CFGDEF_MLOOK},
     {CFGT_Boolean,  "jumping",           &global_flags.jump, CFGDEF_JUMP},
     {CFGT_Boolean,  "crouching",         &global_flags.crouch, CFGDEF_CROUCH},
-    {CFGT_Int,      "mipmapping",        &var_mipmapping, CFGDEF_USE_MIPMAPPING},
     {CFGT_Int,      "smoothing",         &var_smoothing,  CFGDEF_USE_SMOOTHING},
     {CFGT_Int,      "dlights",           &use_dlights,    CFGDEF_USE_DLIGHTS},
     {CFGT_Int,      "detail_level",      &detail_level,   CFGDEF_DETAIL_LEVEL},

--- a/source_files/edge/m_option.cc
+++ b/source_files/edge/m_option.cc
@@ -406,12 +406,10 @@ static optmenuitem_t vidoptions[] =
 	{OPT_Boolean, "Lighting Mode",    "Indexed/Flat",  2,  &r_forceflatlighting.d, M_UpdateCVARFromInt, NULL, &r_forceflatlighting},
 	{OPT_Switch,  "Framerate Target", "35 FPS/70 FPS", 2, &r_doubleframes.d, M_UpdateCVARFromInt, NULL, &r_doubleframes},
 	{OPT_Switch,  "Smoothing",         YesNo, 2, &var_smoothing, M_ChangeMipMap, NULL},
-	{OPT_Switch,  "H.Q.2x Scaling", Hq2xMode, 4, &hq2x_scaling, M_ChangeMipMap, NULL},
+	{OPT_Switch,  "Upscale Textures", Hq2xMode, 4, &hq2x_scaling, M_ChangeMipMap, "Only affects paletted (Doom format) textures"},
 	{OPT_Switch,  "Title/Intermission Scaling", TitleScaleMode, 4, &r_titlescaling.d, M_UpdateCVARFromInt, NULL, &r_titlescaling},
 	{OPT_Switch,  "Sky Scaling", SkyScaleMode, 4, &r_skystretch.d, M_UpdateCVARFromInt, "Vanilla will be forced when Mouselook is Off", &r_skystretch},
 	{OPT_Switch,  "Dynamic Lighting", YesNo, 2, &use_dlights, NULL, NULL},
-	{OPT_Switch,  "Detail Level",   Details,  3, &detail_level, M_ChangeMipMap, NULL},
-	{OPT_Switch,  "Mipmapping",     MipMaps,  3, &var_mipmapping, M_ChangeMipMap, NULL},
 	{OPT_Switch,  "Overlay",  		VidOverlays, 7, &r_overlay.d, M_UpdateCVARFromInt, NULL, &r_overlay},
 	{OPT_Switch,  "Crosshair",       CrossH, 10, &r_crosshair.d, M_UpdateCVARFromInt, NULL, &r_crosshair},
 	{OPT_Switch,  "Crosshair Color", CrosshairColor,  8, &r_crosscolor.d, M_UpdateCVARFromInt, NULL, &r_crosscolor},
@@ -619,6 +617,7 @@ static menuinfo_t gameplay_optmenu =
 //
 static optmenuitem_t perfoptions[] =
 {
+	{OPT_Switch,  "Detail Level",   Details,  3, &detail_level, M_ChangeMipMap, NULL},
 	{OPT_Boolean, "Draw Distance Culling", YesNo, 2, 
      &r_culling.d, M_UpdateCVARFromInt, "Sector/Level Fog will be disabled when this is On", &r_culling},
 	{OPT_FracSlider, "Maximum Draw Distance", NULL, 0, 

--- a/source_files/edge/r_image.cc
+++ b/source_files/edge/r_image.cc
@@ -189,10 +189,6 @@ static void do_DebugDump(real_image_container_c& bucket)
 }
 #endif
 
-// mipmapping enabled ?
-// 0 off, 1 bilinear, 2 trilinear
-int var_mipmapping = 1;
-
 int var_smoothing  = 1;
 
 int hq2x_scaling = 1;
@@ -1234,10 +1230,12 @@ static bool IM_ShouldHQ2X(image_c *rim)
 
 static int IM_PixelLimit(image_c *rim)
 {
-	if (IM_ShouldMipmap(rim))
-		return 65536 * (1 << (2 * detail_level));
-
-	return (1 << 24);
+	if (detail_level == 0)
+		return (1 << 18);
+	else if (detail_level == 1)
+		return (1 << 20);
+	else
+		return (1 << 22);
 }
 
 
@@ -1971,13 +1969,6 @@ bool W_InitImages(void)
 		var_smoothing = 0;
 	else if (argv::Find("smoothing") > 0)
 		var_smoothing = 1;
-
-	if (argv::Find("nomipmap") > 0)
-		var_mipmapping = 0;
-	else if (argv::Find("mipmap") > 0)
-		var_mipmapping = 1;
-	else if (argv::Find("trilinear") > 0)
-		var_mipmapping = 2;
 
 	W_CreateDummyImages();
 

--- a/source_files/edge/r_image.h
+++ b/source_files/edge/r_image.h
@@ -232,7 +232,6 @@ void W_ImageMakeSaveString(const image_c *image, char *type, char *namebuf);
 //  IMAGE USAGE
 //
 
-extern int  var_mipmapping;
 extern int  var_smoothing;
 extern int  hq2x_scaling;
 

--- a/source_files/edge/r_md2.cc
+++ b/source_files/edge/r_md2.cc
@@ -1145,7 +1145,7 @@ I_Debugf("Render model: bad frame %d\n", frame1);
 
 	/* draw the model */
 
-	int num_pass = data.is_fuzzy  ? 1 : 3 + detail_level;
+	int num_pass = data.is_fuzzy  ? 1 : (detail_level > 0 ? 4 : 3);
 
 	rgbcol_t fc_to_use = mo->subsector->sector->props.fog_color;
 	float fd_to_use = mo->subsector->sector->props.fog_density;

--- a/source_files/edge/r_md2.cc
+++ b/source_files/edge/r_md2.cc
@@ -1145,9 +1145,7 @@ I_Debugf("Render model: bad frame %d\n", frame1);
 
 	/* draw the model */
 
-	int num_pass = data.is_fuzzy  ? 1 :
-		           data.is_weapon ? (3 + detail_level) :
-					                (2 + detail_level*2);
+	int num_pass = data.is_fuzzy  ? 1 : 3 + detail_level;
 
 	rgbcol_t fc_to_use = mo->subsector->sector->props.fog_color;
 	float fd_to_use = mo->subsector->sector->props.fog_density;
@@ -1253,8 +1251,6 @@ I_Debugf("Render model: bad frame %d\n", frame1);
 				continue;
 		}
 
-		GLuint model_env = data.is_additive ? ENV_SKIP_RGB : GL_MODULATE;
-
 		glPolygonOffset(0, -pass);
 
 		if (blending & (BL_Masked | BL_Less))
@@ -1316,7 +1312,18 @@ I_Debugf("Render model: bad frame %d\n", frame1);
 		glEnable(GL_TEXTURE_2D);
 		glBindTexture(GL_TEXTURE_2D, skin_tex);
 
-		glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, model_env);
+		if (data.is_additive)
+		{
+			glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_COMBINE);
+			glTexEnvi(GL_TEXTURE_ENV, GL_COMBINE_RGB, GL_REPLACE);
+			glTexEnvi(GL_TEXTURE_ENV, GL_SOURCE0_RGB, GL_PREVIOUS);
+		}
+		else
+		{
+			glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);
+			glTexEnvi(GL_TEXTURE_ENV, GL_COMBINE_RGB, GL_MODULATE);
+			glTexEnvi(GL_TEXTURE_ENV, GL_SOURCE0_RGB, GL_TEXTURE);
+		}
 
 		GLint old_clamp = 789;
 

--- a/source_files/edge/r_mdl.cc
+++ b/source_files/edge/r_mdl.cc
@@ -834,7 +834,7 @@ I_Debugf("Render model: bad frame %d\n", frame1);
 
 	/* draw the model */
 
-	int num_pass = data.is_fuzzy  ? 1 : 3 + detail_level;
+	int num_pass = data.is_fuzzy  ? 1 : (detail_level > 0 ? 4 : 3);
 
 	rgbcol_t fc_to_use = mo->subsector->sector->props.fog_color;
 	float fd_to_use = mo->subsector->sector->props.fog_density;

--- a/source_files/edge/r_mdl.cc
+++ b/source_files/edge/r_mdl.cc
@@ -834,9 +834,7 @@ I_Debugf("Render model: bad frame %d\n", frame1);
 
 	/* draw the model */
 
-	int num_pass = data.is_fuzzy  ? 1 :
-		           data.is_weapon ? (3 + detail_level) :
-					                (2 + detail_level*2);
+	int num_pass = data.is_fuzzy  ? 1 : 3 + detail_level;
 
 	rgbcol_t fc_to_use = mo->subsector->sector->props.fog_color;
 	float fd_to_use = mo->subsector->sector->props.fog_density;
@@ -940,7 +938,6 @@ I_Debugf("Render model: bad frame %d\n", frame1);
 			if (MDL_MulticolMaxRGB(&data, true) <= 0)
 				continue;
 		}
-		GLuint model_env = data.is_additive ? ENV_SKIP_RGB : GL_MODULATE;
 
 		glPolygonOffset(0, -pass);
 
@@ -1003,7 +1000,18 @@ I_Debugf("Render model: bad frame %d\n", frame1);
 		glEnable(GL_TEXTURE_2D);
 		glBindTexture(GL_TEXTURE_2D, skin_tex);
 
-		glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, model_env);
+		if (data.is_additive)
+		{
+			glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_COMBINE);
+			glTexEnvi(GL_TEXTURE_ENV, GL_COMBINE_RGB, GL_REPLACE);
+			glTexEnvi(GL_TEXTURE_ENV, GL_SOURCE0_RGB, GL_PREVIOUS);
+		}
+		else
+		{
+			glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);
+			glTexEnvi(GL_TEXTURE_ENV, GL_COMBINE_RGB, GL_MODULATE);
+			glTexEnvi(GL_TEXTURE_ENV, GL_SOURCE0_RGB, GL_TEXTURE);
+		}
 
 		GLint old_clamp = 789;
 

--- a/source_files/edge/r_shader.cc
+++ b/source_files/edge/r_shader.cc
@@ -335,9 +335,6 @@ public:
 	{
 		for (int DL = 0; DL < 2; DL++)
 		{
-			if (detail_level == 0 && DL > 0)
-				continue;
-
 			if (WhatType(DL) == DLITE_None)
 				break;
 
@@ -535,9 +532,6 @@ public:
 
 		for (int DL = 0; DL < 2; DL++)
 		{
-			if (detail_level == 0 && DL > 0)
-				continue;
-
 			if (WhatType(DL) == DLITE_None)
 				break;
 
@@ -715,9 +709,6 @@ public:
 
 		for (int DL = 0; DL < 2; DL++)
 		{
-			if (detail_level == 0 && DL > 0)
-				continue;
-
 			if (WhatType(DL) == DLITE_None)
 				break;
 

--- a/source_files/edge/r_texgl.cc
+++ b/source_files/edge/r_texgl.cc
@@ -153,7 +153,7 @@ GLuint R_UploadTexture(epi::image_data_c *img, int flags, int max_pix)
 					smooth ? GL_LINEAR : GL_NEAREST);
 
 	// minification mode
-	int mip_level = CLAMP(0, var_mipmapping, 2);
+	int mip_level = CLAMP(0, detail_level, 2);
 
 	// special logic for mid-masked textures.  The UPL_Thresh flag
 	// guarantees that each texture level has simple alpha (0 or 255),
@@ -193,7 +193,7 @@ GLuint R_UploadTexture(epi::image_data_c *img, int flags, int max_pix)
 					 GL_UNSIGNED_BYTE, img->PixelAt(0,0));
 
 		// stop if mipmapping disabled or we have reached the end
-		if (nomip || !var_mipmapping || (new_w == 1 && new_h == 1))
+		if (nomip || !detail_level || (new_w == 1 && new_h == 1))
 			break;
 
 		new_w = MAX(1, new_w / 2);

--- a/source_files/edge/r_things.cc
+++ b/source_files/edge/r_things.cc
@@ -361,7 +361,7 @@ static void RGL_DrawPSprite(pspdef_t * psp, int which,
 
 	RGL_StartUnits(false);
 
-	int num_pass = is_fuzzy ? 1 : (4 + detail_level * 2);
+	int num_pass = is_fuzzy ? 1 : 3 + detail_level;
 
 	for (int pass = 0; pass < num_pass; pass++)
 	{
@@ -1471,7 +1471,7 @@ void RGL_DrawThing(drawfloor_t *dfloor, drawthing_t *dthing)
 
 	/* draw the sprite */
 
-	int num_pass = is_fuzzy ? 1 : (3 + detail_level * 2);
+	int num_pass = is_fuzzy ? 1 : 3 + detail_level;
 
 	rgbcol_t fc_to_use = dthing->mo->subsector->sector->props.fog_color;
 	float fd_to_use = dthing->mo->subsector->sector->props.fog_density;

--- a/source_files/edge/r_things.cc
+++ b/source_files/edge/r_things.cc
@@ -361,7 +361,7 @@ static void RGL_DrawPSprite(pspdef_t * psp, int which,
 
 	RGL_StartUnits(false);
 
-	int num_pass = is_fuzzy ? 1 : 3 + detail_level;
+	int num_pass = is_fuzzy  ? 1 : (detail_level > 0 ? 4 : 3);
 
 	for (int pass = 0; pass < num_pass; pass++)
 	{
@@ -1471,7 +1471,7 @@ void RGL_DrawThing(drawfloor_t *dfloor, drawthing_t *dthing)
 
 	/* draw the sprite */
 
-	int num_pass = is_fuzzy ? 1 : 3 + detail_level;
+	int num_pass = is_fuzzy  ? 1 : (detail_level > 0 ? 4 : 3);
 
 	rgbcol_t fc_to_use = dthing->mo->subsector->sector->props.fog_color;
 	float fd_to_use = dthing->mo->subsector->sector->props.fog_density;

--- a/source_files/edge/r_voxel.cc
+++ b/source_files/edge/r_voxel.cc
@@ -595,9 +595,7 @@ void VXL_RenderModel(vxl_model_c *md, bool is_weapon,
 
 	/* draw the model */
 
-	int num_pass = data.is_fuzzy  ? 1 :
-		           data.is_weapon ? (3 + detail_level) :
-					                (2 + detail_level*2);
+	int num_pass = data.is_fuzzy  ? 1 : 3 + detail_level;
 
 	rgbcol_t fc_to_use = mo->subsector->sector->props.fog_color;
 	float fd_to_use = mo->subsector->sector->props.fog_density;
@@ -700,7 +698,6 @@ void VXL_RenderModel(vxl_model_c *md, bool is_weapon,
 			if (MDL_MulticolMaxRGB(&data, true) <= 0)
 				continue;
 		}
-		GLuint model_env = data.is_additive ? ENV_SKIP_RGB : GL_MODULATE;
 
 		glPolygonOffset(0, -pass);
 
@@ -763,7 +760,18 @@ void VXL_RenderModel(vxl_model_c *md, bool is_weapon,
 		glEnable(GL_TEXTURE_2D);
 		glBindTexture(GL_TEXTURE_2D, skin_tex);
 
-		glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, model_env);
+		if (data.is_additive)
+		{
+			glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_COMBINE);
+			glTexEnvi(GL_TEXTURE_ENV, GL_COMBINE_RGB, GL_REPLACE);
+			glTexEnvi(GL_TEXTURE_ENV, GL_SOURCE0_RGB, GL_PREVIOUS);
+		}
+		else
+		{
+			glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);
+			glTexEnvi(GL_TEXTURE_ENV, GL_COMBINE_RGB, GL_MODULATE);
+			glTexEnvi(GL_TEXTURE_ENV, GL_SOURCE0_RGB, GL_TEXTURE);
+		}
 
 		GLint old_clamp = 789;
 

--- a/source_files/edge/r_voxel.cc
+++ b/source_files/edge/r_voxel.cc
@@ -595,7 +595,7 @@ void VXL_RenderModel(vxl_model_c *md, bool is_weapon,
 
 	/* draw the model */
 
-	int num_pass = data.is_fuzzy  ? 1 : 3 + detail_level;
+	int num_pass = data.is_fuzzy  ? 1 : (detail_level > 0 ? 4 : 3);
 
 	rgbcol_t fc_to_use = mo->subsector->sector->props.fog_color;
 	float fd_to_use = mo->subsector->sector->props.fog_density;


### PR DESCRIPTION
Tried to make Detail Level behavior more consistent and meaningful:
1 - More sensible max texture sizes and unlinked max size from texture being mipmappable
2 - Tied previously independent mipmap setting to Detail Level
3 - Made number of extra modulate passes provided by Detail Level consistent regardless of unit source
4 - Enabled dlights to work at "Low" Detail Level using minimum number of passes
5 - Moved Detail Level option to Performance Options menu to reflect that it is more of a thing to manipulate if one is resource-constrained as opposed to pure aesthetics like Smoothing/Upscaling

Unrelated:
Renamed "HQ2x" setting to "Upscale Textures" per earlier conversations and added help text