### PR TITLE
Boom Line 242/Height Sector rendering fixes

### DIFF
--- a/source_files/edge/p_spec.cc
+++ b/source_files/edge/p_spec.cc
@@ -967,39 +967,10 @@ static void SectorEffect(Sector *target, Line *source, const LineType *special)
     {
         target->height_sector      = source->front_sector;
         target->height_sector_side = source->side[0];
-        // Quick band-aid fix for Line 242 "windows" - Dasho
-        if (target->ceiling_height - target->floor_height < 1)
+        for (int i = 0; i < target->line_count; i++)
         {
-            target->ceiling_height = source->front_sector->ceiling_height;
-            target->old_ceiling_height = source->front_sector->ceiling_height;
-            target->floor_height   = source->front_sector->floor_height;
-            target->old_floor_height = source->front_sector->floor_height;
-            for (int i = 0; i < target->line_count; i++)
-            {
-                if (target->lines[i]->side[1])
-                {
-                    target->lines[i]->blocked = false;
-                    if (target->lines[i]->side[0]->middle.image && target->lines[i]->side[1]->middle.image &&
-                        target->lines[i]->side[0]->middle.image == target->lines[i]->side[1]->middle.image)
-                    {
-                        target->lines[i]->side[0]->middle_mask_offset = 0;
-                        target->lines[i]->side[1]->middle_mask_offset = 0;
-                        for (Seg *seg = target->subsectors->segs; seg != nullptr; seg = seg->subsector_next)
-                        {
-                            if (seg->linedef == target->lines[i])
-                                seg->linedef->flags |= kLineFlagLowerUnpegged;
-                        }
-                    }
-                }
-            }
-        }
-        else
-        {
-            for (int i = 0; i < target->line_count; i++)
-            {
-                if (target->lines[i]->side[1])
-                    target->lines[i]->blocked = false;
-            }
+            if (target->lines[i]->side[1])
+                target->lines[i]->blocked = false;
         }
     }
 }

--- a/source_files/edge/r_misc.h
+++ b/source_files/edge/r_misc.h
@@ -34,12 +34,22 @@
 //
 // POV related.
 //
+// Used for Boom 242 height_sector checks
+enum ViewHeightZone
+{
+    kHeightZoneNone,
+    kHeightZoneA,
+    kHeightZoneB,
+    kHeightZoneC
+};
+
 extern float    view_cosine;
 extern float    view_sine;
 extern BAMAngle view_vertical_angle;
 
 extern Subsector        *view_subsector;
 extern RegionProperties *view_properties;
+extern ViewHeightZone    view_height_zone;
 
 extern int view_window_x;
 extern int view_window_y;


### PR DESCRIPTION
This fixes a lot of known rendering issues involving Boom Line 242. Tested against the following maps and (from what I can tell) behavior and appearance are in line with other Boom-compatible ports:
- BOOMEDIT (multiple locations)
- MBFEDIT! (invisible windows in the mushroom and point force test rooms)
- Ancient Aliens MAP29 (arches and "sky walkways")
- Pirate Doom 2 MAP05 (the "lattice bridges")
- PUSS31 MAP20 (the glass window in the front of the gas station)
- Firerainbow MAP01 (flat bleeding in combination with height sectors, the rainbows are now properly visible)