### PR TITLE
Remove "DLIGHT2" DDF special and associated code

### DIFF
--- a/source_files/ddf/ddf_attack.cc
+++ b/source_files/ddf/ddf_attack.cc
@@ -263,8 +263,8 @@ static void AttackFinishEntry(void)
         if (dynamic_mobj->model_skin_ < 0 || dynamic_mobj->model_skin_ > 9)
             DDFError("Bad MODEL_SKIN value %d in DDF (must be 0-9).\n", dynamic_mobj->model_skin_);
 
-        if (dynamic_mobj->dlight_[0].radius_ > 512)
-            DDFWarning("DLIGHT RADIUS value %1.1f too large (over 512).\n", dynamic_mobj->dlight_[0].radius_);
+        if (dynamic_mobj->dlight_.radius_ > 512)
+            DDFWarning("DLIGHT RADIUS value %1.1f too large (over 512).\n", dynamic_mobj->dlight_.radius_);
     }
 
     // check DAMAGE stuff
@@ -370,11 +370,11 @@ void DDFAttackCleanUp(void)
                 a->damage_.nominal_ = a->atk_mobj_->explode_damage_.nominal_;
                 a->damage_.linear_max_ = a->atk_mobj_->explode_damage_.linear_max_;
                 MapObjectDefinition *atk_mod = (MapObjectDefinition *)a->atk_mobj_; // const override
-                if (atk_mod->dlight_[0].type_ == kDynamicLightTypeNone)
+                if (atk_mod->dlight_.type_ == kDynamicLightTypeNone)
                 {
-                    atk_mod->dlight_[0].type_ = kDynamicLightTypeModulate;
-                    atk_mod->dlight_[0].radius_ = atk_mod->radius_ * 4;
-                    atk_mod->dlight_[0].autocolour_sprite_ = states[atk_mod->idle_state_].sprite;
+                    atk_mod->dlight_.type_ = kDynamicLightTypeModulate;
+                    atk_mod->dlight_.radius_ = atk_mod->radius_ * 4;
+                    atk_mod->dlight_.autocolour_sprite_ = states[atk_mod->idle_state_].sprite;
                 }
             }
         }

--- a/source_files/ddf/ddf_thing.h
+++ b/source_files/ddf/ddf_thing.h
@@ -848,7 +848,7 @@ class MapObjectDefinition
     const AttackDefinition *rangeattack_;
     const AttackDefinition *spareattack_;
 
-    DynamicLightDefinition dlight_[2];
+    DynamicLightDefinition dlight_;
     int                    glow_type_;
 
     // -AJA- 2007/08/21: weakness support (head-shots etc)

