### PR TITLE
BUGFIX: several new linetypes incorrectly defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,4 @@ General Improvements/Changes
 Bugs fixed
 ----------
 - Fixed sector fogwall check producing black 0% alpha fog walls for otherwise unfogged sectors
+- Fixed Autoscale texture linetypes(855,856,857) and Brightwall(850) being USEable (repeatedly) by the player.

--- a/edge_defs/scripts/lines.ddf
+++ b/edge_defs/scripts/lines.ddf
@@ -4441,33 +4441,25 @@ GLASS=TRUE;
 //3. Any other lines with the same tag will use this brightness 
 // even if the rest of the sector is pitch black.
 [850] // Bright wall 
-TYPE=PUSH;
 AUTO=TRUE;
-ACTIVATORS=PLAYER;
 LINE_EFFECT=LIGHT_WALL;
 LINE_PARTS=LEFT,RIGHT;
 
 [855] // autoscale texture to line length: stretch width 
-TYPE=PUSH;
 AUTO=TRUE;
-ACTIVATORS=PLAYER;
 LINE_EFFECT=STRETCH_TEX_WIDTH;
 LINE_PARTS=LEFT,RIGHT;
 // LEFT, LEFT_LOWER, LEFT_MIDDLE, LEFT_UPPER
 // RIGHT, RIGHT_LOWER, RIGHT_MIDDLE, RIGHT_UPPER
 
 [856] // autoscale texture to line length: stretch height 
-TYPE=PUSH;
 AUTO=TRUE;
-ACTIVATORS=PLAYER;
 LINE_EFFECT=STRETCH_TEX_HEIGHT;
 LINE_PARTS=LEFT,RIGHT;
 
 
 [857] // autoscale texture to line length: stretch width and height 
-TYPE=PUSH;
 AUTO=TRUE;
-ACTIVATORS=PLAYER;
 LINE_EFFECT=STRETCH_TEX_WIDTH,STRETCH_TEX_HEIGHT;
 LINE_PARTS=LEFT,RIGHT;
 


### PR DESCRIPTION
Fixed Autoscale texture linetypes(855,856,857) and Brightwall(850) being USEable (repeatedly) by the player.