### PR TITLE
Bugfix: SKULLFLY zero damage causes pain

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -42,3 +42,4 @@ Bugs fixed
 - Removed sector fog color check that was causing the HOM debugging texture to appear even with debug_hom set to 0
 - Fixed A_CloseShotgun2 frame only playing the DBCLS sound and not calling A_Refire as well
 - Fixed custom Dehacked weapons that use the chainsaw attack not playing the SAWFUL sfx when attacking (regardless of hitting a target)
+- SKULLFLY attacks that cause zero damage no longer make victim enter painstate

--- a/source_files/edge/p_action.cc
+++ b/source_files/edge/p_action.cc
@@ -2421,7 +2421,8 @@ void P_SlammedIntoObject(mobj_t *object, mobj_t *target)
 
                 DAMAGE_COMPUTE(damage, &object->currentattack->damage);
 
-                P_DamageMobj(target, object, object, damage, &object->currentattack->damage);
+                if (damage)
+                    P_DamageMobj(target, object, object, damage, &object->currentattack->damage);
             }
         }
 


### PR DESCRIPTION
SKULLFLY attacks that cause zero damage no longer make victim enter painstate. Bullet and missile behaviour seems consistent with this so did the same for skullfly attacks.