### PR TITLE
Remove Exclusive Fullscreen mode

### DIFF
--- a/source_files/edge/defaults.h
+++ b/source_files/edge/defaults.h
@@ -22,7 +22,7 @@
 #define EDGE_DEFAULT_SCREENWIDTH  (1000000) // Super high number to force scaling to native res
 #define EDGE_DEFAULT_SCREENHEIGHT (1000000) // Super high number to force scaling to native res
 #define EDGE_DEFAULT_SCREENBITS   (32)
-#define EDGE_DEFAULT_DISPLAYMODE  (2)
+#define EDGE_DEFAULT_DISPLAYMODE  (1)
 
 // Controls (Key/Mouse Buttons)
 #define EDGE_DEFAULT_KEY_FIRE        (kMouse1 + (kGamepadTriggerRight << 16))

--- a/source_files/edge/e_main.cc
+++ b/source_files/edge/e_main.cc
@@ -345,17 +345,18 @@ static void SetGlobalVariables(void)
     std::string s;
 
     // Screen Resolution Check...
+    // borderless and fullscreen are synonymous now - Dasho
     if (FindArgument("borderless") > 0)
-        current_window_mode = 2;
+        current_window_mode = kWindowModeBorderless;
     else if (FindArgument("fullscreen") > 0)
-        current_window_mode = 1;
+        current_window_mode = kWindowModeBorderless;
     else if (FindArgument("windowed") > 0)
