### PR TITLE
Things.ddf: new Special flag: TRIGGER_TELEPORTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ New Features
 - UDMF: Sector 'alphafloor' and 'alphaceiling' fields now supported; governs translucency of associated planes
 - GAMES.DDF: New command 
 	- DEFAULT_DAMAGE_FLASH = (hex) which will set damage flashes from all sources to this color unless specified otherwise in an individual DDFATK entry.
+- THINGS.DDF: 
+  - New Special flag: TRIGGER_TELEPORTS which will allow this thing to use teleports even if NO_TRIGGER_LINES is set. i.e. you want a dog that cannot open a door, but can teleport for example.
 
 
 

--- a/source_files/ddf/ddf_thing.cc
+++ b/source_files/ddf/ddf_thing.cc
@@ -1552,6 +1552,7 @@ static DDFSpecialFlags hyper_specials[] = {
     {"DEHACKED_COMPAT", kHyperFlagDehackedCompatibility, 0},
     {"IMMOVABLE", kHyperFlagImmovable, 0},
     {"MUSIC_CHANGER", kHyperFlagMusicChanger, 0},
+    {"TRIGGER_TELEPORTS", kHyperFlagTriggerTeleports, 0}, // Lobo: Can always activate teleporters.
     {nullptr, 0, 0}};
 
 static DDFSpecialFlags mbf21_specials[] = {{"LOGRAV", kMBF21FlagLowGravity, 0}, {nullptr, 0, 0}};

--- a/source_files/ddf/ddf_thing.h
+++ b/source_files/ddf/ddf_thing.h
@@ -234,6 +234,8 @@ enum HyperFlag
     // This flag is present because we cannot assume a thing is a
     // music changer just because it has an ID of 14100-14164
     kHyperFlagMusicChanger = (1 << 23),
+    // -Lobo- 2024/07/17: this thing can trigger teleports even if NO_TRIGGER_LINES is set
+    kHyperFlagTriggerTeleports = (1 << 24),
 };
 
 // MBF21 flags not already covered by extended/hyper flags

--- a/source_files/edge/p_spec.cc
+++ b/source_files/edge/p_spec.cc
@@ -1322,10 +1322,23 @@ static bool P_ActivateSpecialLine(Line *line, const LineType *special, int tag, 
             // Monsters don't trigger secrets
             if (line && (line->flags & kLineFlagSecret))
                 return false;
-
+            
             // Monster is not allowed to trigger lines
             if (thing->info_->hyper_flags_ & kHyperFlagNoTriggerLines)
-                return false;
+            {
+                //Except maybe teleporters
+                if (special->t_.teleport_)
+                {
+                    if (!(thing->info_->hyper_flags_ & kHyperFlagTriggerTeleports))
+                    {
+                        return false;  
+                    }
+                }
+                else
+                {
+                     return false;         
+                }
+            }
         }
         else
         {


### PR DESCRIPTION
Will allow this thing to use teleports even if NO_TRIGGER_LINES is set. i.e. you want a dog that cannot open a door, but can teleport for example ;)