### PR TITLE
New STYLES.DDF dropshadow effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,24 +3,28 @@ CHANGELOG for EDGE-Classic 1.38 (since EDGE-Classic 1.37)
 
 New Features
 ------------
-- COALHUDS/LUAHUDS: New commands 
++ COALHUDS/LUAHUDS: New commands 
 	- hud.lookup_LDF(languageEntry) which will return the language.ldf entry
 	- hud.game_skill() which will return a number from 0 to 4 reflecting the current game skill
 	- hud.get_text_width(string,size) will return the width in pixels of the given string, taking into account the current font
-- LUAHUDS-specific commands:
++ LUAHUDS-specific commands:
   - Several functions which will return a table containing useful information:
     - game.info()
     - map.info()
     - sector.info()
-- UDMF: Linedef 'alpha' field now supported; governs translucency of associated sidedef surfaces
-- UDMF: Sector 'alphafloor' and 'alphaceiling' fields now supported; governs translucency of associated planes
-- GAMES.DDF: New command 
++ UDMF: Linedef 'alpha' field now supported; governs translucency of associated sidedef surfaces
++ UDMF: Sector 'alphafloor' and 'alphaceiling' fields now supported; governs translucency of associated planes
++ GAMES.DDF: New command 
 	- DEFAULT_DAMAGE_FLASH = (hex) which will set damage flashes from all sources to this color unless specified otherwise in an individual DDFATK entry.
-- THINGS.DDF: 
++ THINGS.DDF: 
   - New Special flag: TRIGGER_TELEPORTS which will allow this thing to use teleports even if NO_TRIGGER_LINES is set. i.e. you want a dog that cannot open a door, but can teleport for example.
-- New CVARs/params:
++ New CVARs/params:
   - "use_menu_backdrop" which governs the use of the auto-generated monochrome backdrop for option menus
   - "fliplevels" allows you to play a mirrored version of the map. All textures will also be mirrored.
++ STYLES.DDF: able to add a dropshadow effect to TEXT, ALT, TITLE, HELP, HEADER or SELECTED strings via 2 new sub-commands
+  - .DROPSHADOW_COLOURMAP = [colourmap];  //"TEXT_BLACK" colmap generally looks good with everything
+  - .DROPSHADOW_OFFSET = [float]; //smaller values like 1 or 2 are best
+
 
 
 General Improvements/Changes

--- a/edge_defs/scripts/colmap.ddf
+++ b/edge_defs/scripts/colmap.ddf
@@ -110,6 +110,9 @@ gl_colour = #FF2222;
 [TEXT_WHITE]
 gl_colour = #FFFFFF;
 
+[TEXT_BLACK]
+gl_colour = #111111;
+
 [TEXT_GREY]
 gl_colour = #AAAAAA;
 

--- a/source_files/ddf/ddf_style.cc
+++ b/source_files/ddf/ddf_style.cc
@@ -52,6 +52,8 @@ static const DDFCommandList text_commands[] = {
     DDF_FIELD("ASPECT", dummy_textstyle, aspect_, DDFMainGetFloat),
     DDF_FIELD("X_OFFSET", dummy_textstyle, x_offset_, DDFMainGetNumeric),
     DDF_FIELD("Y_OFFSET", dummy_textstyle, y_offset_, DDFMainGetNumeric),
+    DDF_FIELD("DROPSHADOW_COLOURMAP", dummy_textstyle, dropshadow_colmap_, DDFMainGetColourmap),
+    DDF_FIELD("DROPSHADOW_OFFSET", dummy_textstyle, dropshadow_offset_, DDFMainGetFloat),
 
     {nullptr, nullptr, 0, nullptr}};
 
@@ -349,6 +351,8 @@ void TextStyle::Default()
     aspect_   = 1.0f;
     x_offset_ = 0;
     y_offset_ = 0;
+    dropshadow_colmap_       = nullptr;
+    dropshadow_offset_ = 1.0f;
 }
 
 //
@@ -366,6 +370,8 @@ TextStyle &TextStyle::operator=(const TextStyle &rhs)
         aspect_   = rhs.aspect_;
         x_offset_ = rhs.x_offset_;
         y_offset_ = rhs.y_offset_;
+        dropshadow_colmap_       = rhs.dropshadow_colmap_;
+        dropshadow_offset_ = rhs.dropshadow_offset_;
     }
 
     return *this;

--- a/source_files/ddf/ddf_style.h
+++ b/source_files/ddf/ddf_style.h
@@ -65,6 +65,10 @@ class TextStyle
     float aspect_;
     int   x_offset_;
     int   y_offset_;
+
+    const Colormap *dropshadow_colmap_;
+    float   dropshadow_offset_;
+
 };
 
 class CursorStyle

--- a/source_files/edge/hu_style.cc
+++ b/source_files/edge/hu_style.cc
@@ -162,8 +162,18 @@ void HUDWriteText(Style *style, int text_type, int x, int y, const char *str, fl
     HUDSetFont(style->fonts_[text_type]);
     HUDSetScale(scale * style->definition_->text_[text_type].scale_);
 
-    const Colormap *colmap = style->definition_->text_[text_type].colmap_;
+    const Colormap *Dropshadow_colmap = style->definition_->text_[text_type].dropshadow_colmap_;
+    if (Dropshadow_colmap) //we want a dropshadow
+    {
+        float Dropshadow_Offset = style->definition_->text_[text_type].dropshadow_offset_;
+        Dropshadow_Offset *= style->definition_->text_[text_type].scale_ * scale;
 
+        HUDSetTextColor(GetFontColor(Dropshadow_colmap));
+        HUDDrawText(x + Dropshadow_Offset, y + Dropshadow_Offset, str);
+    }
+
+    HUDSetTextColor(); //set it back to normal just in case
+    const Colormap *colmap = style->definition_->text_[text_type].colmap_;
     if (colmap)
         HUDSetTextColor(GetFontColor(colmap));
 
@@ -172,6 +182,7 @@ void HUDWriteText(Style *style, int text_type, int x, int y, const char *str, fl
     HUDSetFont();
     HUDSetScale();
     HUDSetTextColor();
+
 }
 
 //--- editor settings ---


### PR DESCRIPTION
STYLES.DDF: able to add a dropshadow effect to TEXT, ALT, TITLE, HELP, HEADER or SELECTED strings via 2 new sub-commands
- .DROPSHADOW_COLOURMAP = [colourmap];
- .DROPSHADOW_OFFSET = [float];