### PR TITLE
Weapon tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ General Improvements/Changes
   - Remove support for absolute paths and path traversal with '..' for the exec, ls/dir, and cat/type console commands
   - Remove support for path traversal with '..' when searching for or opening pack files
   - FIRST and LAST fields in anims.ddf now work with TX textures
+  - Autoswitch to a new weapon even if the clip is not full
 
 
 Bugs fixed

--- a/source_files/edge/p_user.cc
+++ b/source_files/edge/p_user.cc
@@ -1110,12 +1110,14 @@ bool AddWeapon(Player *player, WeaponDefinition *info, int *index)
     player->weapons_[slot].flags        = kPlayerWeaponNoFlag;
     player->weapons_[slot].clip_size[0] = 0;
     player->weapons_[slot].clip_size[1] = 0;
+    player->weapons_[slot].clip_size[2] = 0;
+    player->weapons_[slot].clip_size[3] = 0;
     player->weapons_[slot].model_skin   = info->model_skin_;
 
     UpdateAvailWeapons(player);
 
     // for NoAmmo+Clip weapons, always begin with a full clip
-    for (int ATK = 0; ATK < 2; ATK++)
+    for (int ATK = 0; ATK < 4; ATK++)
     {
         if (info->clip_size_[ATK] > 0 && info->ammo_[ATK] == kAmmunitionTypeNoAmmo)
             player->weapons_[slot].clip_size[ATK] = info->clip_size_[ATK];

--- a/source_files/edge/p_weapon.cc
+++ b/source_files/edge/p_weapon.cc
@@ -755,11 +755,17 @@ bool TryFillNewWeapon(Player *p, int idx, AmmunitionType ammo, int *qty)
 
         EPI_ASSERT(qty);
 
+        // New weapon has at least a full clip and (maybe) a bit extra
         if (info->clip_size_[ATK] <= *qty)
         {
             p->weapons_[idx].clip_size[ATK] = info->clip_size_[ATK];
             *qty -= info->clip_size_[ATK];
-
+            result = true;
+        }
+        else //New weapon has only a partially full clip
+        {
+            p->weapons_[idx].clip_size[ATK] = *qty;
+            *qty = 0;
             result = true;
         }
     }


### PR DESCRIPTION
- Autoswitch to a new weapon even if the clip is not full.
- Missing the 3rd and 4th clip defaults being applied when getting a weapon.