### PR TITLE
Remove fliplevels/goobers cheats

### DIFF
--- a/source_files/edge/e_input.cc
+++ b/source_files/edge/e_input.cc
@@ -51,8 +51,6 @@ extern bool GameResponder(InputEvent *ev);
 
 extern int JoystickGetAxis(int n);
 
-extern ConsoleVariable fliplevels;
-
 //
 // EVENT HANDLING
 //
@@ -340,10 +338,7 @@ void BuildEventTicCommand(EventTicCommand *cmd)
         // -ACB- 1998/09/06 Angle Turn Speed Control
         turn += angle_turn[t_speed] * ball_deltas[kAxisTurn] / 64.0;
 
-        if (fliplevels.d_)
-            cmd->angle_turn = -RoundToInteger(turn);
-        else
-            cmd->angle_turn = RoundToInteger(turn);
+        cmd->angle_turn = RoundToInteger(turn);
     }
 
     // MLook
@@ -389,10 +384,7 @@ void BuildEventTicCommand(EventTicCommand *cmd)
 
         side = HMM_Clamp(-forward_move[1], side, forward_move[1]);
 
-        if (fliplevels.d_)
-            cmd->side_move = -RoundToInteger(side);
-        else
-            cmd->side_move = RoundToInteger(side);
+        cmd->side_move = RoundToInteger(side);
     }
 
     // Upwards  -MH- 1998/08/18 Fly Up/Down movement

--- a/source_files/edge/e_main.cc
+++ b/source_files/edge/e_main.cc
@@ -100,8 +100,6 @@ extern ImageData *ReadAsEpiBlock(Image *rim);
 extern ConsoleVariable busy_wait;
 
 extern ConsoleVariable gamma_correction;
-extern ConsoleVariable goobers;
-extern ConsoleVariable fliplevels;
 
 ECFrameStats ec_frame_stats;
 
@@ -481,12 +479,6 @@ static void SetGlobalVariables(void)
     strict_errors = ddf_strict.d_ ? true : false;
     lax_errors    = ddf_lax.d_ ? true : false;
     no_warnings   = ddf_quiet.d_ ? true : false;
-
-    if (FindArgument("goobers") > 0)
-        goobers = 1;
-
-    if (FindArgument("fliplevels") > 0)
-        fliplevels = 1;
 }
 
 //

--- a/source_files/edge/hu_draw.cc
+++ b/source_files/edge/hu_draw.cc
@@ -40,7 +40,6 @@ extern ConsoleLine    *quit_lines[kEndoomLines];
 extern int             console_cursor;
 extern Font           *endoom_font;
 extern ConsoleVariable video_overlay;
-extern ConsoleVariable fliplevels;
 
 static Font *default_font;
 
@@ -1391,21 +1390,7 @@ void HUDRenderAutomap(float x, float y, float w, float h, MapObject *player, int
         }
     }
 
-    if (fliplevels.d_)
-    {
-        glMatrixMode(GL_PROJECTION);
-        glLoadIdentity();
-        glOrtho((float)current_screen_width, 0.0f, 0.0f, (float)current_screen_height, -1.0f, 1.0f);
-    }
-
     AutomapRender(x, y, w, h, player);
-
-    if (fliplevels.d_)
-    {
-        glMatrixMode(GL_PROJECTION);
-        glLoadIdentity();
-        glOrtho(0.0f, (float)current_screen_width, 0.0f, (float)current_screen_height, -1.0f, 1.0f);
-    }
 
     HUDPopScissor();
 }

--- a/source_files/edge/m_cheat.cc
+++ b/source_files/edge/m_cheat.cc
@@ -54,7 +54,6 @@
 
 extern ConsoleVariable debug_fps;
 extern ConsoleVariable debug_position;
