### PR TITLE
Fix MSVC warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,12 +33,20 @@ endif()
 
 if (MSVC)
 
-  # These are needed for MSVC to play ball as much as possible
-  # with the /EHs- flag
-  add_definitions("-D_HAS_EXCEPTIONS=0 -D_STATIC_CPPLIB")
-
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /fp:fast /EHs- /GR-")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /fp:fast /EHs- /GR-")
+  # Disable RTTI
+  string(FIND "${CMAKE_CXX_FLAGS}" "/GR" MSVC_HAS_GR)
+  if(MSVC_HAS_GR)
+      string(REGEX REPLACE "/GR" "/GR-" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+  else()
+      add_compile_options(/GR-)
+  endif()
+  
+  # Disable C++ Exceptions
+  string(REGEX REPLACE "/EHsc" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")    
+  add_compile_options(/D_HAS_EXCEPTIONS=0)
+  
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /fp:fast")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /fp:fast")
 
   if (NOT CLANG)
     # get the number of logical cores for parallel build

--- a/libraries/stb/stb_vorbis.h
+++ b/libraries/stb/stb_vorbis.h
@@ -76,6 +76,14 @@
 #ifndef STB_VORBIS_INCLUDE_STB_VORBIS_H
 #define STB_VORBIS_INCLUDE_STB_VORBIS_H
 
+// EDGE - Disable some finicky warnings from MSVC
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4456)
+#pragma warning(disable: 4457)
+#pragma warning(disable: 4701)
+#endif
+
 #if defined(STB_VORBIS_NO_CRT) && !defined(STB_VORBIS_NO_STDIO)
 #define STB_VORBIS_NO_STDIO 1
 #endif
@@ -5651,6 +5659,11 @@ int stb_vorbis_get_samples_float(stb_vorbis *f, int channels, float **buffer, in
     0.91 - conditional compiles to omit parts of the API and the infrastructure to support them: STB_VORBIS_NO_PULLDATA_API, STB_VORBIS_NO_PUSHDATA_API, STB_VORBIS_NO_STDIO, STB_VORBIS_NO_INTEGER_CONVERSION
     0.90 - first public release
 */
+
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #endif // STB_VORBIS_HEADER_ONLY
 

--- a/source_files/edge/f_finale.cc
+++ b/source_files/edge/f_finale.cc
@@ -302,7 +302,7 @@ void FinaleTicker(void)
             finale_count = (int)(strlen(finale_text) * finale->text_speed_);
             skip_finale  = false;
         }
-        else if (skip_finale || finale_count > finale->text_wait_ + (int)(strlen(finale_text) * finale->text_speed_))
+        else if (skip_finale || finale_count > (int) finale->text_wait_ + (int)(strlen(finale_text) * finale->text_speed_))
         {
             DoBumpFinale();
             skip_finale = false;

--- a/source_files/edge/p_action.cc
+++ b/source_files/edge/p_action.cc
@@ -4723,7 +4723,6 @@ void A_SeekTracer(MapObject *mo)
 
     int *args = (int *)mo->state_->action_par;
 
-    BAMAngle threshold = epi::BAMFromDegrees((float)args[0] / 65536.0f);
     BAMAngle maxturn = epi::BAMFromDegrees((float)args[1] / 65536.0f);
 
     // change angle

--- a/source_files/edge/w_epk.cc
+++ b/source_files/edge/w_epk.cc
@@ -779,7 +779,7 @@ class VWADFile : public epi::File
             return 0;
 
         // never read more than what GetLength() reports
-        if (count > length_ - position_)
+        if (count > (unsigned int) length_ - position_)
             count = length_ - position_;
 
         int got = vwad_read(pack_->vwad_archive_, vwad_file_descriptor_, dest, count);


### PR DESCRIPTION
This PR fixes the current warnings under MSVC.  The only thing not sure on is removing `-D_STATIC_CPPLIB`, as this was giving deprecated warnings from the STL here, and causing link failures.  It seemed to work fine without it.