### PR TITLE
Fix warnings under GCC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,9 @@ if (MSVC)
   # Unreferenced formal parameter, and there are many of these
   add_definitions("/wd4100")
 
+  # warning level for edge specific source files 
+  set (EDGE_WARNINGS "/W4")
+
   # To use the sanitizer with MSVC, you will need to either have your Visual Studio
   # or Build Tools install in your PATH variable, or copy the appropriate DLL to the program
   # folder before launching. The paths and filenames can vary based on your setup,
@@ -64,11 +67,16 @@ if (MSVC)
 
   set(CMAKE_EXE_LINKER_FLAGS "/SUBSYSTEM:WINDOWS")
 else()
+
   if (WIN32_CLANG)
     add_definitions("-D_CRT_SECURE_NO_WARNINGS")
   endif()
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-strict-aliasing -Wall")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-strict-aliasing -Wall")
+
+  # warning level for edge specific source files 
+  set (EDGE_WARNINGS -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -Wno-stringop-truncation -Wno-stringop-overflow)
+
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-strict-aliasing")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-strict-aliasing")
 
   if (EDGE_SANITIZE)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address")

--- a/source_files/ajbsp/CMakeLists.txt
+++ b/source_files/ajbsp/CMakeLists.txt
@@ -19,6 +19,6 @@ target_include_directories(edge_ajbsp PRIVATE ../epi)
 target_include_directories(edge_ajbsp PRIVATE ../miniz)
 
 target_compile_options(edge_ajbsp PRIVATE
-  $<$<CXX_COMPILER_ID:MSVC>:/W4>
-  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic>
+  $<$<CXX_COMPILER_ID:MSVC>:${EDGE_WARNINGS}>
+  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:${EDGE_WARNINGS}>
 )