-extern ConsoleVariable fliplevels;
 
 static CheatSequence cheat_powerup[9] = {
     {0, 0},
@@ -85,7 +84,6 @@ static CheatSequence cheat_keys            = {0, 0};
 static CheatSequence cheat_no_clipping     = {0, 0};
 static CheatSequence cheat_no_clipping2    = {0, 0};
 static CheatSequence cheat_hall_of_mirrors = {0, 0};
-static CheatSequence cheat_flip_level      = {0, 0};
 
 static CheatSequence cheat_give_weapon[11] = {
     {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0},
@@ -404,13 +402,6 @@ bool CheatResponder(InputEvent *ev)
         // 'mus' cheat for changing music
         StartMenuMessageInput(language["MusicQ"], M_ChangeMusicCheat);
     }
-    else if (CheckCheatSequence(&cheat_flip_level, key))
-    {
-        if (fliplevels.d_)
-            fliplevels = 0;
-        else
-            fliplevels = 1;
-    }
     else if (CheckCheatSequence(&cheat_show_stats, key))
     {
         debug_fps      = debug_fps.d_ ? 0 : 1;
@@ -454,8 +445,6 @@ void CheatInitialize(void)
     cheat_keys.sequence       = language["idunlock"];
     cheat_loaded.sequence     = language["idloaded"];
     cheat_take_all.sequence   = language["idtakeall"];
-
-    cheat_flip_level.sequence = language["flipme"];
 
     for (i = 0; i < 11; i++)
     {

--- a/source_files/edge/p_setup.cc
+++ b/source_files/edge/p_setup.cc
@@ -119,8 +119,6 @@ static std::string udmf_lump;
 // There is two values for every line: side0 and side1.
 static int *temp_line_sides;
 
-EDGE_DEFINE_CONSOLE_VARIABLE(goobers, "0", kConsoleVariableFlagNone)
-
 // "MUSINFO" is used here to refer to the traditional MUSINFO lump
 struct MUSINFOMapping
 {
@@ -427,13 +425,6 @@ static void LoadSectors(int lump)
 
         ss->floor_height   = AlignedLittleEndianS16(ms->floor_height);
         ss->ceiling_height = AlignedLittleEndianS16(ms->ceiling_height);
-
-        // return to wolfenstein?
-        if (goobers.d_)
-        {
-            ss->floor_height   = 0;
-            ss->ceiling_height = (ms->floor_height == ms->ceiling_height) ? 0 : 128.0f;
-        }
 
         ss->original_height = (ss->floor_height + ss->ceiling_height);
 
@@ -1625,13 +1616,6 @@ static void LoadUDMFSectors()
             ss->floor_height   = fz;
             ss->ceiling_height = cz;
 
-            // return to wolfenstein?
-            if (goobers.d_)
-            {
-                ss->floor_height   = 0;
-                ss->ceiling_height = (AlmostEquals(fz, cz)) ? 0 : 128.0f;
-            }
-
             ss->original_height = (ss->floor_height + ss->ceiling_height);
 
             ss->floor.translucency = falph;
@@ -1942,12 +1926,7 @@ static void LoadUDMFSideDefs()
             sd->top.image = ImageLookup(top_tex, kImageNamespaceTexture, kImageLookupNull);
 
             if (sd->top.image == nullptr)
-            {
-                if (goobers.d_)
-                    sd->top.image = ImageLookup(bottom_tex, kImageNamespaceTexture);
-                else
-                    sd->top.image = ImageLookup(top_tex, kImageNamespaceTexture);
-            }
+                sd->top.image = ImageLookup(top_tex, kImageNamespaceTexture);
 
             sd->middle.image = ImageLookup(middle_tex, kImageNamespaceTexture);
             sd->bottom.image = ImageLookup(bottom_tex, kImageNamespaceTexture);
@@ -2609,12 +2588,7 @@ static void TransferMapSideDef(const RawSidedef *msd, Side *sd, bool two_sided)
     sd->top.image = ImageLookup(upper_tex, kImageNamespaceTexture, kImageLookupNull);
 
     if (sd->top.image == nullptr)
-    {
-        if (goobers.d_)
-            sd->top.image = ImageLookup(upper_tex, kImageNamespaceTexture);
-        else
-            sd->top.image = ImageLookup(upper_tex, kImageNamespaceTexture);
-    }
+        sd->top.image = ImageLookup(upper_tex, kImageNamespaceTexture);
 
     sd->middle.image = ImageLookup(middle_tex, kImageNamespaceTexture);
     sd->bottom.image = ImageLookup(lower_tex, kImageNamespaceTexture);

--- a/source_files/edge/r_main.cc
+++ b/source_files/edge/r_main.cc
@@ -39,7 +39,6 @@ EDGE_DEFINE_CONSOLE_VARIABLE(renderer_far_clip, "64000", kConsoleVariableFlagArc
 EDGE_DEFINE_CONSOLE_VARIABLE(draw_culling, "0", kConsoleVariableFlagArchive)
 EDGE_DEFINE_CONSOLE_VARIABLE_CLAMPED(draw_culling_distance, "3000", kConsoleVariableFlagArchive, 1000.0f, 16000.0f)
 EDGE_DEFINE_CONSOLE_VARIABLE(cull_fog_color, "0", kConsoleVariableFlagArchive)
-EDGE_DEFINE_CONSOLE_VARIABLE(fliplevels, "0", kConsoleVariableFlagNone)
 
 //
 // SetupMatrices2D
@@ -70,12 +69,8 @@ void SetupWorldMatrices2D(void)
 
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
-    if (fliplevels.d_)
-        glOrtho((float)view_window_width, (float)view_window_x, (float)view_window_y, (float)view_window_height, -1.0f,
-                1.0f);
-    else
-        glOrtho((float)view_window_x, (float)view_window_width, (float)view_window_y, (float)view_window_height, -1.0f,
-                1.0f);
+    glOrtho((float)view_window_x, (float)view_window_width, (float)view_window_y, (float)view_window_height, -1.0f,
+            1.0f);
 
     glMatrixMode(GL_MODELVIEW);
     glLoadIdentity();
@@ -96,14 +91,9 @@ void SetupMatrices3d(void)
 
     glLoadIdentity();
 
-    if (fliplevels.d_)
-        glFrustum(view_x_slope * renderer_near_clip.f_, -view_x_slope * renderer_near_clip.f_,
-                  -view_y_slope * renderer_near_clip.f_, view_y_slope * renderer_near_clip.f_, renderer_near_clip.f_,
-                  renderer_far_clip.f_);
-    else
-        glFrustum(-view_x_slope * renderer_near_clip.f_, view_x_slope * renderer_near_clip.f_,
-                  -view_y_slope * renderer_near_clip.f_, view_y_slope * renderer_near_clip.f_, renderer_near_clip.f_,
-                  renderer_far_clip.f_);
+    glFrustum(-view_x_slope * renderer_near_clip.f_, view_x_slope * renderer_near_clip.f_,
+                -view_y_slope * renderer_near_clip.f_, view_y_slope * renderer_near_clip.f_, renderer_near_clip.f_,
+                renderer_far_clip.f_);
 
     // calculate look-at matrix
 

--- a/source_files/edge/r_md2.cc
+++ b/source_files/edge/r_md2.cc
@@ -59,7 +59,6 @@ extern float ApproximateDistance(float dx, float dy, float dz);
 
 extern ConsoleVariable draw_culling;
 extern ConsoleVariable cull_fog_color;
-extern ConsoleVariable fliplevels;
 extern bool            need_to_draw_sky;
 
 /*============== MD2 FORMAT DEFINITIONS ====================*/
@@ -1018,19 +1017,9 @@ void MD2RenderModel(MD2Model *md, const Image *skin_img, bool is_weapon, int fra
         blending |= kBlendingNoZBuffer;
 
     if (MirrorReflective())
-    {
-        if (fliplevels.d_)
-            blending |= kBlendingCullBack;
-        else
-            blending |= kBlendingCullFront;
-    }
+        blending |= kBlendingCullFront;
     else
-    {
-        if (fliplevels.d_)
-            blending |= kBlendingCullFront;
-        else
-            blending |= kBlendingCullBack;
-    }
+        blending |= kBlendingCullBack;
 
     data.map_object_ = mo;
     data.model_      = md;

--- a/source_files/edge/r_mdl.cc
+++ b/source_files/edge/r_mdl.cc
@@ -61,7 +61,6 @@ extern float ApproximateDistance(float dx, float dy, float dz);
 
 extern ConsoleVariable draw_culling;
 extern ConsoleVariable cull_fog_color;
-extern ConsoleVariable fliplevels;
 extern bool            need_to_draw_sky;
 
 /*============== MDL FORMAT DEFINITIONS ====================*/
@@ -694,19 +693,9 @@ void MDLRenderModel(MDLModel *md, const Image *skin_img, bool is_weapon, int fra
         blending |= kBlendingNoZBuffer;
 
     if (MirrorReflective())
-    {
-        if (fliplevels.d_)
-            blending |= kBlendingCullBack;
-        else
-            blending |= kBlendingCullFront;
-    }
+        blending |= kBlendingCullFront;
     else
-    {
-        if (fliplevels.d_)
-            blending |= kBlendingCullFront;
-        else
-            blending |= kBlendingCullBack;
-    }
+        blending |= kBlendingCullBack;
 
     data.map_object_ = mo;
     data.model_      = md;

--- a/source_files/edge/r_sky.cc
+++ b/source_files/edge/r_sky.cc
@@ -46,7 +46,6 @@ bool custom_skybox;
 extern ImageData *ReadAsEpiBlock(Image *rim);
 
 extern ConsoleVariable draw_culling;
-extern ConsoleVariable fliplevels;
 
 static RGBAColor sky_cap_color;
 
@@ -236,14 +235,9 @@ static void SetupSkyMatrices(void)
         glPushMatrix();
         glLoadIdentity();
 
-        if (fliplevels.d_)
-            glFrustum(-view_x_slope * renderer_near_clip.f_, view_x_slope * renderer_near_clip.f_,
-                      -view_y_slope * renderer_near_clip.f_, view_y_slope * renderer_near_clip.f_,
-                      renderer_near_clip.f_, renderer_far_clip.f_);
-        else
-            glFrustum(view_x_slope * renderer_near_clip.f_, -view_x_slope * renderer_near_clip.f_,
-                      -view_y_slope * renderer_near_clip.f_, view_y_slope * renderer_near_clip.f_,
-                      renderer_near_clip.f_, renderer_far_clip.f_);
+        glFrustum(view_x_slope * renderer_near_clip.f_, -view_x_slope * renderer_near_clip.f_,
+                    -view_y_slope * renderer_near_clip.f_, view_y_slope * renderer_near_clip.f_,
+                    renderer_near_clip.f_, renderer_far_clip.f_);
 
         glMatrixMode(GL_MODELVIEW);
         glPushMatrix();
@@ -258,14 +252,9 @@ static void SetupSkyMatrices(void)
         glPushMatrix();
         glLoadIdentity();
 
-        if (fliplevels.d_)
-            glFrustum(view_x_slope * renderer_near_clip.f_, -view_x_slope * renderer_near_clip.f_,
-                    -view_y_slope * renderer_near_clip.f_, view_y_slope * renderer_near_clip.f_, renderer_near_clip.f_,
-                    renderer_far_clip.f_ * 4.0);
-        else
-            glFrustum(-view_x_slope * renderer_near_clip.f_, view_x_slope * renderer_near_clip.f_,
-                    -view_y_slope * renderer_near_clip.f_, view_y_slope * renderer_near_clip.f_, renderer_near_clip.f_,
-                    renderer_far_clip.f_ * 4.0);
+        glFrustum(-view_x_slope * renderer_near_clip.f_, view_x_slope * renderer_near_clip.f_,
+                -view_y_slope * renderer_near_clip.f_, view_y_slope * renderer_near_clip.f_, renderer_near_clip.f_,
+                renderer_far_clip.f_ * 4.0);
 
         glMatrixMode(GL_MODELVIEW);
         glPushMatrix();

--- a/source_files/edge/s_blit.cc
+++ b/source_files/edge/s_blit.cc
@@ -92,8 +92,6 @@ extern int sound_device_samples_per_buffer;
 
 extern bool sound_device_stereo;
 
-extern ConsoleVariable fliplevels;
-
 SoundChannel::SoundChannel() : state_(kChannelEmpty), data_(nullptr)
 {
 }
@@ -157,15 +155,6 @@ void SoundChannel::ComputeVolume()
     volume_right_ = (int)(MAX_VOL * (0.0 + sep));
 
     if (var_sound_stereo == 2) /* SWAP ! */
-    {
-        if (!fliplevels.d_)
-        {
-            int tmp       = volume_left_;
-            volume_left_  = volume_right_;
-            volume_right_ = tmp;
-        }
-    }
-    else if (fliplevels.d_)
     {
         int tmp       = volume_left_;
         volume_left_  = volume_right_;


### PR DESCRIPTION
These are fairly niche and also relatively invasive versus other cheats (directly altering rendering, input and sound mixing functions; altering the levels as they are processed via p_setup, etc). Would be nice if they could come back as scriptable and less 'hardcoded' solutions in the future.