### PR TITLE
Added CHANGE_SECTOR_TYPE RTS command

### DIFF
--- a/source_files/edge/rad_act.cc
+++ b/source_files/edge/rad_act.cc
@@ -913,25 +913,46 @@ void RAD_ActChangeSectorType(rad_trigger_t *R, void *param)
 
 		P_SectorChangeSpecial(sectors + i, t->typenum);
 
-		// Copies colourmap to the sector IF the new sector type uses a special colourmap
-		if (sectors[i].props.special && sectors[i].props.special->use_colourmap)
-			sectors[i].props.colourmap = sectors[i].props.special->use_colourmap;
-
-		// Copies fog to the sector IF the new sector type is foggy
-		if (sectors[i].props.special && sectors[i].props.special->fog_color != RGB_NO_VALUE)
+		if (sectors[i].props.special)
 		{
-			sectors[i].props.fog_color = sectors[i].props.special->fog_color;
-			sectors[i].props.fog_density = 0.01f * sectors[i].props.special->fog_density;
+			// Copies colourmap to the sector IF the new sector type uses a special colourmap
+			if (sectors[i].props.special->use_colourmap)
+				sectors[i].props.colourmap = sectors[i].props.special->use_colourmap;
 
-			// Invalidate "faux walls" that reflect the fog color and density of the adjacent sector. Copied from RAD_ActFogSector.
-			for (int j = 0; j < sectors[i].linecount; j++)
+			// Copies fog to the sector IF the new sector type is foggy
+			if (sectors[i].props.special->fog_color != RGB_NO_VALUE)
 			{
-				for (int k = 0; k < 2; k++)
+				sectors[i].props.fog_color = sectors[i].props.special->fog_color;
+				sectors[i].props.fog_density = 0.01f * sectors[i].props.special->fog_density;
+
+				// Invalidate "faux walls" that reflect the fog color and density of the adjacent sector. Copied from RAD_ActFogSector.
+				for (int j = 0; j < sectors[i].linecount; j++)
 				{
-					side_t *side_check = sectors[i].lines[j]->side[k];
-					if (side_check && side_check->middle.fogwall)
-						side_check->middle.image = nullptr;
+					for (int k = 0; k < 2; k++)
+					{
+						side_t *side_check = sectors[i].lines[j]->side[k];
+						if (side_check && side_check->middle.fogwall)
+							side_check->middle.image = nullptr;
+					}
 				}
+			}
+
+			if (sectors[i].props.special->drag != 0)
+				sectors[i].props.drag = sectors[i].props.special->drag;
+
+			if (sectors[i].props.special->friction != 0)
+				sectors[i].props.friction = sectors[i].props.special->friction;
+
+			if (sectors[i].props.special->gravity != GRAVITY)
+				sectors[i].props.gravity = sectors[i].props.special->gravity;
+
+			if (sectors[i].props.special->push_speed > 0 || sectors[i].props.special->push_zspeed > 0)
+			{
+				float mul = sectors[i].props.special->push_speed / 100.0f;
+
+				sectors[i].props.push.x += M_Cos(sectors[i].props.special->push_angle) * mul;
+				sectors[i].props.push.y += M_Sin(sectors[i].props.special->push_angle) * mul;
+				sectors[i].props.push.z += sectors[i].props.special->push_zspeed / 100.0f;
 			}
 		}
 	}

--- a/source_files/edge/rad_act.cc
+++ b/source_files/edge/rad_act.cc
@@ -903,6 +903,30 @@ void RAD_ActLightSector(rad_trigger_t *R, void *param)
 	}
 }
 
