### PR TITLE
Added "EXACT_" optional prefix to RTS's ON_CONDITION flag

### DIFF
--- a/source_files/ddf/thing.cc
+++ b/source_files/ddf/thing.cc
@@ -2164,6 +2164,7 @@ bool DDF_MainParseCondition(const char *info, condition_check_t *cond)
 	const char *pos;
 
 	cond->negate = false;
+	cond->exact = false;
 	cond->cond_type = COND_NONE;
 	cond->amount = 1;
 
@@ -2198,6 +2199,12 @@ bool DDF_MainParseCondition(const char *info, condition_check_t *cond)
 	{
 		cond->negate = true;
 		t_off = 4;
+	}
+
+	if (epi::prefix_case_cmp(typebuf, "EXACT_") == 0)
+	{
+		cond->exact = true;
+		t_off = 6;
 	}
 
 	if (ConditionTryAmmo(typebuf + t_off, sub_buf, cond) ||

--- a/source_files/ddf/thing.h
+++ b/source_files/ddf/thing.h
@@ -644,6 +644,9 @@ typedef struct condition_check_s
 	// negate the condition
 	bool negate = false;
 
+	// condition is looking for an exact value (not "greater than" or "smaller than")
+	bool exact = false;
+
 	// condition typing. -ACB- 2003/05/15: Made an integer to hold condition_check_type_e enumeration
 	int cond_type = 0;
 

--- a/source_files/edge/e_player.cc
+++ b/source_files/edge/e_player.cc
@@ -599,6 +599,9 @@ bool G_CheckConditions(mobj_t *mo, condition_check_t *cond)
 		switch (cond->cond_type)
 		{
 			case COND_Health:
+				if (cond->exact)
+					return (mo->health == cond->amount);
+				
 				temp = (mo->health >= cond->amount);
 
 				if ((!cond->negate && !temp) || (cond->negate && temp))
@@ -609,6 +612,14 @@ bool G_CheckConditions(mobj_t *mo, condition_check_t *cond)
 			case COND_Armour:
 				if (!p)
 					return false;
+
+				if (cond->exact)
+				{
+					if (cond->sub.type == ARMOUR_Total)
+						return (p->totalarmour == i_amount);
+					else
+						return (p->armours[cond->sub.type] == i_amount);
+				}
 
 				if (cond->sub.type == ARMOUR_Total)
 					temp = (p->totalarmour >= i_amount);
@@ -656,6 +667,9 @@ bool G_CheckConditions(mobj_t *mo, condition_check_t *cond)
 				if (!p)
 					return false;
 
+				if (cond->exact)
+					return (p->powers[cond->sub.type] == cond->amount);
+
 				temp = (p->powers[cond->sub.type] > cond->amount);
 
 				if ((!cond->negate && !temp) || (cond->negate && temp))
@@ -666,6 +680,9 @@ bool G_CheckConditions(mobj_t *mo, condition_check_t *cond)
 			case COND_Ammo:
 				if (!p)
 					return false;
+
+				if (cond->exact)
+					return (p->ammo[cond->sub.type].num == i_amount);
 
 				temp = (p->ammo[cond->sub.type].num >= i_amount);
 
@@ -678,6 +695,9 @@ bool G_CheckConditions(mobj_t *mo, condition_check_t *cond)
 				if (!p)
 					return false;
 
+				if (cond->exact)
+					return (p->inventory[cond->sub.type].num == i_amount);
+
 				temp = (p->inventory[cond->sub.type].num >= i_amount);
 
 				if ((!cond->negate && !temp) || (cond->negate && temp))
@@ -688,6 +708,9 @@ bool G_CheckConditions(mobj_t *mo, condition_check_t *cond)
 			case COND_Counter:
 				if (!p)
 					return false;
+
+				if (cond->exact)
+					return (p->counters[cond->sub.type].num == i_amount);
 
 				temp = (p->counters[cond->sub.type].num >= i_amount);
 


### PR DESCRIPTION
Added "EXACT_" optional prefix to RTS's ON_CONDITION flag.
Returns true only when value exactly matches the value in brackets (unlike the default "greater or equal").

Should be mostly useful with counters, but can also be used to trigger something when player has exactly 4 shells/30 health/50 armor/etc left.

Works with all numerable conditions: health, armour, ammo, power (seconds left), inventory and counter.

Examples:
ON_CONDITION EXACT_AMMO2(4)
ON_CONDITION EXACT_HEALTH(25)
