### PR TITLE
Fixed multiple RTS scripts with the same tag.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,3 +63,5 @@ Bugs fixed
 - Fixed frames with a valid '0' rotation sprite still using other rotations if found elsewhere in the load order
 - Fixed UDMF 'ypanningfloor' and 'ypanningceiling' using inverted values.
 - Fixed COAL/Lua functions hud.get_image_width() and hud.get_image_height() not returning 0 if image does not exist.
+- Fixed multiple RTS scripts with the same tag not running simultaneously: we were only running the first one basically.
+

--- a/source_files/edge/rad_trig.cc
+++ b/source_files/edge/rad_trig.cc
@@ -896,7 +896,7 @@ void SpawnScriptTriggers(const char *map_name)
         trig->tip_slot     = 0;
         trig->wud_tag = trig->wud_count = 0;
 
-    //Lobo 2024: removed GroupTriggerTags(9) since we are not actually using it right now.
+    //Lobo 2024: removed call to GroupTriggerTags() since we are not actually using it right now.
     // Left the code for posterity just in case we need it again.
         //GroupTriggerTags(trig);
 

--- a/source_files/edge/rad_trig.cc
+++ b/source_files/edge/rad_trig.cc
@@ -896,7 +896,9 @@ void SpawnScriptTriggers(const char *map_name)
         trig->tip_slot     = 0;
         trig->wud_tag = trig->wud_count = 0;
 
-        GroupTriggerTags(trig);
+    //Lobo 2024: removed GroupTriggerTags(9) since we are not actually using it right now.
+    // Left the code for posterity just in case we need it again.
+        //GroupTriggerTags(trig);
 
         // initialise state machine
         trig->state     = scr->first_state;


### PR DESCRIPTION
Fixed multiple RTS scripts with the same tag not running simultaneously: we were only running the first one basically.
Now we no longer use linked list lookups, but instead just run through all scripts as the overhead is neglible and the old way was prone to issues.