### PR TITLE
BUGFIX: CTD if player dies while TARGET_JUMP or FRIEND_JUMP weapon sp…

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -91,4 +91,5 @@ Bugs fixed
 - Fixed MODEL_ROTATE not being applied to attacks
 - Fixed savegames not preserving the 'is_voodoo' convenience boolean for mobjs, causing issues when loading a game that had them present
 - Fixed berserk and other powerup effects not modifying model colors accordingly (bug introduced by transition to VBOs for model rendering)
+- Fixed crash if player dies while TARGET_JUMP or FRIEND_JUMP weapon specials are active
 

--- a/source_files/edge/p_weapon.cc
+++ b/source_files/edge/p_weapon.cc
@@ -1441,6 +1441,9 @@ void A_TargetJump(mobj_t * mo)
 	if (psp->state->jumpstate == S_NULL)
 		return;  // show warning ?? error ???
 
+	if (p->ready_wp == WPSEL_None)
+		return;
+
 	atkdef_c *attack = p->weapons[p->ready_wp].info->attack[0];
 
 	if (! attack)
@@ -1461,6 +1464,9 @@ void A_FriendJump(mobj_t * mo)
 
 	if (psp->state->jumpstate == S_NULL)
 		return;  // show warning ?? error ???
+
+	if (p->ready_wp == WPSEL_None)
+		return;
 
 	atkdef_c *attack = p->weapons[p->ready_wp].info->attack[0];
 


### PR DESCRIPTION
…ecials are active

Fixed crash if player dies while TARGET_JUMP or FRIEND_JUMP weapon specials are active