### PR TITLE
COAL: player.play_footstep() now returns 0 if unsuccessful

### DIFF
--- a/edge_defs/scripts/coal_api.ec
+++ b/edge_defs/scripts/coal_api.ec
@@ -389,7 +389,7 @@ module player
 	function sector_tag()      : float = native
 	function use_inventory(type)    : float = native
 	
-	function play_footstep(flat : string) = native
+	function play_footstep(flat : string) : float = native
 	function inventory(type)    : float = native
 	function inventorymax(type) : float = native
 	function rts_enable_tagged(name : string) = native

--- a/source_files/edge/vm_player.cc
+++ b/source_files/edge/vm_player.cc
@@ -1062,14 +1062,22 @@ static void PL_play_footstep(coal::vm_c *vm, int argc)
 	flatdef_c *current_flatdef = flatdefs.Find(flat);
 
 	if (!current_flatdef)
+	{
+		vm->ReturnFloat(0);
 		return;
+	}
+		
 	
 	if (!current_flatdef->footstep)
+	{
+		vm->ReturnFloat(0);
 		return;
+	}
 	else
 	{
 		// Probably need to add check to see if the sfx is valid - Dasho
 		S_StartFX(current_flatdef->footstep);
+		vm->ReturnFloat(1);
 	}
 }
 


### PR DESCRIPTION
This allows us to play a generic sound if no corresponding flats.ddf entry exists