### PR TITLE
Rendering: Make alpha mask part of solid rendering pass

### DIFF
--- a/source_files/edge/r_render.h
+++ b/source_files/edge/r_render.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "r_gldefs.h"
+#include "r_image.h"
+#include "r_units.h"
 
 constexpr uint8_t kMaximumMirrors = 3;
 
@@ -22,3 +24,20 @@ void BspWalkNode(unsigned int);
 
 void QueueSkyWall(Seg *seg, float h1, float h2);
 void QueueSkyPlane(Subsector *sub, float h);
+
+inline BlendingMode GetBlending(float alpha, ImageOpacity opacity)
+{
+    int blending;
+
+    if (alpha >= 0.99f && opacity == kOpacitySolid)
+        blending = kBlendingNone;
+    else if (alpha >= 0.99f && opacity == kOpacityMasked)
+        blending = kBlendingMasked;
+    else
+        blending = kBlendingLess;
+
+    if (alpha < 0.99f || opacity == kOpacityComplex)
+        blending |= kBlendingAlpha;
+
+    return (BlendingMode)blending;
+}

--- a/source_files/edge/r_things.h
+++ b/source_files/edge/r_things.h
@@ -30,11 +30,9 @@
 #include "r_gldefs.h"
 
 void BSPWalkThing(DrawSubsector *dsub, MapObject *mo);
-void SortRenderThings(DrawFloor *dfloor);
+void RenderThings(DrawFloor *dfloor, bool solid);
 
 void RenderWeaponSprites(Player *p);
 void RenderWeaponModel(Player *p);
 void RenderCrosshair(Player *p);
 
-//--- editor settings ---
-// vi:ts=4:sw=4:noexpandtab


### PR DESCRIPTION
Alpha masked polygons do not need to be depth sorted unlike blended ones.  This fixes that assumption and greatly reduces the number of DrawSubsector on the transparent list.  It also means that things which are not actually transparent do not need to be sorted in their subsector.