### PR TITLE
Unconditionally enable MBF21 lines/sectors

### DIFF
--- a/source_files/edge/dm_data.h
+++ b/source_files/edge/dm_data.h
@@ -116,6 +116,10 @@ typedef enum
 	//       be pushed simultaneously.
 	MLF_PassThru = 0x0200,
 
+	// Clear extended line flags (BOOM or later spec); needed to repair mapping/editor errors
+	// with historical maps (i.e., E2M7)
+	MLF_ClearBoom = 0x0800,
+
 	// MBF21
 	MLF_BlockGrounded = 0x1000,
 	MLF_BlockPlayers = 0x2000,

--- a/source_files/edge/m_option.cc
+++ b/source_files/edge/m_option.cc
@@ -128,7 +128,6 @@ extern cvar_c s_soundfont;
 extern cvar_c r_overlay;
 extern cvar_c g_erraticism;
 extern cvar_c r_doubleframes;
-extern cvar_c g_mbf21compat;
 extern cvar_c r_culling;
 extern cvar_c r_culldist;
 extern cvar_c r_cullfog;
@@ -547,9 +546,6 @@ static menuinfo_t f4sound_optmenu =
 //
 static optmenuitem_t playoptions[] =
 {
-	{OPT_Boolean, "MBF21 Map Compatibility", YesNo, 2, 
-     &g_mbf21compat.d, M_UpdateCVARFromInt, "Toggle support for MBF21 lines and sectors", &g_mbf21compat},
-
 	{OPT_Boolean, "Pistol Starts",         YesNo, 2, 
      &pistol_starts, NULL, NULL},
 

--- a/source_files/edge/p_inter.cc
+++ b/source_files/edge/p_inter.cc
@@ -47,7 +47,6 @@
 
 bool var_obituaries = true;
 
-extern cvar_c g_mbf21compat;
 extern cvar_c g_gore;
 extern cvar_c player_dm_dr;
 
@@ -1320,19 +1319,20 @@ void P_DamageMobj(mobj_t * target, mobj_t * inflictor, mobj_t * source,
 	{
 		int i;
 
-		// MBF21 - Don't damage player if sector type should only affect grounded monsters
-		if (damtype && damtype->grounded_monsters && g_mbf21compat.d)
+		// Don't damage player if sector type should only affect grounded monsters
+		if (damtype && damtype->grounded_monsters)
 			return;
 
 		// ignore damage in GOD mode, or with INVUL powerup
 		if ((player->cheats & CF_GODMODE) || player->powers[PW_Invulnerable] > 0)
 		{
-			if (! (damtype && damtype->bypass_all && g_mbf21compat.d))
+			if (! (damtype && damtype->bypass_all))
 				return;
 		}
 
-		// MBF21 - Only damage if not wearing a radsuit (also if not invul, but the above check should theoretically cover that already)
-		if (damtype && damtype->if_naked && (!g_mbf21compat.d || player->powers[PW_AcidSuit] > 0))
+		// Only damage if "if_naked" type and not wearing a radsuit (also if not invul, but the above check should theoretically cover that already)
+		// Dasho: I plane on making this a bit more robust, but this should suffice for at least MBF21 for now
+		if (damtype && damtype->if_naked && player->powers[PW_AcidSuit] > 0)
 			return;
 
 		// take half damage in trainer mode
@@ -1442,14 +1442,9 @@ void P_DamageMobj(mobj_t * target, mobj_t * inflictor, mobj_t * source,
 
 		player->attacker = source;
 
-		// MBF21 instakill sectors
+		// instakill sectors
 		if (damtype && damtype->instakill)
-		{
-			if (g_mbf21compat.d)
-				damage = target->player->health + 1;
-			else
-				return;
-		}
+			damage = target->player->health + 1;
 
 		// add damage after armour / invuln detection
 		if (damage > 0)
@@ -1464,14 +1459,9 @@ void P_DamageMobj(mobj_t * target, mobj_t * inflictor, mobj_t * source,
 	}
 	else
 	{
-		// MBF21 instakill sectors
+		// instakill sectors
 		if (damtype && damtype->instakill)
-		{
-			if (g_mbf21compat.d)
-				damage = target->health + 1;
-			else
-				return;
-		}
+			damage = target->health + 1;
 	}
 
 	// do the damage

--- a/source_files/edge/p_map.cc
+++ b/source_files/edge/p_map.cc
@@ -64,10 +64,7 @@ static void gore_cb(cvar_c *self)
 	level_flags.more_blood = global_flags.more_blood = self->d;
 }
 
-DEF_CVAR(g_mbf21compat, "0", CVAR_ARCHIVE)
 DEF_CVAR_CB(g_gore, "1", CVAR_ARCHIVE, gore_cb)
-
-extern cvar_c g_mbf21compat;
 
 // Forward declaration for ShootCheckGap
 static bool PTR_ShootTraverse(intercept_t * in, void *dataptr);
@@ -285,15 +282,15 @@ static bool PIT_CheckAbsLine(line_t * ld, void *data)
 		if (ld->flags & MLF_Blocking)
 			return false;
 
-		// MBF21: block players ?
-		if (tm_I.mover->player && g_mbf21compat.d && ((ld->flags & MLF_BlockPlayers) ||
+		// block players ?
+		if (tm_I.mover->player && ((ld->flags & MLF_BlockPlayers) ||
 			(ld->special && (ld->special->line_effect & LINEFX_BlockPlayers))))
 		{
 			return false;
 		}
 
-		// MBF21: block grounded monsters ?
-		if ((tm_I.extflags & EF_MONSTER) && g_mbf21compat.d &&
+		// block grounded monsters ?
+		if ((tm_I.extflags & EF_MONSTER) &&
 			((ld->flags & MLF_BlockGrounded) || (ld->special && (ld->special->line_effect & LINEFX_BlockGroundedMonsters))) 
 			&& (tm_I.mover->z <= tm_I.mover->floorz + 1.0f))
 		{
@@ -492,8 +489,8 @@ static bool PIT_CheckRelLine(line_t * ld, void *data)
 		if ((ld->flags & MLF_Blocking) ||
 			((ld->flags & MLF_BlockMonsters) &&
 			(tm_I.extflags & EF_MONSTER)) ||
-			(g_mbf21compat.d && (ld->flags & MLF_BlockGrounded) && (tm_I.extflags & EF_MONSTER) && (tm_I.mover->z <= tm_I.mover->floorz + 1.0f)) ||
-			(g_mbf21compat.d && (ld->flags & MLF_BlockPlayers) && (tm_I.mover->player)))
+			(((ld->special && (ld->special->line_effect & LINEFX_BlockGroundedMonsters)) || (ld->flags & MLF_BlockGrounded)) && (tm_I.extflags & EF_MONSTER) && (tm_I.mover->z <= tm_I.mover->floorz + 1.0f)) ||
+			(((ld->special && (ld->special->line_effect & LINEFX_BlockPlayers)) || (ld->flags & MLF_BlockPlayers)) && (tm_I.mover->player)))
 		{
 			blockline = ld;
 			return false;

--- a/source_files/edge/p_mobj.cc
+++ b/source_files/edge/p_mobj.cc
@@ -76,7 +76,6 @@
 #define DEBUG_MOBJ  0
 
 extern cvar_c r_doubleframes;
-extern cvar_c g_mbf21compat;
 
 DEF_CVAR(g_cullthinkers, "0", CVAR_ARCHIVE)
 
@@ -1434,8 +1433,8 @@ static void P_MobjThinker(mobj_t * mobj, bool extra_tic)
 			}
 		}
 
-		// MBF21 - Only damage grounded monsters (not players)
-		if (props->special && props->special->damage.grounded_monsters && g_mbf21compat.d && mobj->z <= mobj->floorz + 1.0f)
+		// Only damage grounded monsters (not players)
+		if (props->special && props->special->damage.grounded_monsters && mobj->z <= mobj->floorz + 1.0f)
 		{
 			P_DamageMobj(mobj, NULL, NULL, 5.0, &props->special->damage, false);
 		}

--- a/source_files/edge/p_setup.cc
+++ b/source_files/edge/p_setup.cc
@@ -880,6 +880,11 @@ static void LoadLineDefs(int lump)
 		ld->v1 = &vertexes[EPI_LE_U16(mld->start)];
 		ld->v2 = &vertexes[EPI_LE_U16(mld->end)];
 
+		// Check for BoomClear flag bit and clear applicable specials
+		// (PassThru may still be intentionally readded further down)
+		if (ld->flags & MLF_ClearBoom)
+			ld->flags &= ~(MLF_PassThru | MLF_BlockGrounded | MLF_BlockPlayers);
+
 		ld->special = P_LookupLineType(MAX(0, EPI_LE_S16(mld->special)));
 
 		if (ld->special && ld->special->type == line_walkable)

--- a/source_files/edge/p_spec.cc
+++ b/source_files/edge/p_spec.cc
@@ -55,7 +55,6 @@
 #define BOOM_CARRY_FACTOR 0.09375f
 
 extern cvar_c r_doubleframes;
-extern cvar_c g_mbf21compat;
 
 // Level exit timer
 bool levelTimer;
@@ -1882,7 +1881,7 @@ static inline void PlayerInProperties(player_t *player,
 			return;
 	}
 
-	if (player->powers[PW_AcidSuit] && (!g_mbf21compat.d || !special->damage.bypass_all))
+	if (player->powers[PW_AcidSuit] && !special->damage.bypass_all)
 		factor = 0;
 
 	if (r_doubleframes.d && extra_tic)


### PR DESCRIPTION
Remove toggle; added linedef bit 11 flag from Eternity for solving issues with older maps. Will wadfix/otherwise address other map issues if/when encountered.