### PR TITLE
Restore GL state reset (legacy path) after drawing models

### DIFF
--- a/source_files/edge/render/gl/gl_md2.cc
+++ b/source_files/edge/render/gl/gl_md2.cc
@@ -1334,6 +1334,8 @@ void MD2RenderModel(MD2Model *md, const Image *skin_img, bool is_weapon, int fra
             render_state->TextureWrapT(old_clamp);
         }
     }
+
+    render_state->ResetGLState();
 }
 
 void MD2RenderModel2D(MD2Model *md, const Image *skin_img, int frame, float x, float y, float xscale, float yscale,
@@ -1425,9 +1427,7 @@ void MD2RenderModel2D(MD2Model *md, const Image *skin_img, int frame, float x, f
         }
     }
 
-    render_state->Disable(GL_BLEND);
-    render_state->Disable(GL_TEXTURE_2D);
-    render_state->Disable(GL_CULL_FACE);
+    render_state->ResetGLState();
 }
 
 //--- editor settings ---

--- a/source_files/edge/render/gl/gl_mdl.cc
+++ b/source_files/edge/render/gl/gl_mdl.cc
@@ -997,6 +997,8 @@ void MDLRenderModel(MDLModel *md, bool is_weapon, int frame1, int frame2, float 
             render_state->TextureWrapT(old_clamp);
         }
     }
+
+    render_state->ResetGLState();
 }
 
 void MDLRenderModel2D(MDLModel *md, int frame, float x, float y, float xscale, float yscale,
@@ -1054,9 +1056,7 @@ void MDLRenderModel2D(MDLModel *md, int frame, float x, float y, float xscale, f
         glEnd();
     }
 
-    render_state->Disable(GL_BLEND);
-    render_state->Disable(GL_TEXTURE_2D);
-    render_state->Disable(GL_CULL_FACE);
+    render_state->ResetGLState();
 }
 
 //--- editor settings ---


### PR DESCRIPTION
This restores the state reset that is now necessary after restoring the old r_units behavior for legacy GL