--- a/source_files/edge/e_main.cc
+++ b/source_files/edge/e_main.cc
@@ -825,11 +825,11 @@ static void TitleDrawer(void)
 
 static void AutocolourForMapObject(MapObjectDefinition *mobj)
 {
-    if (mobj->dlight_[0].type_ != kDynamicLightTypeNone)
+    if (mobj->dlight_.type_ != kDynamicLightTypeNone)
     {
-        if (!mobj->dlight_[0].autocolour_reference_.empty())
+        if (!mobj->dlight_.autocolour_reference_.empty())
         {
-            const Image *img = ImageLookup(mobj->dlight_[0].autocolour_reference_.c_str());
+            const Image *img = ImageLookup(mobj->dlight_.autocolour_reference_.c_str());
             if (img)
             {
                 const uint8_t *what_palette = (const uint8_t *)&playpal_data[0];
@@ -842,16 +842,16 @@ static void AutocolourForMapObject(MapObjectDefinition *mobj)
                     delete tmp_img_data;
                     tmp_img_data = rgb_img_data;
                 }
-                mobj->dlight_[0].colour_ = tmp_img_data->AverageHue();
+                mobj->dlight_.colour_ = tmp_img_data->AverageHue();
                 delete tmp_img_data;
                 if (what_palette != (const uint8_t *)&playpal_data[0])
                     delete[] what_palette;
-                mobj->dlight_[0].autocolour_reference_.clear();
+                mobj->dlight_.autocolour_reference_.clear();
             }
         }
-        else if (mobj->dlight_[0].autocolour_sprite_ > 0)
+        else if (mobj->dlight_.autocolour_sprite_ > 0)
         {
-            SpriteFrame *ref_frame = GetSpriteFrame(mobj->dlight_[0].autocolour_sprite_, 0);
+            SpriteFrame *ref_frame = GetSpriteFrame(mobj->dlight_.autocolour_sprite_, 0);
             if (ref_frame)
             {
                 const Image *img = nullptr;
@@ -875,70 +875,11 @@ static void AutocolourForMapObject(MapObjectDefinition *mobj)
                         delete tmp_img_data;
                         tmp_img_data = rgb_img_data;
                     }
-                    mobj->dlight_[0].colour_ = tmp_img_data->AverageHue();
+                    mobj->dlight_.colour_ = tmp_img_data->AverageHue();
                     delete tmp_img_data;
                     if (what_palette != (const uint8_t *)&playpal_data[0])
                         delete[] what_palette;
-                    mobj->dlight_[0].autocolour_sprite_ = -1;
-                }
-            }
-        }
-    }
-    if (mobj->dlight_[1].type_ != kDynamicLightTypeNone)
-    {
-        if (!mobj->dlight_[1].autocolour_reference_.empty())
-        {
-            const Image *img = ImageLookup(mobj->dlight_[1].autocolour_reference_.c_str());
-            if (img)
-            {
-                const uint8_t *what_palette = (const uint8_t *)&playpal_data[0];
-                if (img->source_palette_ >= 0)
-                    what_palette = (const uint8_t *)LoadLumpIntoMemory(img->source_palette_);
-                ImageData *tmp_img_data = ReadAsEpiBlock((Image *)img);
-                if (tmp_img_data->depth_ == 1)
-                {
-                    ImageData *rgb_img_data = RGBFromPalettised(tmp_img_data, what_palette, img->opacity_);
-                    delete tmp_img_data;
-                    tmp_img_data = rgb_img_data;
-                }
-                mobj->dlight_[1].colour_ = tmp_img_data->AverageHue();
-                delete tmp_img_data;
-                if (what_palette != (const uint8_t *)&playpal_data[0])
-                    delete[] what_palette;
-                mobj->dlight_[1].autocolour_reference_.clear();
-            }
-        }
-        else if (mobj->dlight_[1].autocolour_sprite_ > 0)
-        {
-            SpriteFrame *ref_frame = GetSpriteFrame(mobj->dlight_[1].autocolour_sprite_, 0);
-            if (ref_frame)
-            {
-                const Image *img = nullptr;
-                for (int i = 0; i < 16; i++)
-                {
-                    if (ref_frame->images_[i])
-                    {
-                        img = ref_frame->images_[i];
-                        break;
-                    }
-                }
-                if (img)
-                {
-                    const uint8_t *what_palette = (const uint8_t *)&playpal_data[0];
-                    if (img->source_palette_ >= 0)
-                        what_palette = (const uint8_t *)LoadLumpIntoMemory(img->source_palette_);
-                    ImageData *tmp_img_data = ReadAsEpiBlock((Image *)img);
-                    if (tmp_img_data->depth_ == 1)
-                    {
-                        ImageData *rgb_img_data = RGBFromPalettised(tmp_img_data, what_palette, img->opacity_);
-                        delete tmp_img_data;
-                        tmp_img_data = rgb_img_data;
-                    }
-                    mobj->dlight_[1].colour_ = tmp_img_data->AverageHue();
-                    delete tmp_img_data;
-                    if (what_palette != (const uint8_t *)&playpal_data[0])
-                        delete[] what_palette;
-                    mobj->dlight_[1].autocolour_sprite_ = -1;
+                    mobj->dlight_.autocolour_sprite_ = -1;
                 }
             }
         }

--- a/source_files/edge/p_action.cc
+++ b/source_files/edge/p_action.cc
@@ -4058,7 +4058,7 @@ void A_Become(MapObject *mo)
 
         // handle dynamic lights
         {
-            const DynamicLightDefinition *dinfo = &mo->info_->dlight_[0];
+            const DynamicLightDefinition *dinfo = &mo->info_->dlight_;
 
             if (dinfo->type_ != kDynamicLightTypeNone)
             {
@@ -4137,7 +4137,7 @@ void A_UnBecome(MapObject *mo)
 
         // handle dynamic lights
         {
-            const DynamicLightDefinition *dinfo = &mo->info_->dlight_[0];
+            const DynamicLightDefinition *dinfo = &mo->info_->dlight_;
 
             if (dinfo->type_ != kDynamicLightTypeNone)
             {
@@ -4220,7 +4220,7 @@ void A_Morph(MapObject *mo)
 
         // handle dynamic lights
         {
-            const DynamicLightDefinition *dinfo = &mo->info_->dlight_[0];
+            const DynamicLightDefinition *dinfo = &mo->info_->dlight_;
 
             if (dinfo->type_ != kDynamicLightTypeNone)
             {
@@ -4303,7 +4303,7 @@ void A_UnMorph(MapObject *mo)
 
         // handle dynamic lights
         {
-            const DynamicLightDefinition *dinfo = &mo->info_->dlight_[0];
+            const DynamicLightDefinition *dinfo = &mo->info_->dlight_;
 
             if (dinfo->type_ != kDynamicLightTypeNone)
             {

--- a/source_files/edge/p_blockmap.cc
+++ b/source_files/edge/p_blockmap.cc
@@ -425,7 +425,7 @@ void UnsetThingPosition(MapObject *mo)
     }
 
     // unlink from dynamic light blockmap
-    if (mo->info_ && (mo->info_->dlight_[0].type_ != kDynamicLightTypeNone) &&
+    if (mo->info_ && (mo->info_->dlight_.type_ != kDynamicLightTypeNone) &&
         (mo->info_->glow_type_ == kSectorGlowTypeNone))
     {
         if (mo->dynamic_light_next_)
@@ -467,7 +467,7 @@ void UnsetThingPosition(MapObject *mo)
     }
 
     // unlink from sector glow list
-    if (mo->info_ && (mo->info_->dlight_[0].type_ != kDynamicLightTypeNone) &&
+    if (mo->info_ && (mo->info_->dlight_.type_ != kDynamicLightTypeNone) &&
         (mo->info_->glow_type_ != kSectorGlowTypeNone))
     {
         Sector *sec = mo->subsector_->sector;
@@ -634,7 +634,7 @@ void SetThingPosition(MapObject *mo)
     }
 
     // link into dynamic light blockmap
-    if (mo->info_ && (mo->info_->dlight_[0].type_ != kDynamicLightTypeNone) &&
+    if (mo->info_ && (mo->info_->dlight_.type_ != kDynamicLightTypeNone) &&
         (mo->info_->glow_type_ == kSectorGlowTypeNone))
     {
         blockx = LightmapGetX(mo->x);
@@ -661,7 +661,7 @@ void SetThingPosition(MapObject *mo)
     }
 
     // link into sector glow list
-    if (mo->info_ && (mo->info_->dlight_[0].type_ != kDynamicLightTypeNone) &&
+    if (mo->info_ && (mo->info_->dlight_.type_ != kDynamicLightTypeNone) &&
         (mo->info_->glow_type_ != kSectorGlowTypeNone))
     {
         Sector *sec = mo->subsector_->sector;

--- a/source_files/edge/p_mobj.cc
+++ b/source_files/edge/p_mobj.cc
@@ -2254,7 +2254,7 @@ MapObject *CreateMapObject(float x, float y, float z, const MapObjectDefinition 
 
     // handle dynamic lights
     {
-        const DynamicLightDefinition *dinfo = &info->dlight_[0];
+        const DynamicLightDefinition *dinfo = &info->dlight_;
 
         if (dinfo->type_ != kDynamicLightTypeNone)
         {

--- a/source_files/edge/r_render.cc
+++ b/source_files/edge/r_render.cc
@@ -652,7 +652,7 @@ static void DLIT_Wall(MapObject *mo, void *dataptr)
     WallCoordinateData *data = (WallCoordinateData *)dataptr;
 
     // light behind the plane ?
-    if (!mo->info_->dlight_[0].leaky_ && !data->mid_masked &&
+    if (!mo->info_->dlight_.leaky_ && !data->mid_masked &&
         !(mo->subsector_->sector->floor_vertex_slope || mo->subsector_->sector->ceiling_vertex_slope))
     {
         float mx = mo->x;
@@ -691,7 +691,7 @@ static void DLIT_Plane(MapObject *mo, void *dataptr)
     PlaneCoordinateData *data = (PlaneCoordinateData *)dataptr;
 
     // light behind the plane ?
-    if (!mo->info_->dlight_[0].leaky_ &&
+    if (!mo->info_->dlight_.leaky_ &&
         !(mo->subsector_->sector->floor_vertex_slope || mo->subsector_->sector->ceiling_vertex_slope))
     {
         float z = data->vertices[0].Z;
@@ -1798,7 +1798,7 @@ static void DLIT_Flood(MapObject *mo, void *dataptr)
     FloodEmulationData *data = (FloodEmulationData *)dataptr;
 
     // light behind the plane ?
-    if (!mo->info_->dlight_[0].leaky_ &&
+    if (!mo->info_->dlight_.leaky_ &&
         !(mo->subsector_->sector->floor_vertex_slope || mo->subsector_->sector->ceiling_vertex_slope))
     {
         if ((MapObjectMidZ(mo) > data->plane_h) != (data->normal.Z > 0))

--- a/source_files/edge/rad_act.cc
+++ b/source_files/edge/rad_act.cc
@@ -1439,7 +1439,7 @@ void P_ActReplace(MapObject *mo, const MapObjectDefinition *newThing)
 
         // handle dynamic lights
         {
-            const DynamicLightDefinition *dinfo = &mo->info_->dlight_[0];
+            const DynamicLightDefinition *dinfo = &mo->info_->dlight_;
 
             if (dinfo->type_ != kDynamicLightTypeNone)
             {


### PR DESCRIPTION
This removes the second dlight that could be defined for map objects; most places in the code didn't seem to account for it at all (referencing only index 0 instead of both 0 and 1). This also reduces the potential for even more rendering passes per thing.