### PR TITLE
Added NO_SKILL_MENU boolean option to Games.ddf

### DIFF
--- a/source_files/ddf/game.cc
+++ b/source_files/ddf/game.cc
@@ -60,6 +60,7 @@ static const commandlist_t gamedef_commands[] =
 	DF("SPECIAL_MUSIC", special_music, DDF_MainGetNumeric),
 	DF("LIGHTING", lighting, DDF_GameGetLighting),
 	DF("DESCRIPTION", description, DDF_MainGetString),
+	DF("NO_SKILL_MENU", no_skill_menu, DDF_MainGetBoolean),
 
 	DDF_CMD_END
 };
@@ -783,6 +784,7 @@ void gamedef_c::Default()
 
 	bg_camera.clear();
 	music = 0;
+	no_skill_menu = false;
 
 	percent = sfx_None;
 	done = sfx_None;

--- a/source_files/ddf/game.cc
+++ b/source_files/ddf/game.cc
@@ -755,6 +755,7 @@ void gamedef_c::CopyDetail(gamedef_c &src)
 	nextmap = src.nextmap;
 	accel_snd = src.accel_snd;
 	frag_snd = src.frag_snd;
+	no_skill_menu = src.no_skill_menu;
 
 	firstmap = src.firstmap;
 	namegraphic = src.namegraphic;

--- a/source_files/ddf/game.h
+++ b/source_files/ddf/game.h
@@ -192,6 +192,7 @@ public:
 	std::string bg_camera;
 
 	int music;
+	bool no_skill_menu;
 	struct sfx_s *percent;
 	struct sfx_s *done;
 	struct sfx_s *endmap;

--- a/source_files/edge/m_menu.cc
+++ b/source_files/edge/m_menu.cc
@@ -362,6 +362,7 @@ static menu_t MainDef =
 // -KM- 1998/12/16 This is generated dynamically.
 //
 static menuitem_t *EpisodeMenu = NULL;
+static bool *EpisodeMenuSkipSkill = NULL;
 
 static menuitem_t DefaultEpiMenu =
 {
@@ -1322,6 +1323,7 @@ static void CreateEpisodeMenu(void)
 		I_Error("No defined episodes !\n");
 
 	EpisodeMenu = new menuitem_t[gamedefs.GetSize()];
+	EpisodeMenuSkipSkill = new bool[gamedefs.GetSize()];
 
 	int e = 0;
 	epi::array_iterator_c it;
@@ -1341,6 +1343,7 @@ static void CreateEpisodeMenu(void)
 		EpisodeMenu[e].select_func = M_Episode;
 		EpisodeMenu[e].image = NULL;
 		EpisodeMenu[e].alpha_key = '1' + e;
+		EpisodeMenuSkipSkill[e] = g->no_skill_menu;
 
 		Z_StrNCpy(EpisodeMenu[e].patch_name, g->namegraphic.c_str(), 8);
 		EpisodeMenu[e].patch_name[8] = 0;
@@ -1547,7 +1550,10 @@ void M_ChooseSkill(int choice)
 void M_Episode(int choice)
 {
 	chosen_epi = choice;
-	M_SetupNextMenu(&SkillDef);
+	if (EpisodeMenuSkipSkill[chosen_epi])
+		DoStartLevel((skill_t)2);
+	else
+		M_SetupNextMenu(&SkillDef);
 }
 
 //


### PR DESCRIPTION
Added an optional boolean option NO_SKILL_MENU to Games.ddf. When set to TRUE, skill menu is skipped after episode selection (or after "new game" is selected if there's only one episode) and game starts immediately with skill set to 2 ("Hurt me plenty"). Useful for creating Quake-like skill selection levels using RTS, or when you just don't want to have skill levels in your game.