### PR TITLE
Sokol: Add render unit locking and isolate rendering from BSP traversal

### DIFF
--- a/source_files/edge/r_backend.cc
+++ b/source_files/edge/r_backend.cc
@@ -44,6 +44,8 @@ void RenderBackend::SoftInit(void)
 
     render_state->Hint(GL_FOG_HINT, GL_NICEST);
     render_state->Hint(GL_PERSPECTIVE_CORRECTION_HINT, GL_NICEST);
+
+    LockRenderUnits(false);
 }
 
 void RenderBackend::Init()

--- a/source_files/edge/r_backend.h
+++ b/source_files/edge/r_backend.h
@@ -59,6 +59,16 @@ class RenderBackend
 
     virtual RenderLayer GetRenderLayer() = 0;
 
+    void LockRenderUnits(bool locked) 
+    {
+        units_locked_ = locked;
+    }
+
+    bool RenderUnitsLocked() 
+    {
+        return units_locked_;
+    }
+
     virtual void Resize(int32_t width, int32_t height) = 0;
 
     virtual void Shutdown() = 0;
@@ -85,6 +95,7 @@ class RenderBackend
 
     int32_t max_texture_size_ = 0;
     int64_t frame_number_;
+    bool units_locked_ = false;
 
     std::vector<FrameFinishedCallback> on_frame_finished_;
 };

--- a/source_files/edge/r_bsp.cc
+++ b/source_files/edge/r_bsp.cc
@@ -411,7 +411,7 @@ static void BSPWalkSeg(DrawSubsector *dsub, Seg *seg)
     {
         if (f_fh < b_fh)
         {
-            RenderSkyWall(seg, f_fh, b_fh);
+            QueueSkyWall(seg, f_fh, b_fh);
         }
     }
 
@@ -419,7 +419,7 @@ static void BSPWalkSeg(DrawSubsector *dsub, Seg *seg)
     {
         if (f_ch < fsector->sky_height && (!bsector || !EDGE_IMAGE_IS_SKY(*b_ceil) || b_fh >= f_ch))
         {
-            RenderSkyWall(seg, f_ch, fsector->sky_height);
+            QueueSkyWall(seg, f_ch, fsector->sky_height);
         }
         else if (bsector && EDGE_IMAGE_IS_SKY(*b_ceil))
         {
@@ -427,7 +427,7 @@ static void BSPWalkSeg(DrawSubsector *dsub, Seg *seg)
 
             if (b_ch <= max_f && max_f < fsector->sky_height)
             {
-                RenderSkyWall(seg, max_f, fsector->sky_height);
+                QueueSkyWall(seg, max_f, fsector->sky_height);
             }
         }
     }
@@ -435,7 +435,7 @@ static void BSPWalkSeg(DrawSubsector *dsub, Seg *seg)
     else if (!debug_hall_of_mirrors.d_ && bsector && EDGE_IMAGE_IS_SKY(*b_ceil) && seg->sidedef->top.image == nullptr &&
              b_ch < f_ch)
     {
-        RenderSkyWall(seg, b_ch, f_ch);
+        QueueSkyWall(seg, b_ch, f_ch);
     }
 }
 
@@ -660,12 +660,12 @@ static void BSPWalkSubsector(int num)
     {
         if (EDGE_IMAGE_IS_SKY(sub->sector->floor) && view_z > sub->sector->interpolated_floor_height)
         {
-            RenderSkyPlane(sub, sub->sector->interpolated_floor_height);
+            QueueSkyPlane(sub, sub->sector->interpolated_floor_height);
         }
 
         if (EDGE_IMAGE_IS_SKY(sub->sector->ceiling) && view_z < sub->sector->sky_height)
         {
-            RenderSkyPlane(sub, sub->sector->sky_height);
+            QueueSkyPlane(sub, sub->sector->sky_height);
         }
     }
 
@@ -703,11 +703,11 @@ static void BSPWalkSubsector(int num)
         }
         if (EDGE_IMAGE_IS_SKY(*floor_s) && view_z > floor_h)
         {
-            RenderSkyPlane(sub, floor_h);
+            QueueSkyPlane(sub, floor_h);
         }
         if (EDGE_IMAGE_IS_SKY(*ceil_s) && view_z < sub->sector->sky_height)
         {
-            RenderSkyPlane(sub, sub->sector->sky_height);
+            QueueSkyPlane(sub, sub->sector->sky_height);
         }
     }
     // -AJA- 2004/04/22: emulate the Deep-Water TRICK

--- a/source_files/edge/r_render.h
+++ b/source_files/edge/r_render.h
@@ -8,14 +8,17 @@ void MirrorPush(DrawMirror *mir);
 void MirrorPop();
 void RenderMirror(DrawMirror *mir);
 bool MirrorSegOnPortal(Seg *seg);
-void MirrorPushSubsector(int32_t index, DrawSubsector* subsector);
+void MirrorPushSubsector(int32_t index, DrawSubsector *subsector);
 
-void MirrorTransform(int32_t index, float& x, float& y);
+void MirrorTransform(int32_t index, float &x, float &y);
 bool MirrorIsPortal(int32_t index);
