### PR TITLE
THINGS.DDF: SET_PAINCHANCE() action and IMMOVABLE flag

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -45,6 +45,14 @@ New Features
 - RSCRIPT: "EXACT_" prefix added for ON_CONDITION checks (Courtesy of akaAgar - https://github.com/edge-classic/EDGE-classic/pull/578)
   - Allows check for the exact value of a benefit/etc, versus the default of greater-than-or-equal
 
+- THINGS.DDF: 
+  - New Action command: SET_PAINCHANCE(percentage) which will dynamically change a monsters painchance.
+    Possible usage: if we do SET_PAINCHANCE(0%) at the start of a lengthy PAIN state, this will make sure the 
+	whole animation is played out and won't be interrupted by another shot which would normally make us 
+	re-start the pain animation again. Remember to set it back to normal at the end of the lengthy animation.
+  - New Special flag: IMMOVABLE which will make this thing be unaffected by thrust from attack impacts 
+    irrespective of whether it has a small MASS or a very large one.
+
 
 General Improvements/Changes
 --------------------
@@ -83,3 +91,4 @@ Bugs fixed
 - Fixed MODEL_ROTATE not being applied to attacks
 - Fixed savegames not preserving the 'is_voodoo' convenience boolean for mobjs, causing issues when loading a game that had them present
 - Fixed berserk and other powerup effects not modifying model colors accordingly (bug introduced by transition to VBOs for model rendering)
+

--- a/source_files/ddf/thing.cc
+++ b/source_files/ddf/thing.cc
@@ -318,6 +318,7 @@ const actioncode_t thing_actions[] =
 	{"PATH_FOLLOW",       P_ActPathFollow, NULL},
 	{"SET_INVULNERABLE",  P_ActSetInvuln,   NULL},
 	{"CLEAR_INVULNERABLE",P_ActClearInvuln, NULL},
+	{"SET_PAINCHANCE",    P_ActPainChanceSet, DDF_StateGetPercent},
 
 	{"DROPITEM",          P_ActDropItem, DDF_StateGetMobj},
 	{"SPAWN",             P_ActSpawn,    DDF_StateGetMobj},
@@ -1738,6 +1739,7 @@ static specflags_t hyper_specials[] =
 	{"SHOVEABLE", HF_SHOVEABLE, 0}, //Lobo: can be pushed
 	{"SPLASH", HF_NOSPLASH, 1}, //Lobo: causes no splash on liquids
 	{"DEHACKED_COMPAT", HF_DEHACKED_COMPAT, 0},
+	{"IMMOVABLE", HF_IMMOVABLE, 0},
 	{NULL, 0, 0}
 };
 

--- a/source_files/ddf/thing.h
+++ b/source_files/ddf/thing.h
@@ -313,6 +313,10 @@ typedef enum
 
 	// -AJA- 2022/10/04: used by DEH_EDGE to workaround issues
 	HF_DEHACKED_COMPAT = (1 << 21),
+
+	// -Lobo- 2023/10/19: this thing will not be affected by thrust forces
+	HF_IMMOVABLE = (1 << 22),
+	
 }
 mobjhyperflag_t;
 

--- a/source_files/edge/p_action.cc
+++ b/source_files/edge/p_action.cc
@@ -3876,6 +3876,8 @@ void P_ActBecome(struct mobj_s *mo)
 		mo->model_skin    = mo->info->model_skin;
 		mo->model_last_frame = -1;
 
