### PR TITLE
Fix: Breaking glass influenced by Blood menu

### DIFF
--- a/source_files/edge/p_local.h
+++ b/source_files/edge/p_local.h
@@ -149,6 +149,7 @@ bool P_SetMobjState(mobj_t * mobj, statenum_t state);
 bool P_SetMobjStateDeferred(mobj_t * mobj, statenum_t state, int tic_skip);
 void P_SetMobjDirAndSpeed(mobj_t * mobj, angle_t angle, float slope, float speed);
 void P_RunMobjThinkers(bool extra_tic);
+void P_SpawnDebris(float x, float y, float z, float damage, angle_t angle, const mobjtype_c * debris);
 void P_SpawnSplash(float x, float y, float z, const mobjtype_c * splash, angle_t angle);
 void P_SpawnPuff(float x, float y, float z, const mobjtype_c * puff, angle_t angle);
 void P_SpawnBlood(float x, float y, float z, float damage, angle_t angle, const mobjtype_c * blood);

--- a/source_files/edge/p_map.cc
+++ b/source_files/edge/p_map.cc
@@ -2168,8 +2168,8 @@ static bool PTR_ShootTraverse(intercept_t * in, void *dataptr)
 
 			if (info && tempspecial->type == line_shootable)
 			{
-				//P_SpawnPuff(x, y, z, info, shoot_I.angle + ANG180);
-				P_SpawnBlood(x, y, z, 0, shoot_I.angle + ANG180, info);
+				//P_SpawnBlood(x, y, z, 0, shoot_I.angle + ANG180, info);
+				P_SpawnDebris(x, y, z, 0, shoot_I.angle + ANG180, info);
 			}
 			P_UnblockLineEffectDebris(ld, tempspecial);
 		}

--- a/source_files/edge/p_mobj.cc
+++ b/source_files/edge/p_mobj.cc
@@ -915,7 +915,8 @@ static void P_XYMovement(mobj_t * mo, const region_properties_t *props, bool ext
 						if (tempspecial->effectobject)
 						{
 							DebrisThing = tempspecial->effectobject;
-							P_SpawnBlood(mo->x, mo->y, mo->z, 0, mo->angle + ANG180, DebrisThing);
+							//P_SpawnBlood(mo->x, mo->y, mo->z, 0, mo->angle + ANG180, DebrisThing);
+							P_SpawnDebris(mo->x, mo->y, mo->z, 0, mo->angle + ANG180, DebrisThing);
 						}
 					}
 				}
@@ -1915,6 +1916,37 @@ void P_RunMobjThinkers(bool extra_tic)
 //
 // GAME SPAWN FUNCTIONS
 //
+
+//
+// P_SpawnDebris
+//
+void P_SpawnDebris(float x, float y, float z, float damage,
+				  angle_t angle, const mobjtype_c * debris)
+{
+	mobj_t *th;
+
+	//angle += ANG180;
+	angle += (angle_t) (P_RandomNegPos() * (int)(ANG1 / 2));
+
+	z += (float)(P_RandomNegPos() / 64.0f);
+
+	th = P_MobjCreateObject(x, y, z, debris);
+
+	P_SetMobjDirAndSpeed(th, angle, 2.0f, 0.25f);
+
+	th->tics -= P_Random() & 3;
+
+	if (th->tics < 1)
+		th->tics = 1;
+/*
+	if (damage <= 12 && th->state && th->next_state)
+		P_SetMobjState(th, th->next_state - states);
+
+	if (damage <= 8 && th->state && th->next_state)
+		P_SetMobjState(th, th->next_state - states);
+*/	
+}
+
 
 //
 // P_SpawnSplash

--- a/source_files/edge/p_spec.cc
+++ b/source_files/edge/p_spec.cc
@@ -611,9 +611,9 @@ static void P_SpawnLineEffectDebris(line_t *TheLine, const linetype_c *special)
 	//move slightly forward to spawn the debris
 	midx += dx + info->radius;
 	midy += dy + info->radius;
-	//P_MobjCreateObject(midx, midy, midz, info);
 
-	P_SpawnBlood(midx, midy, midz, 0, 0 + ANG180, info);
+	//P_SpawnBlood(midx, midy, midz, 0, 0 + ANG180, info);
+	P_SpawnDebris(midx, midy, midz, 0, 0 + ANG180, info);
 
 	midx = (TheLine->v1->x + TheLine->v2->x) / 2;
 	midy = (TheLine->v1->y + TheLine->v2->y) / 2;
@@ -621,8 +621,9 @@ static void P_SpawnLineEffectDebris(line_t *TheLine, const linetype_c *special)
 	//move slightly backward to spawn the debris
 	midx -= dx + info->radius;
 	midy -= dy + info->radius;
-	//P_MobjCreateObject(midx, midy, midz, info);	
-	P_SpawnBlood(midx, midy, midz, 0, 0 + ANG180, info);
+	
+	//P_SpawnBlood(midx, midy, midz, 0, 0 + ANG180, info);
+	P_SpawnDebris(midx, midy, midz, 0, 0 + ANG180, info);
 }
 
 //


### PR DESCRIPTION
Replaced usage of P_SpawnBlood() with a new dedicated function for spawing debris.