### PR TITLE
New DDF action: SET_SCALE(float)

### DIFF
--- a/source_files/ddf/ddf_thing.cc
+++ b/source_files/ddf/ddf_thing.cc
@@ -318,6 +318,8 @@ const DDFActionCode thing_actions[] = {{"NOTHING", nullptr, nullptr},
 									   {"CLEAR_TARGET", A_ClearTarget, nullptr},
                                        {"FRIEND_LOOKOUT", A_FriendLook, nullptr},
 
+                                       {"SET_SCALE", A_ScaleSet, DDFStateGetFloat},
+
                                        {"DROPITEM", A_DropItem, DDFStateGetMobj},
                                        {"SPAWN", A_Spawn, DDFStateGetMobj},
                                        {"TRANS_SET", A_TransSet, DDFStateGetPercent},

--- a/source_files/edge/p_action.cc
+++ b/source_files/edge/p_action.cc
@@ -5088,6 +5088,19 @@ void A_PainChanceSet(MapObject *mo)
     mo->pain_chance_ = value;
 }
 
+void A_ScaleSet(MapObject *mo)
+{
+    float value = mo->info_->scale_; //grab the default scale for this thing as a fallback
+
+    const State *st = mo->state_;
+
+    if (st && st->action_par)
+    {
+        value = ((float *)st->action_par)[0];
+    }
+    mo->scale_ = value;
+}
+
 void A_Gravity(MapObject *mo)
 {
     mo->flags_ &= ~kMapObjectFlagNoGravity; //Remove NoGravity flag

--- a/source_files/edge/p_action.h
+++ b/source_files/edge/p_action.h
@@ -200,6 +200,8 @@ void A_ClearInvuln(MapObject *mo);
 
 void A_PainChanceSet(MapObject *mo);
 
+void A_ScaleSet(MapObject *mo);
+
 void A_Gravity(MapObject *mo);
 void A_NoGravity(MapObject *mo);
 


### PR DESCRIPTION
Changes the objects visual scale. This does not affect the actual collision box and is mainly intended for special effects things, such as a puff of smoke gradually dissipating by expansion (in combination with TRANS_FADE) or  shrinking and disappearing.