+		mo->painchance    = PERCENT_2_FLOAT(mo->info->painchance);
+
 		// handle dynamic lights
 		{
 			const dlight_info_c *dinfo = &mo->info->dlight[0];
@@ -3951,6 +3953,8 @@ void P_ActUnBecome(struct mobj_s *mo)
 		mo->currentattack = NULL;
 		mo->model_skin    = mo->info->model_skin;
 		mo->model_last_frame = -1;
+
+		mo->painchance    = PERCENT_2_FLOAT(mo->info->painchance);
 
 		// handle dynamic lights
 		{
@@ -4032,6 +4036,8 @@ void P_ActMorph(struct mobj_s *mo)
 		mo->model_skin    = mo->info->model_skin;
 		mo->model_last_frame = -1;
 
+		mo->painchance    = PERCENT_2_FLOAT(mo->info->painchance);
+
 		// handle dynamic lights
 		{
 			const dlight_info_c *dinfo = &mo->info->dlight[0];
@@ -4110,6 +4116,8 @@ void P_ActUnMorph(struct mobj_s *mo)
 		mo->currentattack = NULL;
 		mo->model_skin    = mo->info->model_skin;
 		mo->model_last_frame = -1;
+
+		mo->painchance    = PERCENT_2_FLOAT(mo->info->painchance);
 
 		// handle dynamic lights
 		{
@@ -4277,6 +4285,21 @@ void P_ActMushroom(struct mobj_s *mo)
 				continue;
 		}
 	}
+}
+
+void P_ActPainChanceSet(mobj_t * mo)
+{
+	float value = 0;
+
+	const state_t *st = mo->state;
+
+	if (st && st->action_par)
+	{
+		value = ((percent_t *)st->action_par)[0];
+		value = MAX(0.0f, MIN(1.0f, value));
+	}
+	mo->painchance = value;
+
 }
 
 

--- a/source_files/edge/p_action.h
+++ b/source_files/edge/p_action.h
@@ -193,6 +193,8 @@ void P_ActUnMorph(struct mobj_s *mo);
 void P_ActSetInvuln(struct mobj_s *mo);
 void P_ActClearInvuln(struct mobj_s *mo);
 
+void P_ActPainChanceSet(struct mobj_s *mo);
+
 // Movement actions
 void P_ActFaceDir(struct mobj_s *mo);
 void P_ActTurnDir(struct mobj_s *mo);

--- a/source_files/edge/p_inter.cc
+++ b/source_files/edge/p_inter.cc
@@ -1221,6 +1221,10 @@ void P_ThrustMobj(mobj_t * target, mobj_t * inflictor, float thrust)
 	if (target->hyperflags & HF_INVULNERABLE)
 		return;
 
+	//check for lead feet ;)
+	if (target->hyperflags & HF_IMMOVABLE)
+		return;
+
 	if (inflictor && inflictor->currentattack && BITSET_EMPTY ==
 		(inflictor->currentattack->attack_class & ~target->info->immunity))
 	{
@@ -1629,7 +1633,8 @@ if(inflictor && inflictor->currentattack &&
 			 (inflictor->currentattack->attack_class & ~target->info->resistance))
 		pain_chance = target->info->resist_painchance;
 	else
-		pain_chance = target->info->painchance;
+		pain_chance = target->painchance; //Lobo 2023: use dynamic painchance
+		//pain_chance = target->info->painchance;
 
 	if (pain_chance > 0 && P_RandomTest(pain_chance))
 	{

--- a/source_files/edge/p_mobj.cc
+++ b/source_files/edge/p_mobj.cc
@@ -459,6 +459,8 @@ static void ResurrectRespawn(mobj_t * mobj)
 	mobj->visibility = PERCENT_2_FLOAT(info->translucency);
 	mobj->movecount = 0;  // -ACB- 1998/08/03 Don't head off in any direction
 
+	mobj->painchance = PERCENT_2_FLOAT(info->painchance);
+
 	mobj->SetSource(NULL);
 	mobj->SetTarget(NULL);
 
@@ -2222,6 +2224,8 @@ mobj_t *P_MobjCreateObject(float x, float y, float z, const mobjtype_c *info)
 	mobj->model_skin = info->model_skin;
 	mobj->model_last_frame = -1;
 	mobj->wud_tags.clear();
+
+	mobj->painchance = PERCENT_2_FLOAT(info->painchance);
 
 	mobj->morphtimeout = info->morphtimeout;
 

--- a/source_files/edge/p_mobj.h
+++ b/source_files/edge/p_mobj.h
@@ -285,6 +285,8 @@ struct mobj_s : public position_c
 	float visibility = 0;
 	float vis_target = 0;
 
+	float painchance = 0;
+
 	// current attack to be made
 	const atkdef_c *currentattack = nullptr;
 
@@ -375,6 +377,7 @@ struct mobj_s : public position_c
 	bool slopesighthit = false;
 
 	int teleport_tic = 0;
+
 
 public:
 	bool isRemoved() const;

--- a/source_files/edge/sv_mobj.cc
+++ b/source_files/edge/sv_mobj.cc
@@ -111,6 +111,7 @@ static savefield_t sv_fields_mobj[] =
 	SF(origheight, "origheight", 1, SVT_FLOAT, SR_GetFloat, SR_PutFloat),
 	SF(visibility, "visibility", 1, SVT_FLOAT, SR_GetFloat, SR_PutFloat),
 	SF(vis_target, "vis_target", 1, SVT_FLOAT, SR_GetFloat, SR_PutFloat),
+	SF(painchance, "painchance", 1, SVT_FLOAT, SR_GetFloat, SR_PutFloat),
 	SF(vertangle, "vertangle", 1, SVT_FLOAT, SR_GetAngleFromSlope, SR_PutAngleToSlope),
 	SF(spreadcount, "spreadcount", 1, SVT_INT, SR_GetInt, SR_PutInt),
 	SF(currentattack, "currentattack", 1, SVT_STRING, SR_MobjGetAttack, SR_MobjPutAttack),


### PR DESCRIPTION
THINGS.DDF:
  - New Action command: SET_PAINCHANCE(percentage) which will dynamically change a monsters painchance. Possible usage: if we do SET_PAINCHANCE(0%) at the start of a lengthy PAIN state, this will make sure the whole animation is played out and won't be interrupted by another shot which would normally make us re-start the pain animation again. Remember to set it back to normal at the end of the lengthy animation.
  - New Special flag: IMMOVABLE which will make this thing be unaffected by thrust from attack impacts irrespective of whether it has a small MASS or a very large one.