-        current_window_mode = 0;
+        current_window_mode = kWindowModeWindowed;
 
     s = ArgumentValue("width");
     if (!s.empty())
     {
-        if (current_window_mode == 2)
+        if (current_window_mode == kWindowModeBorderless)
             LogWarning("Current display mode set to borderless fullscreen. Provided "
                        "width of %d will be ignored!\n",
                        atoi(s.c_str()));
@@ -366,7 +367,7 @@ static void SetGlobalVariables(void)
     s = ArgumentValue("height");
     if (!s.empty())
     {
-        if (current_window_mode == 2)
+        if (current_window_mode == kWindowModeBorderless)
             LogWarning("Current display mode set to borderless fullscreen. Provided "
                        "height of %d will be ignored!\n",
                        atoi(s.c_str()));
@@ -377,7 +378,7 @@ static void SetGlobalVariables(void)
     p = FindArgument("res");
     if (p > 0 && p + 2 < int(program_argument_list.size()) && !ArgumentIsOption(p + 1) && !ArgumentIsOption(p + 2))
     {
-        if (current_window_mode == 2)
+        if (current_window_mode == kWindowModeBorderless)
             LogWarning("Current display mode set to borderless fullscreen. Provided "
                        "resolution of %dx%d will be ignored!\n",
                        atoi(program_argument_list[p + 1].c_str()), atoi(program_argument_list[p + 2].c_str()));
@@ -406,7 +407,7 @@ static void SetGlobalVariables(void)
 
     // If borderless fullscreen mode, override any provided dimensions so
     // StartupGraphics will scale to native res
-    if (current_window_mode == 2)
+    if (current_window_mode == kWindowModeBorderless)
     {
         current_screen_width  = 100000;
         current_screen_height = 100000;

--- a/source_files/edge/i_ctrl.cc
+++ b/source_files/edge/i_ctrl.cc
@@ -588,7 +588,7 @@ void ActiveEventProcess(SDL_Event *sdl_ev)
             current_screen_width  = sdl_ev->window.data1;
             current_screen_height = sdl_ev->window.data2;
             current_screen_depth  = 24;
-            current_window_mode   = 0;
+            current_window_mode   = kWindowModeWindowed;
             DeterminePixelAspect();
         }
 #endif

--- a/source_files/edge/i_web.cc
+++ b/source_files/edge/i_web.cc
@@ -45,7 +45,7 @@ static void WebSyncScreenSize(int width, int height)
     current_screen_width  = (int)width;
     current_screen_height = (int)height;
     current_screen_depth  = 24;
-    current_window_mode   = 0;
+    current_window_mode   = kWindowModeWindowed;
     DeterminePixelAspect();
 
     SoftInitializeResolution();

--- a/source_files/edge/m_option.cc
+++ b/source_files/edge/m_option.cc
@@ -1069,7 +1069,7 @@ void OptionMenuDrawer()
 
         if (current_menu == &res_optmenu && current_menu->items[i].routine == OptionMenuChangeResSize)
         {
-            if (new_window_mode.window_mode == 2)
+            if (new_window_mode.window_mode == kWindowModeBorderless)
             {
                 curry += deltay;
                 continue;
@@ -1235,12 +1235,12 @@ static void OptionMenuResOptDrawer(Style *style, int topy, int bottomy, int dy, 
     float TEXTscale = style->definition_->text_[fontType].scale_;
 
     stbsp_sprintf(tempstring, "%s",
-            new_window_mode.window_mode == 2
+            new_window_mode.window_mode == kWindowModeBorderless
                 ? "Borderless Fullscreen"
-                : (new_window_mode.window_mode == kWindowModeFullscreen ? "Exclusive Fullscreen" : "Windowed"));
+                : "Windowed");
     HUDWriteText(style, fontType, centrex + 15, y, tempstring);
 
-    if (new_window_mode.window_mode < 2)
+    if (new_window_mode.window_mode == kWindowModeWindowed)
     {
         y += dy;
         stbsp_sprintf(tempstring, "%dx%d", new_window_mode.width, new_window_mode.height);
@@ -1262,11 +1262,10 @@ static void OptionMenuResOptDrawer(Style *style, int topy, int bottomy, int dy, 
 
     y += dy;
     y += 5;
-    if (current_window_mode == 2)
+    if (current_window_mode == kWindowModeBorderless)
         stbsp_sprintf(tempstring, "%s", "Borderless Fullscreen");
     else
-        stbsp_sprintf(tempstring, "%d x %d %s", current_screen_width, current_screen_height,
-                current_window_mode == 1 ? "Exclusive Fullscreen" : "Windowed");
+        stbsp_sprintf(tempstring, "%d x %d %s", current_screen_width, current_screen_height, "Windowed");
 
     HUDWriteText(style, fontType, 160 - (style->fonts_[fontType]->StringWidth(tempstring) * TEXTscale / 2), y,
                  tempstring);
@@ -1375,7 +1374,7 @@ bool OptionMenuResponder(InputEvent *ev, int ch)
         do
         {
             current_menu->pos++;
-            if (current_menu == &res_optmenu && new_window_mode.window_mode == 2)
+            if (current_menu == &res_optmenu && new_window_mode.window_mode == kWindowModeBorderless)
             {
                 if (current_menu->pos >= 0 && current_menu->pos < current_menu->item_number)
                 {
@@ -1396,7 +1395,7 @@ bool OptionMenuResponder(InputEvent *ev, int ch)
         do
         {
             current_menu->pos++;
-            if (current_menu == &res_optmenu && new_window_mode.window_mode == 2)
+            if (current_menu == &res_optmenu && new_window_mode.window_mode == kWindowModeBorderless)
             {
                 if (current_menu->pos >= 0 && current_menu->pos < current_menu->item_number)
                 {
@@ -1426,7 +1425,7 @@ bool OptionMenuResponder(InputEvent *ev, int ch)
         do
         {
             current_menu->pos--;
-            if (current_menu == &res_optmenu && new_window_mode.window_mode == 2)
+            if (current_menu == &res_optmenu && new_window_mode.window_mode == kWindowModeBorderless)
             {
                 if (current_menu->pos >= 0 && current_menu->pos < current_menu->item_number)
                 {
@@ -1447,7 +1446,7 @@ bool OptionMenuResponder(InputEvent *ev, int ch)
         do
         {
             current_menu->pos--;
-            if (current_menu == &res_optmenu && new_window_mode.window_mode == 2)
+            if (current_menu == &res_optmenu && new_window_mode.window_mode == kWindowModeBorderless)
             {
                 if (current_menu->pos >= 0 && current_menu->pos < current_menu->item_number)
                 {
@@ -2132,14 +2131,7 @@ static void OptionMenuionSetResolution(int key_pressed, ConsoleVariable *console
 {
     if (ChangeResolution(&new_window_mode))
     {
-        if (new_window_mode.window_mode > kWindowModeWindowed)
-        {
-            toggle_fullscreen_depth       = new_window_mode.depth;
-            toggle_fullscreen_height      = new_window_mode.height;
-            toggle_fullscreen_width       = new_window_mode.width;
-            toggle_fullscreen_window_mode = new_window_mode.window_mode;
-        }
-        else
+        if (new_window_mode.window_mode == kWindowModeWindowed)
         {
             toggle_windowed_depth       = new_window_mode.depth;
             toggle_windowed_height      = new_window_mode.height;

--- a/source_files/edge/r_modes.h
+++ b/source_files/edge/r_modes.h
@@ -34,7 +34,6 @@ enum WindowMode
 {
     kWindowModeInvalid = -1,
     kWindowModeWindowed,
-    kWindowModeFullscreen,
     kWindowModeBorderless
 };
 
@@ -44,21 +43,17 @@ struct DisplayMode
     int width       = 0;
     int height      = 0;
     int depth       = 0;
-    int window_mode = kWindowModeWindowed;
+    WindowMode window_mode = kWindowModeWindowed;
 };
 
 // Exported Vars
 extern int                        current_screen_width;
 extern int                        current_screen_height;
 extern int                        current_screen_depth;
-extern int                        current_window_mode;
+extern WindowMode                 current_window_mode;
 extern DisplayMode                borderless_mode;
 extern std::vector<DisplayMode *> screen_modes;
 // CVARs related to Alt+Enter toggling
-extern ConsoleVariable toggle_fullscreen_width;
-extern ConsoleVariable toggle_fullscreen_height;
-extern ConsoleVariable toggle_fullscreen_depth;
-extern ConsoleVariable toggle_fullscreen_window_mode;
 extern ConsoleVariable toggle_windowed_width;
 extern ConsoleVariable toggle_windowed_height;
 extern ConsoleVariable toggle_windowed_depth;


### PR DESCRIPTION
For things like the web player, eventual migration to SDL3, and other factors, it makes less sense to try to continue to support exclusive fullscreen mode. This makes Windowed and Borderless Fullscreen the only available screen modes.