### PR TITLE
Fix performance regression in legacy GL r_units code

### DIFF
--- a/source_files/edge/r_state.h
+++ b/source_files/edge/r_state.h
@@ -185,6 +185,11 @@ class RenderState
     virtual void Flush() = 0;
 
     virtual void SetPipeline(uint32_t flags) = 0;
+
+    // Needed only for the legacy GL render path when ending unit batches
+#ifndef EDGE_SOKOL
+    virtual void ResetGLState() = 0;
+#endif
 };
 
 extern RenderState *render_state;

--- a/source_files/edge/render/gl/gl_state.cc
+++ b/source_files/edge/render/gl/gl_state.cc
@@ -516,6 +516,33 @@ class GLRenderState : public RenderState
         EPI_UNUSED(flags);
     }
 
+    // Might need to add more here since the state's scope has expanded - Dasho
+    void ResetGLState()
+    {
+        Disable(GL_BLEND);
+        BlendFunction(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+
+        Disable(GL_ALPHA_TEST);
+
+        DepthMask(true);
+
+        CullFace(GL_BACK);
+        Disable(GL_CULL_FACE);
+
+        Disable(GL_FOG);
+
+        PolygonOffset(0, 0);
+
+        for (int i = 0; i < 2; i++)
+        {
+            bind_texture_2d_[i]                  = 0;
+            texture_environment_mode_[i]         = 0;
+            texture_environment_combine_rgb_[i]  = 0;
+            texture_environment_source_0_rgb_[i] = 0;
+            texture_wrap_t_[i]                   = 0;
+        }
+    }
+
     int frameStateChanges_ = 0;
 
   private:


### PR DESCRIPTION
While consolidating the render state and such, I tossed out a bit of texture/environment tracking that ended up causing a regression in performance when using the legacy GL render path. This restores the active_tex/active_env tracking in RenderCurrentUnits for legacy GL while leaving the Sokol path untouched.