--- a/source_files/ajbsp/bsp_level.cc
+++ b/source_files/ajbsp/bsp_level.cc
@@ -868,8 +868,7 @@ void ParseLinedefField(linedef_t *line, const std::string& key, const std::strin
 void ParseUDMF_Block(epi::lexer_c& lex, int cur_type)
 {
 	vertex_t  * vertex = NULL;
-	thing_t   * thing  = NULL;
-	sector_t  * sector = NULL;
+	thing_t   * thing  = NULL;	
 	sidedef_t * side   = NULL;
 	linedef_t * line   = NULL;
 
@@ -877,7 +876,7 @@ void ParseUDMF_Block(epi::lexer_c& lex, int cur_type)
 	{
 		case UDMF_VERTEX:  vertex = NewVertex();  break;
 		case UDMF_THING:   thing  = NewThing();   break;
-		case UDMF_SECTOR:  sector = NewSector();  break;
+		case UDMF_SECTOR:  NewSector();  break;
 		case UDMF_SIDEDEF: side   = NewSidedef(); break;
 		case UDMF_LINEDEF: line   = NewLinedef(); break;
 		default: break;

--- a/source_files/ajbsp/bsp_wad.cc
+++ b/source_files/ajbsp/bsp_wad.cc
@@ -148,7 +148,7 @@ bool Lump_c::GetLine(char *buffer, size_t buf_size)
 		if (parent->mem_fp)
 		{
 			mem_pos = parent->mem_fp->Read(dest, 1);
-			*dest++;
+			dest++;
 		}
 		else
 			*dest++ = fgetc(parent->fp);

--- a/source_files/coal/CMakeLists.txt
+++ b/source_files/coal/CMakeLists.txt
@@ -12,6 +12,6 @@ add_library(
 target_include_directories(edge_coal PRIVATE ../almostequals)
 
 target_compile_options(edge_coal PRIVATE
-  $<$<CXX_COMPILER_ID:MSVC>:/W4>
-  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic>
+  $<$<CXX_COMPILER_ID:MSVC>:${EDGE_WARNINGS}>
+  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:${EDGE_WARNINGS}>
 )

--- a/source_files/coal/c_compile.cc
+++ b/source_files/coal/c_compile.cc
@@ -1502,6 +1502,8 @@ int real_vm_c::GLOB_FunctionBody(def_t *func_def, type_t *type, const char *func
 	{
 		if (FindDef(type->parm_types[i], comp.parm_names[i], comp.scope))
 			CompileError("parameter %s redeclared\n", comp.parm_names[i]);
+
+		DeclareDef(type->parm_types[i], comp.parm_names[i], comp.scope);			
 	}
 
 	int code = EmitCode(OP_NULL);

--- a/source_files/coal/c_compile.cc
+++ b/source_files/coal/c_compile.cc
@@ -1497,14 +1497,11 @@ int real_vm_c::GLOB_FunctionBody(def_t *func_def, type_t *type, const char *func
 	//
 	// create the parmeters as locals
 	//
-	def_t *defs[MAX_PARMS];
 
 	for (int i=0 ; i < type->parm_num ; i++)
 	{
 		if (FindDef(type->parm_types[i], comp.parm_names[i], comp.scope))
 			CompileError("parameter %s redeclared\n", comp.parm_names[i]);
-
-		defs[i] = DeclareDef(type->parm_types[i], comp.parm_names[i], comp.scope);
 	}
 
 	int code = EmitCode(OP_NULL);
@@ -1906,7 +1903,11 @@ real_vm_c::real_vm_c() :
 {
 	// string #0 must be the empty string
 	int ofs = string_mem.alloc(2);
-	assert(ofs == 0);
+	if (ofs != 0)
+	{
+		RunError("string #0 must be the empty string\n");
+	}
+	
 	strcpy((char *)string_mem.deref(0), "");
 
 
@@ -1919,8 +1920,10 @@ real_vm_c::real_vm_c() :
 
 	// statement #0 is never used
 	ofs = EmitCode(OP_RET);
-	assert(ofs == 0);
-
+	if (ofs != 0)
+	{
+		RunError("statement #0 is never used\n");
+	}
 
 	// global #0 is never used (equivalent to NULL)
 	// global #1-#3 are reserved for function return values

--- a/source_files/ddf/CMakeLists.txt
+++ b/source_files/ddf/CMakeLists.txt
@@ -32,6 +32,6 @@ target_include_directories(edge_ddf PRIVATE ../edge)
 target_include_directories(edge_ddf PRIVATE ../epi)
 
 target_compile_options(edge_ddf PRIVATE
-  $<$<CXX_COMPILER_ID:MSVC>:/W4>
-  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic>
+  $<$<CXX_COMPILER_ID:MSVC>:${EDGE_WARNINGS}>
+  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:${EDGE_WARNINGS}>
 )

--- a/source_files/ddf/language.cc
+++ b/source_files/ddf/language.cc
@@ -65,6 +65,9 @@ std::string DDF_SanitizeName(const std::string& s)
 // Until unicode is truly implemented, restrict characters to extended ASCII
 std::string DDF_SanitizePrintString(const std::string& s)
 {
+	return std::string(s);
+	// This is always true and warns as std::string is char
+	/*
 	std::string out;
 
 	for (size_t i = 0 ; i < s.size() ; i++)
@@ -76,6 +79,7 @@ std::string DDF_SanitizePrintString(const std::string& s)
 	}
 
 	return out;
+	*/
 }
 
 class lang_choice_c

--- a/source_files/ddf/thing.cc
+++ b/source_files/ddf/thing.cc
@@ -1097,7 +1097,7 @@ static bool BenefitTryCounterLimit(const char *name, benefit_t *be,
 									 int num_vals)
 {
 	char namebuf[200];
-	int len = strlen(name);
+	size_t len = strlen(name);
 
 	// check for ".LIMIT" prefix
 	if (len < 7 || DDF_CompareName(name+len-6, ".LIMIT") != 0)
@@ -1225,7 +1225,7 @@ static bool BenefitTryAmmoLimit(const char *name, benefit_t *be,
 									 int num_vals)
 {
 	char namebuf[200];
-	int len = strlen(name);
+	size_t len = strlen(name);
 
 	// check for ".LIMIT" prefix
 

--- a/source_files/dehacked/CMakeLists.txt
+++ b/source_files/dehacked/CMakeLists.txt
@@ -30,6 +30,6 @@ target_include_directories(edge_deh PRIVATE ../epi)
 target_include_directories(edge_deh PRIVATE ../ddf)
 
 target_compile_options(edge_deh PRIVATE
-  $<$<CXX_COMPILER_ID:MSVC>:/W4>
-  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic>
+  $<$<CXX_COMPILER_ID:MSVC>:${EDGE_WARNINGS}>
+  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:${EDGE_WARNINGS}>
 )

--- a/source_files/ec_voxelib/CMakeLists.txt
+++ b/source_files/ec_voxelib/CMakeLists.txt
@@ -10,6 +10,6 @@ add_library(
 target_include_directories(ec_voxelib PRIVATE ../almostequals)
 
 target_compile_options(ec_voxelib PRIVATE
-  $<$<CXX_COMPILER_ID:MSVC>:/W4>
-  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic>
+  $<$<CXX_COMPILER_ID:MSVC>:${EDGE_WARNINGS}>
+  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:${EDGE_WARNINGS}>
 )

--- a/source_files/ec_voxelib/ec_voxelib.cc
+++ b/source_files/ec_voxelib/ec_voxelib.cc
@@ -1887,30 +1887,21 @@ void VoxelMesh::createFrom (VoxelData &vox, int optlevel) {
 
 //==========================================================================
 //
-//  normNegZero
-//
-//==========================================================================
-static inline void normNegZero (float *f) {
-  if (*f == 0.0f) memset((void *)f, 0, sizeof(*f));
-}
-
-
-//==========================================================================
-//
 //  GLVoxelMesh::appendVertex
 //
 //==========================================================================
 uint32_t GLVoxelMesh::appendVertex (VVoxVertexEx &gv) {
   ++totaladded;
   // normalize negative zeroes
-  normNegZero(&gv.x);
-  normNegZero(&gv.y);
-  normNegZero(&gv.z);
-  normNegZero(&gv.s);
-  normNegZero(&gv.t);
-  normNegZero(&gv.nx);
-  normNegZero(&gv.ny);
-  normNegZero(&gv.nz);
+  if (AlmostEquals(gv.x, 0.0f)) gv.x = 0.0f;
+  if (AlmostEquals(gv.y, 0.0f)) gv.y = 0.0f;
+  if (AlmostEquals(gv.z, 0.0f)) gv.z = 0.0f;
+  if (AlmostEquals(gv.s, 0.0f)) gv.s = 0.0f;
+  if (AlmostEquals(gv.t, 0.0f)) gv.t = 0.0f;
+  if (AlmostEquals(gv.nx, 0.0f)) gv.nx = 0.0f;
+  if (AlmostEquals(gv.ny, 0.0f)) gv.ny = 0.0f;
+  if (AlmostEquals(gv.nz, 0.0f)) gv.nz = 0.0f;
+  
   // check hashtable
   auto vp = vertcache.get(gv);
   if (vp) return *vp;

--- a/source_files/edge/CMakeLists.txt
+++ b/source_files/edge/CMakeLists.txt
@@ -158,21 +158,21 @@ else()
 	set(EDGE_LINK_LIBRARIES ${EDGE_LINK_LIBRARIES} gl4es)
 endif()
 
-target_include_directories(edge-classic PRIVATE ../almostequals)
+target_include_directories(edge-classic SYSTEM PRIVATE ../almostequals)
 target_include_directories(edge-classic PRIVATE ../ajbsp)
 target_include_directories(edge-classic PRIVATE ../coal)
-target_include_directories(edge-classic PRIVATE ../crsid)
+target_include_directories(edge-classic SYSTEM PRIVATE ../crsid)
 target_include_directories(edge-classic PRIVATE ../ddf)
 target_include_directories(edge-classic PRIVATE ../dehacked)
-target_include_directories(edge-classic PRIVATE ../dr_libs)
+target_include_directories(edge-classic SYSTEM PRIVATE ../dr_libs)
 target_include_directories(edge-classic PRIVATE ../ec_voxelib)
 target_include_directories(edge-classic PRIVATE ../epi)
-target_include_directories(edge-classic PRIVATE ../libprimesynth)
-target_include_directories(edge-classic PRIVATE ../libRAD)
-target_include_directories(edge-classic PRIVATE ../m4p)
-target_include_directories(edge-classic PRIVATE ../minivorbis)
-target_include_directories(edge-classic PRIVATE ../miniz)
-target_include_directories(edge-classic PRIVATE ../stb)
+target_include_directories(edge-classic SYSTEM PRIVATE ../libprimesynth)
+target_include_directories(edge-classic SYSTEM PRIVATE ../libRAD)
+target_include_directories(edge-classic SYSTEM PRIVATE ../m4p)
+target_include_directories(edge-classic SYSTEM PRIVATE ../minivorbis)
+target_include_directories(edge-classic SYSTEM PRIVATE ../miniz)
+target_include_directories(edge-classic SYSTEM PRIVATE ../stb)
 if(MSVC OR WIN32_CLANG)
   target_include_directories(edge-classic PRIVATE ../sdl2/include)
 endif()
@@ -180,8 +180,8 @@ endif()
 target_link_libraries(edge-classic PRIVATE ${EDGE_LINK_LIBRARIES})
 
 target_compile_options(edge-classic PRIVATE
-  $<$<CXX_COMPILER_ID:MSVC>:/W4>
-  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic>
+  $<$<CXX_COMPILER_ID:MSVC>:${EDGE_WARNINGS}>
+  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:${EDGE_WARNINGS}>
 )
 
 set(COPY_FILES "")

--- a/source_files/edge/am_map.cc
+++ b/source_files/edge/am_map.cc
@@ -605,6 +605,7 @@ static void DrawMLineDoor(mline_t * ml, rgbcol_t rgb)
 	HUD_SolidLine(x1, y1, x2, y2, rgb, linewidth, true, dx, dy);
 }
 
+/*
 static mline_t door_key[] =
 {
 	{{-2, 0}, {-1.7, -0.5}},
@@ -622,7 +623,7 @@ static mline_t door_key[] =
 };
 
 #define NUMDOORKEYLINES (sizeof(door_key)/sizeof(mline_t))
-
+*/
 
 static mline_t player_dagger[] =
 {

--- a/source_files/edge/bot_nav.cc
+++ b/source_files/edge/bot_nav.cc
@@ -846,8 +846,6 @@ static void NAV_EnemiesInSubsector(const subsector_t *sub, bot_t *bot, float rad
 
 static void NAV_EnemiesInNode(unsigned int bspnum, bot_t *bot, float radius, mobj_t*& best_mo, float& best_score)
 {
-	SYS_ASSERT(((int)bspnum) >= 0);
-
 	if (bspnum & NF_V5_SUBSECTOR)
 	{
 		bspnum &= ~NF_V5_SUBSECTOR;

--- a/source_files/edge/bot_nav.cc
+++ b/source_files/edge/bot_nav.cc
@@ -846,7 +846,7 @@ static void NAV_EnemiesInSubsector(const subsector_t *sub, bot_t *bot, float rad
 
 static void NAV_EnemiesInNode(unsigned int bspnum, bot_t *bot, float radius, mobj_t*& best_mo, float& best_score)
 {
-	SYS_ASSERT(bspnum >= 0);
+	SYS_ASSERT(((int)bspnum) >= 0);
 
 	if (bspnum & NF_V5_SUBSECTOR)
 	{

--- a/source_files/edge/con_var.cc
+++ b/source_files/edge/con_var.cc
@@ -35,7 +35,7 @@ static cvar_c * all_cvars = NULL;
 cvar_c::cvar_c(const char *_name, const char *_def, int _flags, float _min, float _max, cvar_callback _cb) :
 	d(), f(), s(_def),
 	name(_name), def(_def), flags(_flags), min(_min), max(_max),
-	modified(0), cvar_cb(_cb)
+	cvar_cb(_cb), modified(0)
 {
 	ParseString();
 

--- a/source_files/edge/e_main.cc
+++ b/source_files/edge/e_main.cc
@@ -289,7 +289,7 @@ void E_ProgressMessage(const char *message)
 //
 static void SetGlobalVars(void)
 {
-	int p;
+	size_t p;
 	std::string s;
 
 	// Screen Resolution Check...
@@ -1339,7 +1339,7 @@ static void CheckTurbo(void)
 {
 	int turbo_scale = 100;
 
-	int p = argv::Find("turbo");
+	size_t p = argv::Find("turbo");
 
 	if (p > 0)
 	{
@@ -1451,7 +1451,7 @@ static void AddCommandLineFiles(void)
 {
 	// first handle "loose" files (arguments before the first option)
 
-	int p;
+	size_t p;
 
 	for (p = 1; p < argv::list.size() && !argv::IsOption(p); p++)
 	{
@@ -1803,7 +1803,7 @@ static void E_InitialState(void)
 	}
 
 	// deathmatch check...
-	int pp = argv::Find("deathmatch");
+	size_t pp = argv::Find("deathmatch");
 	if (pp > 0)
 	{
 		warp_deathmatch = 1;

--- a/source_files/edge/e_main.cc
+++ b/source_files/edge/e_main.cc
@@ -289,7 +289,7 @@ void E_ProgressMessage(const char *message)
 //
 static void SetGlobalVars(void)
 {
-	size_t p;
+	int p;
 	std::string s;
 
 	// Screen Resolution Check...
@@ -319,7 +319,7 @@ static void SetGlobalVars(void)
 	}
 
 	p = argv::Find("res");
-	if (p > 0 && p + 2 < argv::list.size() && !argv::IsOption(p+1) && !argv::IsOption(p+2))
+	if (p > 0 && p + 2 < int(argv::list.size()) && !argv::IsOption(p+1) && !argv::IsOption(p+2))
 	{
 		if (DISPLAYMODE == 2)
 			I_Warning("Current display mode set to borderless fullscreen. Provided resolution of %dx%d will be ignored!\n", 
@@ -356,7 +356,7 @@ static void SetGlobalVars(void)
 	p = argv::Find("spritekludge");
 	if (p > 0)
 	{
-		if (p + 1 < argv::list.size() && !argv::IsOption(p+1))
+		if (p + 1 < int(argv::list.size()) && !argv::IsOption(p+1))
 			sprite_kludge = atoi(argv::list[p+1].c_str());
 
 		if (!sprite_kludge)
@@ -1339,11 +1339,11 @@ static void CheckTurbo(void)
 {
 	int turbo_scale = 100;
 
-	size_t p = argv::Find("turbo");
+	int p = argv::Find("turbo");
 
 	if (p > 0)
 	{
-		if (p + 1 < argv::list.size() && !argv::IsOption(p+1))
+		if (p + 1 < int(argv::list.size()) && !argv::IsOption(p+1))
 			turbo_scale = atoi(argv::list[p+1].c_str());
 		else
 			turbo_scale = 200;
@@ -1803,12 +1803,12 @@ static void E_InitialState(void)
 	}
 
 	// deathmatch check...
-	size_t pp = argv::Find("deathmatch");
+	int pp = argv::Find("deathmatch");
 	if (pp > 0)
 	{
 		warp_deathmatch = 1;
 
-		if (pp + 1 < argv::list.size() && !argv::IsOption(pp+1))
+		if (pp + 1 < int(argv::list.size()) && !argv::IsOption(pp+1))
 			warp_deathmatch = MAX(1, atoi(argv::list[pp+1].c_str()));
 
 		warp = true;

--- a/source_files/edge/e_main.cc
+++ b/source_files/edge/e_main.cc
@@ -1451,9 +1451,9 @@ static void AddCommandLineFiles(void)
 {
 	// first handle "loose" files (arguments before the first option)
 
-	size_t p;
+	int p;
 
-	for (p = 1; p < argv::list.size() && !argv::IsOption(p); p++)
+	for (p = 1; p < int(argv::list.size()) && !argv::IsOption(p); p++)
 	{
 		AddSingleCmdLineFile(std::filesystem::u8path(argv::list[p]), false);
 	}
@@ -1462,7 +1462,7 @@ static void AddCommandLineFiles(void)
 
 	p = argv::Find("file");
 
-	while (p > 0 && p < argv::list.size() && (!argv::IsOption(p) || epi::strcmp(argv::list[p], "-file") == 0))
+	while (p > 0 && p < int(argv::list.size()) && (!argv::IsOption(p) || epi::strcmp(argv::list[p], "-file") == 0))
 	{
 		// the parms after p are wadfile/lump names,
 		// go until end of parms or another '-' preceded parm
@@ -1476,7 +1476,7 @@ static void AddCommandLineFiles(void)
 
 	p = argv::Find("script");
 
-	while (p > 0 && p < argv::list.size() && (!argv::IsOption(p) || epi::strcmp(argv::list[p], "-script") == 0))
+	while (p > 0 && p < int(argv::list.size()) && (!argv::IsOption(p) || epi::strcmp(argv::list[p], "-script") == 0))
 	{
 		// the parms after p are script filenames,
 		// go until end of parms or another '-' preceded parm
@@ -1507,7 +1507,7 @@ static void AddCommandLineFiles(void)
 
 	p = argv::Find("deh");
 
-	while (p > 0 && p < argv::list.size() && (!argv::IsOption(p) || epi::strcmp(argv::list[p], "-deh") == 0))
+	while (p > 0 && p < int(argv::list.size()) && (!argv::IsOption(p) || epi::strcmp(argv::list[p], "-deh") == 0))
 	{
 		// the parms after p are Dehacked/BEX filenames,
 		// go until end of parms or another '-' preceded parm
@@ -1537,7 +1537,7 @@ static void AddCommandLineFiles(void)
 
 	p = argv::Find("dir");
 
-	while (p > 0 && p < argv::list.size() && (!argv::IsOption(p) || epi::strcmp(argv::list[p],"-dir") == 0))
+	while (p > 0 && p < int(argv::list.size()) && (!argv::IsOption(p) || epi::strcmp(argv::list[p],"-dir") == 0))
 	{
 		// the parms after p are directory names,
 		// go until end of parms or another '-' preceded parm

--- a/source_files/edge/f_finale.cc
+++ b/source_files/edge/f_finale.cc
@@ -932,7 +932,7 @@ void F_Drawer(void)
 
 		case f_pic:
 			{
-				const image_c *image = W_ImageLookup(finale->pics[MIN(picnum, finale->pics.size()-1)].c_str());
+				const image_c *image = W_ImageLookup(finale->pics[MIN((size_t)picnum, finale->pics.size()-1)].c_str());
 				if (r_titlescaling.d == 2) // Stretch
 					HUD_StretchImage(hud_x_left, 0, hud_x_right-hud_x_left, 200, image, 0, 0);
 				else

--- a/source_files/edge/i_video.cc
+++ b/source_files/edge/i_video.cc
@@ -213,7 +213,7 @@ void I_StartupGraphics(void)
 	// If needed, set the default window toggle mode to the largest non-native res
 	if (tw_displaymode.d == scrmode_c::SCR_INVALID)
 	{
-		for (int i = 0; i < screen_modes.size(); i++)
+		for (size_t i = 0; i < screen_modes.size(); i++)
 		{
 			scrmode_c *check = screen_modes[i];
 			if (check->display_mode == scrmode_c::SCR_WINDOW)

--- a/source_files/edge/m_argv.cc
+++ b/source_files/edge/m_argv.cc
@@ -169,12 +169,12 @@ std::string argv::Value(std::string longName, int *numParams)
 {
     SYS_ASSERT(!longName.empty());
 
-    size_t pos = Find(longName, numParams);
+    int pos = Find(longName, numParams);
 
     if (pos <= 0)
         return "";
 
-    if (pos + 1 < list.size() && !IsOption(pos+1))
+    if (pos + 1 < int(list.size()) && !IsOption(pos+1))
         return list[pos+1];
     else
         return "";
@@ -316,13 +316,13 @@ void argv::DebugDumpArgs(void)
 {
 	I_Printf("Command-line Options:\n");
 
-	size_t i = 0;
+	int i = 0;
 
-	while (i < list.size())
+	while (i < int(list.size()))
 	{
 		bool pair_it_up = false;
 
-		if (i>0 && i+1 < list.size() && !IsOption(i+1))
+		if (i>0 && i+1 < int(list.size()) && !IsOption(i+1))
 			pair_it_up = true;
 
 		I_Printf("  %s %s\n", list[i].c_str(), pair_it_up ? list[i+1].c_str() : "");

--- a/source_files/edge/m_argv.cc
+++ b/source_files/edge/m_argv.cc
@@ -98,8 +98,8 @@ void argv::Init(const int argc, const char *const *argv)
 #else
 void argv::Init(const int argc, const char *const *argv) 
 {
-    list.reserve(argc);
-    SYS_ASSERT(argv::list.size() >= 0);
+	SYS_ASSERT(argc >= 0);
+    list.reserve(argc);    
 
     for (int i = 0; i < argc; i++) 
 	{
@@ -169,7 +169,7 @@ std::string argv::Value(std::string longName, int *numParams)
 {
     SYS_ASSERT(!longName.empty());
 
-    int pos = Find(longName, numParams);
+    size_t pos = Find(longName, numParams);
 
     if (pos <= 0)
         return "";
@@ -316,7 +316,7 @@ void argv::DebugDumpArgs(void)
 {
 	I_Printf("Command-line Options:\n");
 
-	int i = 0;
+	size_t i = 0;
 
 	while (i < list.size())
 	{

--- a/source_files/edge/m_menu.cc
+++ b/source_files/edge/m_menu.cc
@@ -838,7 +838,6 @@ void M_DrawLoad(void)
 {
 	int i;
 	int fontType;
-	float txtscale = 1.0;
 	float LineHeight;
 	int TempX = 0;
 	int TempY = 0;
@@ -855,9 +854,6 @@ void M_DrawLoad(void)
 	else
 		fontType=styledef_c::T_HEADER;
 
-	if (style->def->text[fontType].scale)
-		txtscale=style->def->text[fontType].scale;
-
 	HUD_SetAlpha(style->def->text[fontType].translucency);
 
 	//1. Draw the header i.e. "Load Game"
@@ -873,8 +869,6 @@ void M_DrawLoad(void)
 	TempY = 0; 
 
 	fontType=styledef_c::T_TEXT;
-	if (style->def->text[fontType].scale)
-		txtscale=style->def->text[fontType].scale;
 
 	TempX += style->def->text[styledef_c::T_TEXT].x_offset;
 	TempY += style->def->text[styledef_c::T_TEXT].y_offset;
@@ -1621,8 +1615,8 @@ static void QuitResponse(int ch)
 	if (!netgame)
 	{
 		int numsounds = 0;
-		char refname[16];
-		char sound[16];
+		char refname[64];
+		char sound[64];
 		int i, start;
 
 		// Count the quit messages
@@ -1831,7 +1825,7 @@ void M_DrawFracThermo(int x, int y, float thermDot, float increment, int div, fl
 
 		HUD_StretchImage(x, y, step+1, IM_HEIGHT(therm_l)/div, therm_l, 0.0, 0.0);
 
-		for (i, x += step; i < (50/step); i++, x += step)
+		for (x += step; i < (50/step); i++, x += step)
 		{
 			HUD_StretchImage(x, y, step+1, IM_HEIGHT(therm_m)/div, therm_m, 0.0, 0.0);
 		}
@@ -2907,7 +2901,6 @@ void M_DrawItems(style_c *style, bool graphical_item)
 	{
 		ShortestLine = 10000.0f;
 		TallestLine = 0.0f;
-		bool backdrop_menu = false;
 		for (i = 0; i < max; i++)
 		{
 			if (! currentMenu->menuitems[i].patch_name[0])
@@ -2946,7 +2939,6 @@ void M_DrawItems(style_c *style, bool graphical_item)
 		}
 		if (ShortestLine == 10000.0f && TallestLine == 0.0f)
 		{
-			backdrop_menu = true;
 			ShortestLine = 20.0f;
 			TallestLine = 20.0f;
 			WidestLine = 121.0f;

--- a/source_files/edge/m_option.cc
+++ b/source_files/edge/m_option.cc
@@ -222,7 +222,6 @@ static char JoyAxis[]      = "Off/Turn/Turn (Reversed)/Look (Inverted)/Look/Walk
 static char JoyDevs[]   = "None/1/2/3/4/5/6";
 static char JpgPng[]    = "JPEG/PNG";  // basic on/off
 static char AAim[]      = "Off/On/Mlook";
-static char MipMaps[]   = "None/Good/Best";
 static char Details[]   = "Low/Medium/High";
 static char Hq2xMode[]  = "Off/UI Only/UI & Sprites/All";
 static char TitleScaleMode[]  = "Normal/Zoom/Stretch/Fill Border";

--- a/source_files/edge/p_action.cc
+++ b/source_files/edge/p_action.cc
@@ -2202,10 +2202,8 @@ void P_ActEffectTracker(mobj_t * object)
 //
 void P_ActPsychicEffect(mobj_t * object)
 {
-	mobj_t *tracker;
 	mobj_t *target;
 	const atkdef_c *attack;
-	angle_t angle;
 	float damage;
 
 	if (!object->target || !object->currentattack)
@@ -2225,9 +2223,6 @@ void P_ActPsychicEffect(mobj_t * object)
 
 	if (attack->sound)
 		S_StartFX(attack->sound, P_MobjGetSfxCategory(object), object);
-
-	angle = object->angle;
-	tracker = object->tracer;
 
 	DAMAGE_COMPUTE(damage, &attack->damage);
 

--- a/source_files/edge/p_blockmap.cc
+++ b/source_files/edge/p_blockmap.cc
@@ -882,7 +882,7 @@ void P_DynamicLightIterator(float x1, float y1, float z1,
 
 			if (r_maxdlights.d > 0 && seen_dlights.count(mo->dlight.shader) == 0)
 			{
-				if (seen_dlights.size() >= r_maxdlights.d * 20)
+				if ((int)seen_dlights.size() >= r_maxdlights.d * 20)
 					continue;
 				else
 				{
@@ -934,7 +934,7 @@ void P_SectorGlowIterator(sector_t *sec,
 				{
 					// Use first line that the dlight mobj touches
 					// Ideally it is only touching one line
-					for (size_t i = 0; i < sec->linecount; i++)
+					for (int i = 0; i < sec->linecount; i++)
 					{
 						if (P_ThingOnLineSide(mo, sec->lines[i]) == -1)
 						{

--- a/source_files/edge/p_map.cc
+++ b/source_files/edge/p_map.cc
@@ -2120,8 +2120,8 @@ static bool PTR_ShootTraverse(intercept_t * in, void *dataptr)
 
 		sector_t *last_shoota_sec = R_PointInSubsector(x, y)->sector;
 
-		if (last_shoota_sec && (ld->frontsector && (ld->frontsector->floor_vertex_slope || ld->frontsector->ceil_vertex_slope)) ||
-			(ld->backsector && (ld->backsector->floor_vertex_slope || ld->backsector->ceil_vertex_slope)))
+		if (last_shoota_sec && ((ld->frontsector && (ld->frontsector->floor_vertex_slope || ld->frontsector->ceil_vertex_slope)) ||
+			(ld->backsector && (ld->backsector->floor_vertex_slope || ld->backsector->ceil_vertex_slope))))
 		{
 			bool fs_good = true;
 			bool cs_good = true;

--- a/source_files/edge/p_plane.cc
+++ b/source_files/edge/p_plane.cc
@@ -1067,7 +1067,7 @@ bool EV_DoPlane(sector_t * sec, const movplanedef_c * def, sector_t * model)
     // Do sector action
     if (sec->floor_vertex_slope || sec->ceil_vertex_slope)
     {
-        I_Warning("Plane movers are not supported for vertex slopes! (Sector %d)\n", sec - sectors);
+        I_Warning("Plane movers are not supported for vertex slopes! (Sector %u)\n", int(sec - sectors));
         return false;
     }
     plane_move_t *secaction = P_SetupSectorAction(sec, def, model);

--- a/source_files/edge/p_setup.cc
+++ b/source_files/edge/p_setup.cc
@@ -1485,7 +1485,7 @@ static void LoadUDMFSectors()
 		if (section == "sector")
 		{
 			int cz = 0, fz = 0;
-			float fx = 0.0f, fy = 0.0f, cx = 0.0f, cy = 0.0f;
+			float fx = 0.0f, fy = 0.0f;
 			float fx_sc = 1.0f, fy_sc = 1.0f, cx_sc = 1.0f, cy_sc = 1.0f;
 			float rf = 0.0f, rc = 0.0f;
 			float gravfactor = 1.0f;
@@ -1548,9 +1548,13 @@ static void LoadUDMFSectors()
 				else if (key == "ypanningfloor")
 					fy = epi::LEX_Double(value);
 				else if (key == "xpanningceiling")
-					cx = epi::LEX_Double(value);
+				{
+					//cx = epi::LEX_Double(value);
+				}
 				else if (key == "ypanningceiling")
-					cy = epi::LEX_Double(value);
+				{
+					//cy = epi::LEX_Double(value);
+				}					
 				else if (key == "xscalefloor")
 					fx_sc = epi::LEX_Double(value);
 				else if (key == "yscalefloor")
@@ -3347,7 +3351,10 @@ void ShutdownLevel(void)
 
 	P_RemoveAllMobjs(false);
 
-	for (auto adhoc : level_adhocs) delete adhoc; level_adhocs.clear();
+	for (auto adhoc : level_adhocs) 
+		delete adhoc; 
+		
+	level_adhocs.clear();
 }
 
 

--- a/source_files/edge/p_sight.cc
+++ b/source_files/edge/p_sight.cc
@@ -272,8 +272,6 @@ static bool CrossSubsector(subsector_t *sub)
 //
 static bool CheckSightBSP(unsigned int bspnum)
 {
-	SYS_ASSERT((int)bspnum >= 0);
-
 	while (! (bspnum & NF_V5_SUBSECTOR))
 	{
 		node_t *node = nodes + bspnum;
@@ -307,7 +305,7 @@ static bool CheckSightBSP(unsigned int bspnum)
 
 	bspnum &= ~NF_V5_SUBSECTOR;
 
-	SYS_ASSERT(0 <= int(bspnum) && int(bspnum) < numsubsectors);
+	SYS_ASSERT(bspnum < (unsigned int)numsubsectors);
 
 	{
 		subsector_t *sub = subsectors + bspnum;

--- a/source_files/edge/p_sight.cc
+++ b/source_files/edge/p_sight.cc
@@ -272,7 +272,7 @@ static bool CrossSubsector(subsector_t *sub)
 //
 static bool CheckSightBSP(unsigned int bspnum)
 {
-	SYS_ASSERT(bspnum >= 0);
+	SYS_ASSERT((int)bspnum >= 0);
 
 	while (! (bspnum & NF_V5_SUBSECTOR))
 	{
@@ -307,7 +307,7 @@ static bool CheckSightBSP(unsigned int bspnum)
 
 	bspnum &= ~NF_V5_SUBSECTOR;
 
-	SYS_ASSERT(0 <= bspnum && int(bspnum) < numsubsectors);
+	SYS_ASSERT(0 <= int(bspnum) && int(bspnum) < numsubsectors);
 
 	{
 		subsector_t *sub = subsectors + bspnum;

--- a/source_files/edge/p_user.cc
+++ b/source_files/edge/p_user.cc
@@ -482,7 +482,7 @@ static void MovePlayer(player_t * player, bool extra_tic)
 			if (! (player->ready_wp < 0 || player->pending_wp >= 0))
 				fov =player->weapons[player->ready_wp].info->zoom_fov;
 		
-			if (fov == ANG_MAX)
+			if (fov == int(ANG_MAX))
 				fov = 0;
 		}
 

--- a/source_files/edge/p_weapon.cc
+++ b/source_files/edge/p_weapon.cc
@@ -477,7 +477,7 @@ static void P_BringUpWeapon(player_t * p)
 
 	if (p->zoom_fov > 0)
 	{
-		if (info->zoom_fov < ANG_MAX)
+		if (info->zoom_fov < int(ANG_MAX))
 			p->zoom_fov = info->zoom_fov;
 		else
 			p->zoom_fov = 0;
@@ -1940,7 +1940,7 @@ void A_WeaponZoom(mobj_t * mo)
 		if (! (p->ready_wp < 0 || p->pending_wp >= 0))
 			fov =p->weapons[p->ready_wp].info->zoom_fov;
 	
-		if (fov == ANG_MAX)
+		if (fov == int(ANG_MAX))
 			fov = 0;
 	}
 

--- a/source_files/edge/r_misc.cc
+++ b/source_files/edge/r_misc.cc
@@ -185,7 +185,11 @@ void R_InitShaderTables()
 //
 void R_Init(void)
 {
-	I_Printf("%s", language["RefreshDaemon"]);
+	if (language["RefreshDaemon"])
+		I_Printf("%s", language["RefreshDaemon"]);
+	else
+		I_Printf("Unknown Refresh Daemon");
+	
 	R_InitShaderTables();
 
 	framecount = 0;

--- a/source_files/edge/r_misc.cc
+++ b/source_files/edge/r_misc.cc
@@ -185,7 +185,7 @@ void R_InitShaderTables()
 //
 void R_Init(void)
 {
-	I_Printf(language["RefreshDaemon"]);
+	I_Printf("%s", language["RefreshDaemon"]);
 	R_InitShaderTables();
 
 	framecount = 0;

--- a/source_files/edge/r_modes.cc
+++ b/source_files/edge/r_modes.cc
@@ -106,7 +106,7 @@ static scrmode_c *R_FindResolution(int w, int h, int depth, int display_mode)
 //
 void R_AddResolution(scrmode_c *mode)
 {
-    scrmode_c *exist = R_FindResolution(mode->width, mode->height,
+	scrmode_c *exist = R_FindResolution(mode->width, mode->height,
 							mode->depth, mode->display_mode);
 	if (exist)
 	{
@@ -127,7 +127,7 @@ void R_AddResolution(scrmode_c *mode)
 
 void R_DumpResList(void)
 {
-    I_Printf("Available Resolutions:\n");
+	I_Printf("Available Resolutions:\n");
 
 	for (int i = 0; i < (int)screen_modes.size(); i++)
 	{
@@ -136,8 +136,8 @@ void R_DumpResList(void)
 		if (i > 0 && (i % 3) == 0)
 			I_Printf("\n");
 
-        I_Printf("  %4dx%4d @ %02d %s", 
-                 cur->width, cur->height, cur->depth, cur->display_mode == cur->SCR_BORDERLESS ?
+		I_Printf("  %4dx%4d @ %02d %s", 
+				 cur->width, cur->height, cur->depth, cur->display_mode == cur->SCR_BORDERLESS ?
 				 "BL" : (cur->display_mode == cur->SCR_FULLSCREEN ? "FS " : "win"));
 	}
 
@@ -261,11 +261,11 @@ void R_SoftInitResolution(void)
 	RGL_NewScreenSize(SCREENWIDTH, SCREENHEIGHT, SCREENBITS);
 
 	if (SCREENWIDTH < 720)
-        current_font_size = 0;
-    else if (SCREENWIDTH < 1440)
-        current_font_size = 1;
-    else
-        current_font_size = 2;
+		current_font_size = 0;
+	else if (SCREENWIDTH < 1440)
+		current_font_size = 1;
+	else
+		current_font_size = 2;
 
 	// -ES- 1999/08/29 Fixes the garbage palettes, and the blank 16-bit console
 	V_SetPalette(PALETTE_NORMAL, 0);
@@ -298,11 +298,11 @@ static bool DoExecuteChangeResolution(scrmode_c *mode)
 	DISPLAYMODE  = mode->display_mode;
 
 	if (SCREENWIDTH < 720)
-        current_font_size = 0;
-    else if (SCREENWIDTH < 1440)
-        current_font_size = 1;
-    else
-        current_font_size = 2;
+		current_font_size = 0;
+	else if (SCREENWIDTH < 1440)
+		current_font_size = 1;
+	else
+		current_font_size = 2;
 
 	I_DeterminePixelAspect();
 
@@ -369,7 +369,7 @@ void R_InitialResolution(void)
 	mode.depth  = SCREENBITS;
 	mode.display_mode   = DISPLAYMODE;
 
-    if (DoExecuteChangeResolution(&mode))
+	if (DoExecuteChangeResolution(&mode))
 	{
 		// this mode worked, make sure it's in the list
 		R_AddResolution(&mode);
@@ -390,7 +390,7 @@ void R_InitialResolution(void)
 			return;
 	}
 
-    // FOOBAR!
+	// FOOBAR!
 	I_Error("Unable to set any resolutions!");
 }
 

--- a/source_files/edge/r_render.cc
+++ b/source_files/edge/r_render.cc
@@ -961,9 +961,9 @@ wall_tile_flag_e;
 
 
 static void DrawWallPart(drawfloor_t *dfloor,
-		                 float x1, float y1, float lz1, float lz2,
+						 float x1, float y1, float lz1, float lz2,
 						 float x2, float y2, float rz1, float rz2,
-		                 float tex_top_h, surface_t *surf,
+						 float tex_top_h, surface_t *surf,
 						 const image_c *image,
 						 bool mid_masked, bool opaque,
    						 float tex_x1, float tex_x2,
@@ -977,10 +977,10 @@ static void DrawWallPart(drawfloor_t *dfloor,
 	//if (! props)
 	//	props = surf->override_p ? surf->override_p : dfloor->props;
 	if (surf->override_p)
-        props = surf->override_p;
+		props = surf->override_p;
 
-    if (! props)
-        props = dfloor->props;
+	if (! props)
+		props = dfloor->props;
 
 	float trans = surf->translucency;
 
@@ -1192,7 +1192,7 @@ static void DrawWallPart(drawfloor_t *dfloor,
 							   DLIT_Wall, &data);
 
 		P_SectorGlowIterator(cur_seg->frontsector,
-				             v_bbox[BOXLEFT],  v_bbox[BOXBOTTOM], bottom,
+							 v_bbox[BOXLEFT],  v_bbox[BOXBOTTOM], bottom,
 							 v_bbox[BOXRIGHT], v_bbox[BOXTOP],    top,
 							 GLOWLIT_Wall, &data);
 	}
@@ -1201,8 +1201,8 @@ static void DrawWallPart(drawfloor_t *dfloor,
 }
 
 static void DrawSlidingDoor(drawfloor_t *dfloor, float c, float f,
-						    float tex_top_h, surface_t *surf,
-						    bool opaque, float x_offset)
+							float tex_top_h, surface_t *surf,
+							bool opaque, float x_offset)
 {
 
 	/* smov may be NULL */
@@ -1305,14 +1305,14 @@ static void DrawSlidingDoor(drawfloor_t *dfloor, float c, float f,
 		e_tex += x_offset;
 
 		DrawWallPart(dfloor, x1,y1,f,c, x2,y2,f,c, tex_top_h,
-		             surf, surf->image, true, opaque, s_tex, e_tex);
+					 surf, surf->image, true, opaque, s_tex, e_tex);
 	}
 }
 
 // Mirror the texture on the back of the line
 static void DrawGlass(drawfloor_t *dfloor, float c, float f,
-						    float tex_top_h, surface_t *surf,
-						    bool opaque, float x_offset)
+							float tex_top_h, surface_t *surf,
+							bool opaque, float x_offset)
 {
 
 	line_t *ld = cur_seg->linedef;
@@ -1370,8 +1370,8 @@ static void DrawGlass(drawfloor_t *dfloor, float c, float f,
 }
 
 static void DrawTile(seg_t *seg, drawfloor_t *dfloor,
-                    float lz1, float lz2, float rz1, float rz2,
-                    float tex_z, int flags, surface_t *surf)
+					float lz1, float lz2, float rz1, float rz2,
+					float tex_z, int flags, surface_t *surf)
 {
 	// tex_z = texturing top, in world coordinates
 
@@ -1451,7 +1451,7 @@ static void DrawTile(seg_t *seg, drawfloor_t *dfloor,
 
 static inline void AddWallTile( seg_t *seg, drawfloor_t *dfloor,
  							   surface_t *surf,
-                               float z1, float z2,
+							   float z1, float z2,
 							   float tex_z, int flags,
 							   float f_min, float c_max)
 {
@@ -1465,9 +1465,9 @@ static inline void AddWallTile( seg_t *seg, drawfloor_t *dfloor,
 }
 
 static inline void AddWallTile2( seg_t *seg, drawfloor_t *dfloor,
-                                surface_t *surf,
-                                float lz1, float lz2, float rz1, float rz2,
-							    float tex_z, int flags)
+								surface_t *surf,
+								float lz1, float lz2, float rz1, float rz2,
+								float tex_z, int flags)
 {
 	DrawTile(seg, dfloor, lz1,lz2, rz1,rz2, tex_z, flags, surf);
 }
@@ -1926,7 +1926,7 @@ static void EmulateFloodPlane(const drawfloor_t *dfloor,
 
 	// ignore fake 3D bridges (Batman MAP03)
 	if (cur_seg->linedef &&
-	    cur_seg->linedef->frontsector == cur_seg->linedef->backsector)
+		cur_seg->linedef->frontsector == cur_seg->linedef->backsector)
 		return;
 
 	const region_properties_t *props = surf->override_p ?
@@ -2055,7 +2055,7 @@ static void EmulateFloodPlane(const drawfloor_t *dfloor,
 //		I_Debugf("Flood BBox size: %1.0f x %1.0f\n", lx2-lx1, ly2-ly1);
 
 		P_DynamicLightIterator(lx1,ly1,data.plane_h, lx2,ly2,data.plane_h,
-				               DLIT_Flood, &data);
+							   DLIT_Flood, &data);
 	}
 }
 
@@ -2692,12 +2692,12 @@ static void RGL_DrawPlane(drawfloor_t *dfloor, float h,
 	if (use_dlights && ren_extralight < 250)
 	{
 		P_DynamicLightIterator(v_bbox[BOXLEFT],  v_bbox[BOXBOTTOM], h,
-				               v_bbox[BOXRIGHT], v_bbox[BOXTOP],    h,
+							   v_bbox[BOXRIGHT], v_bbox[BOXTOP],    h,
 							   DLIT_Plane, &data);
 
 		P_SectorGlowIterator(cur_sub->sector,
-				             v_bbox[BOXLEFT],  v_bbox[BOXBOTTOM], h,
-				             v_bbox[BOXRIGHT], v_bbox[BOXTOP],    h,
+							 v_bbox[BOXLEFT],  v_bbox[BOXBOTTOM], h,
+							 v_bbox[BOXRIGHT], v_bbox[BOXTOP],    h,
 							 GLOWLIT_Plane, &data);
 	}
 
@@ -3454,7 +3454,7 @@ static void InitCamera(mobj_t *mo, bool full_height, float expand_w)
 
 
 void R_Render(int x, int y, int w, int h, mobj_t *camera,
-              bool full_height, float expand_w)
+			  bool full_height, float expand_w)
 {
 	viewwindow_x = x;
 	viewwindow_y = y;

--- a/source_files/edge/r_shader.cc
+++ b/source_files/edge/r_shader.cc
@@ -350,8 +350,8 @@ public:
 
 
 			local_gl_vert_t *glvert = RGL_BeginUnit(shape, num_vert,
-						(is_additive && masked) ? ENV_SKIP_RGB :
-						 is_additive ? ENV_NONE : GL_MODULATE,
+						(is_additive && masked) ? (GLuint) ENV_SKIP_RGB :
+						 is_additive ? (GLuint) ENV_NONE : GL_MODULATE,
 						(is_additive && !masked) ? 0 : tex,
 						GL_MODULATE, lim[DL]->tex_id(),
 						*pass_var, blending, *pass_var > 0 ? RGB_NO_VALUE : mo->subsector->sector->props.fog_color,
@@ -547,8 +547,8 @@ public:
 
 
 			local_gl_vert_t *glvert = RGL_BeginUnit(shape, num_vert,
-						(is_additive && masked) ? ENV_SKIP_RGB :
-						 is_additive ? ENV_NONE : GL_MODULATE,
+						(is_additive && masked) ? (GLuint) ENV_SKIP_RGB :
+						 is_additive ? (GLuint) ENV_NONE : GL_MODULATE,
 						(is_additive && !masked) ? 0 : tex,
 						GL_MODULATE, lim[DL]->tex_id(),
 						*pass_var, blending, *pass_var > 0 ? RGB_NO_VALUE : mo->subsector->sector->props.fog_color,
@@ -724,8 +724,8 @@ public:
 
 
 			local_gl_vert_t *glvert = RGL_BeginUnit(shape, num_vert,
-						(is_additive && masked) ? ENV_SKIP_RGB :
-						 is_additive ? ENV_NONE : GL_MODULATE,
+						(is_additive && masked) ? (GLuint) ENV_SKIP_RGB :
+						 is_additive ? (GLuint) ENV_NONE : GL_MODULATE,
 						(is_additive && !masked) ? 0 : tex,
 						GL_MODULATE, lim[DL]->tex_id(),
 						*pass_var, blending, *pass_var > 0 ? RGB_NO_VALUE : mo->subsector->sector->props.fog_color,

--- a/source_files/edge/r_things.cc
+++ b/source_files/edge/r_things.cc
@@ -387,8 +387,8 @@ static void RGL_DrawPSprite(pspdef_t * psp, int which,
 		GLuint fuzz_tex = is_fuzzy ? W_ImageCache(fuzz_image, false) : 0;
 
 		local_gl_vert_t * glvert = RGL_BeginUnit(GL_POLYGON, 4,
-				 is_additive ? ENV_SKIP_RGB : GL_MODULATE, tex_id,
-				 is_fuzzy ? GL_MODULATE : ENV_NONE, fuzz_tex,
+				 is_additive ? (GLuint) ENV_SKIP_RGB : GL_MODULATE, tex_id,
+				 is_fuzzy ? GL_MODULATE : (GLuint) ENV_NONE, fuzz_tex,
 				 pass, blending, pass > 0 ? RGB_NO_VALUE : fc_to_use,
 				 fd_to_use);
 
@@ -1518,8 +1518,8 @@ void RGL_DrawThing(drawfloor_t *dfloor, drawthing_t *dthing)
 		GLuint fuzz_tex = is_fuzzy ? W_ImageCache(fuzz_image, false) : 0;
 
 		local_gl_vert_t * glvert = RGL_BeginUnit(GL_POLYGON, 4,
-				 is_additive ? ENV_SKIP_RGB : GL_MODULATE, tex_id,
-				 is_fuzzy ? GL_MODULATE : ENV_NONE, fuzz_tex,
+				 is_additive ? (GLuint) ENV_SKIP_RGB : GL_MODULATE, tex_id,
+				 is_fuzzy ? GL_MODULATE : (GLuint) ENV_NONE, fuzz_tex,
 				 pass, blending, pass > 0 ? RGB_NO_VALUE : fc_to_use,
 				 fd_to_use);
 

--- a/source_files/edge/s_prime.cc
+++ b/source_files/edge/s_prime.cc
@@ -68,7 +68,7 @@ bool S_StartupPrime(void)
 
 	// Check for presence of previous CVAR value's file
 	bool cvar_good = false;
-	for (int i=0; i < available_soundfonts.size(); i++)
+	for (size_t i=0; i < available_soundfonts.size(); i++)
 	{
 		if(epi::case_cmp(s_soundfont.s, available_soundfonts.at(i).generic_u8string()) == 0)
 		{

--- a/source_files/edge/w_epk.cc
+++ b/source_files/edge/w_epk.cc
@@ -414,7 +414,7 @@ static pack_file_c * ProcessZip(data_file_c *df)
 			case MZ_ZIP_FILE_READ_FAILED:
 			case MZ_ZIP_FILE_SEEK_FAILED:
 				I_Error("Failed to open EPK file: %s\n", df->name.u8string().c_str());
-
+				break;	
 			default:
 				I_Error("Not a EPK file (or is corrupted): %s\n", df->name.u8string().c_str());
 		}
@@ -639,9 +639,9 @@ static void ProcessDDFInPack(pack_file_c *pack)
 	if (bare_filename.empty())
 		bare_filename = df->name.string();
 
-	for (int dir=0; dir < pack->dirs.size(); dir++)
+	for (size_t dir=0; dir < pack->dirs.size(); dir++)
 	{
-		for (int entry=0; entry < pack->dirs[dir].entries.size(); entry++)
+		for (size_t entry=0; entry < pack->dirs[dir].entries.size(); entry++)
 		{
 			pack_entry_c& ent = pack->dirs[dir].entries[entry];
 
@@ -693,9 +693,9 @@ static void ProcessCoalAPIInPack(pack_file_c *pack)
 	source += " in ";
 	source += bare_filename;
 
-	for (int dir=0; dir < pack->dirs.size(); dir++)
+	for (size_t dir=0; dir < pack->dirs.size(); dir++)
 	{
-		for (int entry=0; entry < pack->dirs[dir].entries.size(); entry++)
+		for (size_t entry=0; entry < pack->dirs[dir].entries.size(); entry++)
 		{
 			pack_entry_c& ent = pack->dirs[dir].entries[entry];
 			if (epi::PATH_GetFilename(ent.name) == "COAL_API.EC" || epi::PATH_GetBasename(ent.name) == "COALAPI")
@@ -724,9 +724,9 @@ static void ProcessCoalHUDInPack(pack_file_c *pack)
 	source += " in ";
 	source += bare_filename;
 
-	for (int dir=0; dir < pack->dirs.size(); dir++)
+	for (size_t dir=0; dir < pack->dirs.size(); dir++)
 	{
-		for (int entry=0; entry < pack->dirs[dir].entries.size(); entry++)
+		for (size_t entry=0; entry < pack->dirs[dir].entries.size(); entry++)
 		{
 			pack_entry_c& ent = pack->dirs[dir].entries[entry];
 			if (epi::PATH_GetFilename(ent.name) == "COAL_HUD.EC" || epi::PATH_GetBasename(ent.name) == "COALHUDS")
@@ -769,7 +769,7 @@ void Pack_ProcessSubstitutions(pack_file_c *pack, int pack_index)
 				bool add_it = true;
 
 				// Check DDFIMAGE definitions to see if this is replacing a lump type def
-				for (size_t j = 0; j < imagedefs.GetSize(); j++)
+				for (int j = 0; j < imagedefs.GetSize(); j++)
 				{
 					imagedef_c *img = imagedefs[j];
 					if (img->type == IMGDT_Lump && epi::case_cmp(img->info, texname) == 0 && 
@@ -813,7 +813,7 @@ void Pack_ProcessSubstitutions(pack_file_c *pack, int pack_index)
 		for (size_t i = 0 ; i < pack->dirs[d].entries.size() ; i++)
 		{
 			pack_entry_c& entry = pack->dirs[d].entries[i];
-			for (size_t j = 0; j < sfxdefs.GetSize(); j++)
+			for (int j = 0; j < sfxdefs.GetSize(); j++)
 			{
 				sfxdef_c *sfx = sfxdefs[j];
 				// Assume that same stem name is meant to replace an identically named lump entry
@@ -835,7 +835,7 @@ void Pack_ProcessSubstitutions(pack_file_c *pack, int pack_index)
 		for (size_t i = 0 ; i < pack->dirs[d].entries.size() ; i++)
 		{
 			pack_entry_c& entry = pack->dirs[d].entries[i];
-			for (size_t j = 0; j < playlist.GetSize(); j++)
+			for (int j = 0; j < playlist.GetSize(); j++)
 			{
 				pl_entry_c *song = playlist[j];
 				if (epi::PATH_GetExtension(song->info).empty())
@@ -1070,7 +1070,7 @@ std::vector<std::string> Pack_GetSpriteList(pack_file_c *pack)
 				epi::STR_TextureNameFromFilename(texname, stem);
 
 				// Don't add things already defined in DDFIMAGE
-				for (size_t j = 0; j < imagedefs.GetSize(); j++)
+				for (int j = 0; j < imagedefs.GetSize(); j++)
 				{
 					imagedef_c *img = imagedefs[j];
 					if (epi::case_cmp(img->name, texname) == 0)

--- a/source_files/edge/w_files.cc
+++ b/source_files/edge/w_files.cc
@@ -363,7 +363,7 @@ byte *W_OpenPackOrLumpInMemory(const std::string& name, const std::vector<std::s
 
 void W_DoPackSubstitutions()
 {
-	for (int i=0; i < data_files.size(); i++)
+	for (size_t i=0; i < data_files.size(); i++)
 	{
 		if (data_files[i]->pack)
 			Pack_ProcessSubstitutions(data_files[i]->pack, i);

--- a/source_files/edge/w_sprite.cc
+++ b/source_files/edge/w_sprite.cc
@@ -314,11 +314,11 @@ static void FillSpriteFrames(int file)
 
 		int S = 0, L = 0;
 
-		for (S; S < sprite_map_len; S++)
+		for (; S < sprite_map_len; S++)
 		{
 			std::string sprname  = sprite_map[S]->name;
 			size_t spr_len = sprname.size();
-			for (L; L < lumpnum; L++)
+			for (; L < lumpnum; L++)
 			{
 				const char *lumpname = W_GetLumpName((*lumps)[L]);
 
@@ -353,13 +353,13 @@ static void FillSpriteFrames(int file)
 		{
 			std::sort(packsprites.begin(), packsprites.end());
 
-			int S = 0, L = 0;
+			size_t S = 0, L = 0;
 
-			for (S; S < sprite_map_len; S++)
+			for (; S < (size_t) sprite_map_len; S++)
 			{
 				std::string sprname  = sprite_map[S]->name;
 				size_t spr_len = sprname.size();
-				for (L; L < packsprites.size(); L++)
+				for (; L < packsprites.size(); L++)
 				{
 					std::string spritebase;
 					epi::STR_TextureNameFromFilename(spritebase, epi::PATH_GetBasename(packsprites[L]).string());
@@ -408,11 +408,11 @@ static void FillSpriteFramesUser()
 
 	int S = 0, L = 0;
 
-	for (S; S < sprite_map_len; S++)
+	for (; S < sprite_map_len; S++)
 	{
 		std::string sprname  = sprite_map[S]->name;
 		size_t spr_len = sprname.size();
-		for (L; L < img_num; L++)
+		for (; L < img_num; L++)
 		{
 			const char *img_name = W_ImageGetName(images[L]);
 

--- a/source_files/epi/CMakeLists.txt
+++ b/source_files/epi/CMakeLists.txt
@@ -38,6 +38,6 @@ if(MSVC OR WIN32_CLANG)
 endif()
 
 target_compile_options(edge_epi PRIVATE
-  $<$<CXX_COMPILER_ID:MSVC>:/W4>
-  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic>
+  $<$<CXX_COMPILER_ID:MSVC>:${EDGE_WARNINGS}>
+  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:${EDGE_WARNINGS}>
 )

--- a/source_files/epi/file_memory.cc
+++ b/source_files/epi/file_memory.cc
@@ -73,7 +73,7 @@ mem_file_c::~mem_file_c()
 unsigned int mem_file_c::Read(void *dest, unsigned int size)
 {
 	SYS_ASSERT(dest);
-	SYS_ASSERT(size >= 0);
+	SYS_ASSERT((int)size >= 0);
 		
 	unsigned int avail = length - pos;
 

--- a/source_files/epi/file_memory.cc
+++ b/source_files/epi/file_memory.cc
@@ -73,7 +73,6 @@ mem_file_c::~mem_file_c()
 unsigned int mem_file_c::Read(void *dest, unsigned int size)
 {
 	SYS_ASSERT(dest);
-	SYS_ASSERT((int)size >= 0);
 		
 	unsigned int avail = length - pos;
 

--- a/source_files/epi/image_funcs.cc
+++ b/source_files/epi/image_funcs.cc
@@ -240,9 +240,15 @@ image_atlas_c *Image_Pack(const std::vector<image_data_c *> &im_pack_data)
 		rects[i].w = im_pack_data[i]->width;
 		rects[i].h = im_pack_data[i]->height;
 		if (rects[i].w > atlas_w)
-			atlas_w = 1; while (atlas_w < (int)rects[i].w)  atlas_w <<= 1;
+		{
+			atlas_w = 1; 
+			while (atlas_w < (int)rects[i].w)  atlas_w <<= 1;
+		}
 		if (rects[i].h > atlas_h)
-			atlas_h = 1; while (atlas_h < (int)rects[i].h)  atlas_h <<= 1;
+		{
+			atlas_h = 1; 
+			while (atlas_h < (int)rects[i].h)  atlas_h <<= 1;
+		}			
 	}
 	if (atlas_h < atlas_w)
 		atlas_h = atlas_w;
@@ -265,9 +271,9 @@ image_atlas_c *Image_Pack(const std::vector<image_data_c *> &im_pack_data)
 	{
 		int rect_x = rects[i].x;
 		int rect_y = rects[i].y;
-		for (size_t x = 0; x < im_pack_data[i]->width; x++)
+		for (short x = 0; x < im_pack_data[i]->width; x++)
 		{
-			for (size_t y = 0; y < im_pack_data[i]->height; y++)
+			for (short y = 0; y < im_pack_data[i]->height; y++)
 			{
 				memcpy(atlas->data->PixelAt(rect_x + x, rect_y + y), im_pack_data[i]->PixelAt(x, y), 4);
 			}

--- a/source_files/epi/midi_sequencer_impl.hpp
+++ b/source_files/epi/midi_sequencer_impl.hpp
@@ -2426,7 +2426,7 @@ bool BW_MidiSequencer::parseIMF(epi::mem_file_c *mfr, uint16_t rate)
     if(imfEnd == 0) // IMF Type 0 with unlimited file length
         imfEnd = mfr->GetLength();
 
-    while(mfr->GetPosition() < imfEnd)
+    while(mfr->GetPosition() < (int) imfEnd)
     {
         if(mfr->Read(imfRaw, 4) != 4)
             break;

--- a/source_files/miniz/miniz.c
+++ b/source_files/miniz/miniz.c
@@ -3182,7 +3182,7 @@ static int mz_stat64(const char *path, struct __stat64 *buffer)
 #define MZ_DELETE_FILE remove
 
 #else
-#pragma message("Using fopen, ftello, fseeko, stat() etc. path for file I/O - this path may not support large files.")
+//#pragma message("Using fopen, ftello, fseeko, stat() etc. path for file I/O - this path may not support large files.")
 #ifndef MINIZ_NO_TIME
 #include <utime.h>
 #endif


### PR DESCRIPTION
This fixes warnings under GCC, putting dependency headers under SYSTEM so that warnings are not surfaced for these, also adds configurable warning settings for EDGE specific sources.  There was some mixed tabs/spaces that were also causing issues specifically with misleading conditionals, thus the whitespace fixes

I disabled these, though should circle back on them, and perhaps opt in for some dependencies: 

` -Wno-unused-parameter -Wno-missing-field-initializers -Wno-stringop-truncation -Wno-stringop-overflow`

There are a few warnings left for void* deletes and switch fallthrus, which talked about in Discord. Overall not bad at all, and now can see legit things we should fix not masked with 1K+ lines of warning spam