### PR TITLE
Speed up level loads by improving texture lookups

### DIFF
--- a/source_files/edge/r_image.h
+++ b/source_files/edge/r_image.h
@@ -232,7 +232,15 @@ enum ImageLookupFlag
     kImageLookupFont  = 0x0008, // font character (be careful with backups)
 };
 
-Image       *ImageContainerLookup(std::list<Image *> &bucket, const char *name, int source_type = -1);
+enum ImageType
+{
+    kImageTypeTexture = 0,
+    kImageTypeGraphic,
+    kImageTypeFlat,
+    kImageTypeSprite
+};
+
+Image       *ImageContainerLookup(ImageType image_type, const char *name, int source_type = -1);
 const Image *ImageLookup(const char *name, ImageNamespace = kImageNamespaceGraphic, int flags = 0);
 
 const Image *ImageForDummySprite(void);
@@ -318,13 +326,9 @@ enum ImageSource
 };
 
 // Helper stuff for images in packages
-extern std::list<Image *>       real_graphics;
-extern std::list<Image *>       real_textures;
-extern std::list<Image *>       real_flats;
-extern std::list<Image *>       real_sprites;
 extern std::vector<std::string> TX_names;
 
-Image *AddPackImageSmart(const char *name, ImageSource type, const char *packfile_name, std::list<Image *> &container,
+Image *AddPackImageSmart(const char *name, ImageSource type, const char *packfile_name, ImageType image_type,
                          const Image *replaces = nullptr);
 
 //--- editor settings ---

--- a/source_files/edge/w_epk.cc
+++ b/source_files/edge/w_epk.cc
@@ -1164,13 +1164,13 @@ void ProcessPackSubstitutions(PackFile *pack, int pack_index)
                 LogDebug("- Adding image file in EPK: %s\n", entry.pack_path_.c_str());
 
                 if (dir_name == "textures")
-                    AddPackImageSmart(texname.c_str(), kImageSourceTXHI, entry.pack_path_.c_str(), real_textures);
+                    AddPackImageSmart(texname.c_str(), kImageSourceTXHI, entry.pack_path_.c_str(), kImageTypeTexture);
                 else if (dir_name == "graphics")
-                    AddPackImageSmart(texname.c_str(), kImageSourceGraphic, entry.pack_path_.c_str(), real_graphics);
+                    AddPackImageSmart(texname.c_str(), kImageSourceGraphic, entry.pack_path_.c_str(), kImageTypeGraphic);
                 else if (dir_name == "flats")
-                    AddPackImageSmart(texname.c_str(), kImageSourceGraphic, entry.pack_path_.c_str(), real_flats);
+                    AddPackImageSmart(texname.c_str(), kImageSourceGraphic, entry.pack_path_.c_str(), kImageTypeFlat);
                 else if (dir_name == "skins") // Not sure about this still
-                    AddPackImageSmart(texname.c_str(), kImageSourceSprite, entry.pack_path_.c_str(), real_sprites);
+                    AddPackImageSmart(texname.c_str(), kImageSourceSprite, entry.pack_path_.c_str(), kImageTypeSprite);
             }
             else
             {
@@ -1283,24 +1283,24 @@ void ProcessHiresPackSubstitutions(PackFile *pack, int pack_index)
 
             LogDebug("- Adding Hires substitute from EPK: %s\n", entry.pack_path_.c_str());
 
-            const Image *rim = ImageContainerLookup(real_textures, texname.c_str(), -2);
+            const Image *rim = ImageContainerLookup(kImageTypeTexture, texname.c_str(), -2);
             if (rim && rim->source_type_ != kImageSourceUser)
             {
-                AddPackImageSmart(texname.c_str(), kImageSourceTXHI, entry.pack_path_.c_str(), real_textures, rim);
+                AddPackImageSmart(texname.c_str(), kImageSourceTXHI, entry.pack_path_.c_str(), kImageTypeTexture, rim);
                 continue;
             }
 
-            rim = ImageContainerLookup(real_flats, texname.c_str(), -2);
+            rim = ImageContainerLookup(kImageTypeFlat, texname.c_str(), -2);
             if (rim && rim->source_type_ != kImageSourceUser)
             {
-                AddPackImageSmart(texname.c_str(), kImageSourceTXHI, entry.pack_path_.c_str(), real_flats, rim);
+                AddPackImageSmart(texname.c_str(), kImageSourceTXHI, entry.pack_path_.c_str(), kImageTypeFlat, rim);
                 continue;
             }
 
-            rim = ImageContainerLookup(real_sprites, texname.c_str(), -2);
+            rim = ImageContainerLookup(kImageTypeSprite, texname.c_str(), -2);
             if (rim && rim->source_type_ != kImageSourceUser)
             {
-                AddPackImageSmart(texname.c_str(), kImageSourceTXHI, entry.pack_path_.c_str(), real_sprites, rim);
+                AddPackImageSmart(texname.c_str(), kImageSourceTXHI, entry.pack_path_.c_str(), kImageTypeSprite, rim);
                 continue;
             }
 
@@ -1309,13 +1309,13 @@ void ProcessHiresPackSubstitutions(PackFile *pack, int pack_index)
 
             if (rim && rim->source_type_ != kImageSourceUser)
             {
-                AddPackImageSmart(texname.c_str(), kImageSourceTXHI, entry.pack_path_.c_str(), real_graphics, rim);
+                AddPackImageSmart(texname.c_str(), kImageSourceTXHI, entry.pack_path_.c_str(), kImageTypeGraphic, rim);
                 continue;
             }
 
             LogDebug("HIRES replacement '%s' has no counterpart.\n", texname.c_str());
 
-            AddPackImageSmart(texname.c_str(), kImageSourceTXHI, entry.pack_path_.c_str(), real_textures);
+            AddPackImageSmart(texname.c_str(), kImageSourceTXHI, entry.pack_path_.c_str(), kImageTypeTexture);
         }
         else
         {

--- a/source_files/epi/epi_ename.h
+++ b/source_files/epi/epi_ename.h
@@ -64,6 +64,8 @@ enum KnownEName
 #undef EPI_XY
 };
 
+typedef int32_t ENameIndex;
+
 class EName
 {
   public:
@@ -83,7 +85,7 @@ class EName
         index_ = index;
     }
 
-    int GetIndex() const
+    ENameIndex GetIndex() const
     {
         return index_;
     }
@@ -104,7 +106,7 @@ class EName
         return *this;
     }
 
-    int SetName(std::string_view text, bool no_create = false)
+    ENameIndex SetName(std::string_view text, bool no_create = false)
     {
         return index_ = name_data_.FindName(text, no_create);
     }
@@ -167,7 +169,7 @@ class EName
     }
 
   protected:
-    int index_;
+    ENameIndex index_;
 
     struct NameEntry
     {


### PR DESCRIPTION
I was waiting upwards of 40 seconds for some maps to load in debug, making debugging features pretty slow to iterate on.  This gets that time down to a couple seconds, and also greatly improves level load time of complex maps in release builds.