### PR TITLE
Some minor CQ1 tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Bugfixes and detailed changes can be found in CHANGELOG.txt
 
 - The Ultimate Doom/Doom 1/Freedoom Phase 1
 - Doom 2/Freedoom Phase 2
+- Chex Quest 1
 - Chex Quest 3: Vanilla Edition
 - Heretic/Blasphemer
 - HacX 1.2

--- a/edge_base/chex1/scripts/language.ldf
+++ b/edge_base/chex1/scripts/language.ldf
@@ -141,8 +141,31 @@ Shareware = "this is Chex(R) Quest. look for\n"
   "press a key.";
 ZombiemanName = "FLEMOIDUS COMMONUS";
 ShotgunGuyName = "FLEMOIDUS BIPEDICUS";
-DemonName = "FLEMOIDUS BIPEDICUS WITH ARMOR";
+DemonName = "FLEMOIDUS CYCLOPTIS";
+ImpName = "FLEMOIDUS BIPEDICUS WITH ARMOR";
 BaronOfHellName = "THE FLEMBRANE";
+
+OB_SECTOR   = "%o sinks into some slime.";
+OB_SUICIDE  = "%o prefers the flemoid dimension.";
+OB_LAVA     = "%o got stuck in quick-slime.";
+
+OB_Baron      = "%o was defeated by the Flembrane.";
+OB_BaronClaw  = "%o was defeated by the Flembrane.";
+OB_Demon      = "%o was slimed by a cycloptis.";
+OB_Dog        = "%o was gooed by a friendly larva.";
+OB_Imp        = "%o was slimed by an armored bipedicus.";
+OB_ImpClaw    = "%o was slimed by an armored bipedicus.";
+OB_ShotgunGuy = "%o was slimed by a bipedicus.";
+OB_Zombie     = "%o was slimed by a flemoid.";
+
+OB_Chaingun  = "%o was rapid zorched by %k.";
+OB_Pistol    = "%o was hit by %k's mini-zorcher.";
+OB_Missile   = "%o was zorched by %k's propulsor.";
+OB_Plasma    = "%o was phase zorched by %k.";
+OB_Punch     = "%o was spoon fed by %k.";
+OB_Saw       = "%o was thouroughly mixed with %k's bootspork.";
+OB_Shotgun   = "%o was hit by %k's large-zorcher.";
+OB_BFG       = "%o fell prey to %k's LAZ device.";
 
 idbehold5 = "digitalcafe";
 idbehold3 = "marybregi";


### PR DESCRIPTION
- Add mention of Chex Quest 1 back to the README, since support for it was restored.
- Fix an error where the Cycloptis is mistakenly labeled as a "Flemoidus Bipedicus with Armor" in the cast call strings, and add the proper string for the Armored Bipedicus.
- Add proper obituaries for Chex Quest 1. These strings originate from ZDoom and are still used in GZDoom, by the way. I don't know if they need to be changed to more original ones.