### PR TITLE
Bugfix: hud.get_image_width() and hud.get_image_height()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,3 +53,4 @@ Bugs fixed
 - Fixed Dehacked code pointer entries with trailing spaces not matching defined actions
 - Fixed frames with a valid '0' rotation sprite still using other rotations if found elsewhere in the load order
 - Fixed UDMF 'ypanningfloor' and 'ypanningceiling' using inverted values.
+- Fixed COAL/Lua functions hud.get_image_width() and hud.get_image_height() not returning 0 if image does not exist.

--- a/source_files/edge/script/compat/lua_hud.cc
+++ b/source_files/edge/script/compat/lua_hud.cc
@@ -972,7 +972,7 @@ static int HD_get_image_width(lua_State *L)
 {
     const char *name = luaL_checkstring(L, 1);
 
-    const Image *img = ImageLookup(name, kImageNamespaceGraphic);
+    const Image *img = ImageLookup(name, kImageNamespaceGraphic, kImageLookupNull);
 
     if (img)
     {
@@ -992,7 +992,7 @@ static int HD_get_image_height(lua_State *L)
 {
     const char *name = luaL_checkstring(L, 1);
 
-    const Image *img = ImageLookup(name, kImageNamespaceGraphic);
+    const Image *img = ImageLookup(name, kImageNamespaceGraphic, kImageLookupNull);
 
     if (img)
     {

--- a/source_files/edge/vm_hud.cc
+++ b/source_files/edge/vm_hud.cc
@@ -1021,7 +1021,7 @@ static void HD_get_image_width(coal::VM *vm, int argc)
     (void)argc;
     const char *name = vm->AccessParamString(0);
 
-    const Image *img = ImageLookup(name, kImageNamespaceGraphic);
+    const Image *img = ImageLookup(name, kImageNamespaceGraphic, kImageLookupNull);
 
     if (img)
     {
@@ -1040,7 +1040,7 @@ static void HD_get_image_height(coal::VM *vm, int argc)
     (void)argc;
     const char *name = vm->AccessParamString(0);
 
-    const Image *img = ImageLookup(name, kImageNamespaceGraphic);
+    const Image *img = ImageLookup(name, kImageNamespaceGraphic, kImageLookupNull);
 
     if (img)
     {


### PR DESCRIPTION
Fixed COAL/Lua functions hud.get_image_width() and hud.get_image_height() never returning 0 if image does not exist. They were instead always returning the dummy image size if the requested image did not exist.