+void RAD_ActChangeSectorType(rad_trigger_t *R, void *param)
+{
+	s_sectortypechanger_t *t = (s_sectortypechanger_t *) param;
+	int i;
+
+	for (i=0; i < numsectors; i++)
+	{
+		if (sectors[i].tag != t->tag) continue;
+
+		P_SectorChangeSpecial(sectors + i, t->typenum);
+
+		if (sectors[i].props.special && sectors[i].props.special->fog_color != RGB_NO_VALUE)
+		{
+			sectors[i].props.fog_color = sectors[i].props.special->fog_color;
+			sectors[i].props.fog_density = 0.01f * sectors[i].props.special->fog_density;
+		}
+
+		if (sectors[i].props.special && sectors[i].props.special->use_colourmap)
+		{
+			sectors[i].props.colourmap = sectors[i].props.special->use_colourmap;
+		}
+	}
+}
+
 void RAD_ActFogSector(rad_trigger_t *R, void *param)
 {
 	s_fogsector_t *t = (s_fogsector_t *) param;

--- a/source_files/edge/rad_act.h
+++ b/source_files/edge/rad_act.h
@@ -42,6 +42,7 @@ void RAD_ActBlockLines(rad_trigger_t *R, void *param);
 void RAD_ActJump(rad_trigger_t *R, void *param);
 void RAD_ActSleep(rad_trigger_t *R, void *param);
 void RAD_ActRetrigger(rad_trigger_t *R, void *param);
+void RAD_ActChangeSectorType(rad_trigger_t *R, void *param);
 
 void RAD_ActDamagePlayers(rad_trigger_t *R, void *param);
 void RAD_ActHealPlayers(rad_trigger_t *R, void *param);

--- a/source_files/edge/rad_defs.h
+++ b/source_files/edge/rad_defs.h
@@ -323,6 +323,16 @@ typedef struct s_lineactivator_s
 }
 s_lineactivator_t;
 
+// ChangeSectorType
+typedef struct s_sectortypechanger_s
+{
+	// sector type
+	int typenum = 0;
+
+	// sector tag
+	int tag = 0;
+}
+s_sectortypechanger_t;
 
 // UnblockLines
 typedef struct s_lineunblocker_s

--- a/source_files/edge/rad_pars.cc
+++ b/source_files/edge/rad_pars.cc
@@ -1879,6 +1879,23 @@ static void RAD_ParseLightSector(param_set_t& pars)
 	AddStateToScript(this_rad, 0, RAD_ActLightSector, secl);
 }
 
+static void RAD_ParseChangeSectorType(param_set_t& pars)
+{
+	// ChangeSectorType <tag> <newType>
+
+	s_sectortypechanger_s *sect;
+
+	sect = new s_sectortypechanger_s;
+
+	RAD_CheckForInt(pars[1], &sect->tag);
+	RAD_CheckForInt(pars[2], &sect->typenum);
+
+	if (sect->tag == 0)
+		RAD_Error("%s: Invalid tag number: %d\n", pars[0], sect->tag);
+
+	AddStateToScript(this_rad, 0, RAD_ActChangeSectorType, sect);
+}
+
 static void RAD_ParseFogSector(param_set_t& pars)
 {
 	// FogSector <tag> <color or SAME or CLEAR> <density(%) or SAME or CLEAR>
@@ -2315,6 +2332,7 @@ static const rts_parser_t radtrig_parsers[] =
 	{2, "REPLACE_WEAPON", 3,3, RAD_ParseReplaceWeapon},
 	{2, "WEAPON_EVENT", 3,3, RAD_ParseWeaponEvent},
 	{2, "REPLACE_THING", 3,3, RAD_ParseReplaceThing},
+	{2, "CHANGE_SECTOR_TYPE", 3,3, RAD_ParseChangeSectorType},
 
 	// old crud
 	{2, "SECTORV", 4,4, RAD_ParseMoveSector},


### PR DESCRIPTION
Added a RTS command (syntax is CHANGE_SECTOR_TYPE TAG NEWTYPE). It will change a sector special type on the fly. Useful to make a sector airless or damaging, change colormap, etc.

If the new sector type (as defined in SECTORS.DDF) has a colormap or fog specified, they will be used and override the current sector's. Otherwise, current colormap and fog settings are kept.