-Seg* MirrorSeg(int32_t index);
+Seg *MirrorSeg(int32_t index);
 
 int32_t MirrorTotalActive();
 
 void RenderSubList(std::list<DrawSubsector *> &dsubs, bool for_mirror = false);
 
 void BspWalkNode(unsigned int);
+
+void QueueSkyWall(Seg *seg, float h1, float h2);
+void QueueSkyPlane(Subsector *sub, float h);

--- a/source_files/edge/render/gl/gl_units.cc
+++ b/source_files/edge/render/gl/gl_units.cc
@@ -33,6 +33,7 @@
 #include "i_defs_gl.h"
 #include "im_data.h"
 #include "m_argv.h"
+#include "r_backend.h"
 #include "r_colormap.h"
 #include "r_gldefs.h"
 #include "r_image.h"
@@ -104,6 +105,11 @@ RGBAColor culling_fog_color;
 //
 void StartUnitBatch(bool sort_em)
 {
+    if (render_backend->RenderUnitsLocked())
+    {
+        FatalError("StartUnitBatch - Render units are locked");
+    }
+
     current_render_vert = current_render_unit = 0;
 
     batch_sort = sort_em;
@@ -118,6 +124,11 @@ void StartUnitBatch(bool sort_em)
 //
 void FinishUnitBatch(void)
 {
+    if (render_backend->RenderUnitsLocked())
+    {
+        FatalError("FinishUnitBatch - Render units are locked");
+    }
+
     RenderCurrentUnits();
 }
 
@@ -134,6 +145,11 @@ void FinishUnitBatch(void)
 RendererVertex *BeginRenderUnit(GLuint shape, int max_vert, GLuint env1, GLuint tex1, GLuint env2, GLuint tex2,
                                 int pass, int blending, RGBAColor fog_color, float fog_density)
 {
+    if (render_backend->RenderUnitsLocked())
+    {
+        FatalError("BeginRenderUnit - Render units are locked");
+    }
+
     RendererUnit *unit;
 
     EPI_ASSERT(max_vert > 0);
@@ -175,6 +191,12 @@ RendererVertex *BeginRenderUnit(GLuint shape, int max_vert, GLuint env1, GLuint 
 //
 void EndRenderUnit(int actual_vert)
 {
+
+    if (render_backend->RenderUnitsLocked())
+    {
+        FatalError("EndRenderUnit - Render units are locked");
+    }
+
     RendererUnit *unit;
 
     EPI_ASSERT(actual_vert >= 0);
@@ -224,6 +246,11 @@ struct Compare_Unit_pred
 void RenderCurrentUnits(void)
 {
     EDGE_ZoneScoped;
+
+    if (render_backend->RenderUnitsLocked())
+    {
+        FatalError("RenderCurrentUnits - Render units are locked");
+    }
 
     if (current_render_unit == 0)
         return;

--- a/source_files/edge/render/sokol/sokol_units.cc
+++ b/source_files/edge/render/sokol/sokol_units.cc
@@ -106,6 +106,11 @@ RGBAColor culling_fog_color;
 //
 void StartUnitBatch(bool sort_em)
 {
+    if (render_backend->RenderUnitsLocked())
+    {
+        FatalError("StartUnitBatch - Render units are locked");
+    }
+
     current_render_vert = current_render_unit = 0;
 
     batch_sort = sort_em;
@@ -120,6 +125,11 @@ void StartUnitBatch(bool sort_em)
 //
 void FinishUnitBatch(void)
 {
+    if (render_backend->RenderUnitsLocked())
+    {
+        FatalError("FinishUnitBatch - Render units are locked");
+    }
+
     RenderCurrentUnits();
 }
 
@@ -136,6 +146,11 @@ void FinishUnitBatch(void)
 RendererVertex *BeginRenderUnit(GLuint shape, int max_vert, GLuint env1, GLuint tex1, GLuint env2, GLuint tex2,
                                 int pass, int blending, RGBAColor fog_color, float fog_density)
 {
+    if (render_backend->RenderUnitsLocked())
+    {
+        FatalError("BeginRenderUnit - Render units are locked");
+    }
+
     RendererUnit *unit;
 
     EPI_ASSERT(max_vert > 0);
@@ -177,6 +192,11 @@ RendererVertex *BeginRenderUnit(GLuint shape, int max_vert, GLuint env1, GLuint 
 //
 void EndRenderUnit(int actual_vert)
 {
+    if (render_backend->RenderUnitsLocked())
+    {
+        FatalError("EndRenderUnit - Render units are locked");
+    }
+
     RendererUnit *unit;
 
     EPI_ASSERT(actual_vert >= 0);
@@ -227,6 +247,11 @@ struct Compare_Unit_pred
 void RenderCurrentUnits(void)
 {
     EDGE_ZoneScoped;
+
+    if (render_backend->RenderUnitsLocked())
+    {
+        FatalError("RenderCurrentUnits - Render units are locked");
+    }
 
     if (current_render_unit == 0)
         return;


### PR DESCRIPTION
This entirely decouples rendering from the BSP traversal.  It also adds a render unit locking mechanism which guards render unit generation around critical sections.  In case someone tries to add rendering code outside of where it should be :)  This is key for multithreading bsp traversal and render unit generation.