### PR TITLE
Revert previous model interpolated tilt fix for player weapons only

### DIFF
--- a/source_files/edge/render/gl/gl_md2.cc
+++ b/source_files/edge/render/gl/gl_md2.cc
@@ -1062,17 +1062,22 @@ void MD2RenderModel(MD2Model *md, const Image *skin_img, bool is_weapon, int fra
 
     bool tilt = is_weapon || (mo->flags_ & kMapObjectFlagMissile) || (mo->hyper_flags_ & kHyperFlagForceModelTilt);
 
-    BAMAngleToMatrix(tilt ? ~mo->vertical_angle_ : 0, &data.mouselook_x_matrix_, &data.mouselook_z_matrix_);
-
     if (uncapped_frames.d_ && !paused && !menu_active && !rts_menu_active &&
         (is_weapon || (!time_stop_active && !erraticism_active)))
     {
+        if (is_weapon)
+            BAMAngleToMatrix(tilt ? ~epi::BAMInterpolate(mo->old_vertical_angle_, mo->vertical_angle_, fractional_tic) : 0,
+                            &data.mouselook_x_matrix_, &data.mouselook_z_matrix_);
+        else
+            BAMAngleToMatrix(tilt ? ~mo->vertical_angle_ : 0, &data.mouselook_x_matrix_, &data.mouselook_z_matrix_);
+        
         BAMAngle ang = epi::BAMInterpolate(mo->old_angle_, mo->angle_, fractional_tic) + rotation;
         render_mirror_set.Angle(ang);
         BAMAngleToMatrix(~ang, &data.rotation_x_matrix_, &data.rotation_y_matrix_);
     }
     else
     {
+        BAMAngleToMatrix(tilt ? ~mo->vertical_angle_ : 0, &data.mouselook_x_matrix_, &data.mouselook_z_matrix_);
         BAMAngle ang = mo->angle_ + rotation;
         render_mirror_set.Angle(ang);
         BAMAngleToMatrix(~ang, &data.rotation_x_matrix_, &data.rotation_y_matrix_);

--- a/source_files/edge/render/gl/gl_mdl.cc
+++ b/source_files/edge/render/gl/gl_mdl.cc
@@ -729,17 +729,22 @@ void MDLRenderModel(MDLModel *md, bool is_weapon, int frame1, int frame2, float 
 
     bool tilt = is_weapon || (mo->flags_ & kMapObjectFlagMissile) || (mo->hyper_flags_ & kHyperFlagForceModelTilt);
 
-    BAMAngleToMatrix(tilt ? ~mo->vertical_angle_ : 0, &data.mouselook_x_vector_, &data.mouselook_z_vector_);
-
     if (uncapped_frames.d_ && !paused && !menu_active && !rts_menu_active &&
         (is_weapon || (!time_stop_active && !erraticism_active)))
     {
+        if (is_weapon)
+            BAMAngleToMatrix(tilt ? ~epi::BAMInterpolate(mo->old_vertical_angle_, mo->vertical_angle_, fractional_tic) : 0,
+                            &data.mouselook_x_vector_, &data.mouselook_z_vector_);
+        else
+            BAMAngleToMatrix(tilt ? ~mo->vertical_angle_ : 0, &data.mouselook_x_vector_, &data.mouselook_z_vector_);
+        
         BAMAngle ang = epi::BAMInterpolate(mo->old_angle_, mo->angle_, fractional_tic) + rotation;
         render_mirror_set.Angle(ang);
         BAMAngleToMatrix(~ang, &data.rotation_vector_x_, &data.rotation_vector_y_);
     }
     else
     {
+        BAMAngleToMatrix(tilt ? ~mo->vertical_angle_ : 0, &data.mouselook_x_vector_, &data.mouselook_z_vector_);
         BAMAngle ang = mo->angle_ + rotation;
         render_mirror_set.Angle(ang);
         BAMAngleToMatrix(~ang, &data.rotation_vector_x_, &data.rotation_vector_y_);

--- a/source_files/edge/render/sokol/sokol_md2.cc
+++ b/source_files/edge/render/sokol/sokol_md2.cc
@@ -1067,17 +1067,22 @@ void MD2RenderModel(MD2Model *md, const Image *skin_img, bool is_weapon, int fra
 
     bool tilt = is_weapon || (mo->flags_ & kMapObjectFlagMissile) || (mo->hyper_flags_ & kHyperFlagForceModelTilt);
 
-    BAMAngleToMatrix(tilt ? ~mo->vertical_angle_ : 0, &data.mouselook_x_matrix_, &data.mouselook_z_matrix_);
-
     if (uncapped_frames.d_ && !paused && !menu_active && !rts_menu_active &&
         (is_weapon || (!time_stop_active && !erraticism_active)))
     {
+        if (is_weapon)
+            BAMAngleToMatrix(tilt ? ~epi::BAMInterpolate(mo->old_vertical_angle_, mo->vertical_angle_, fractional_tic) : 0,
+                            &data.mouselook_x_matrix_, &data.mouselook_z_matrix_);
+        else
+            BAMAngleToMatrix(tilt ? ~mo->vertical_angle_ : 0, &data.mouselook_x_matrix_, &data.mouselook_z_matrix_);
+        
         BAMAngle ang = epi::BAMInterpolate(mo->old_angle_, mo->angle_, fractional_tic) + rotation;
         render_mirror_set.Angle(ang);
         BAMAngleToMatrix(~ang, &data.rotation_x_matrix_, &data.rotation_y_matrix_);
     }
     else
     {
+        BAMAngleToMatrix(tilt ? ~mo->vertical_angle_ : 0, &data.mouselook_x_matrix_, &data.mouselook_z_matrix_);
         BAMAngle ang = mo->angle_ + rotation;
         render_mirror_set.Angle(ang);
         BAMAngleToMatrix(~ang, &data.rotation_x_matrix_, &data.rotation_y_matrix_);

--- a/source_files/edge/render/sokol/sokol_mdl.cc
+++ b/source_files/edge/render/sokol/sokol_mdl.cc
@@ -737,12 +737,19 @@ void MDLRenderModel(MDLModel *md, bool is_weapon, int frame1, int frame2, float 
     if (uncapped_frames.d_ && !paused && !menu_active && !rts_menu_active &&
         (is_weapon || (!time_stop_active && !erraticism_active)))
     {
+        if (is_weapon)
+            BAMAngleToMatrix(tilt ? ~epi::BAMInterpolate(mo->old_vertical_angle_, mo->vertical_angle_, fractional_tic) : 0,
+                            &data.mouselook_x_vector_, &data.mouselook_z_vector_);
+        else
+            BAMAngleToMatrix(tilt ? ~mo->vertical_angle_ : 0, &data.mouselook_x_vector_, &data.mouselook_z_vector_);
+        
         BAMAngle ang = epi::BAMInterpolate(mo->old_angle_, mo->angle_, fractional_tic) + rotation;
         render_mirror_set.Angle(ang);
         BAMAngleToMatrix(~ang, &data.rotation_vector_x_, &data.rotation_vector_y_);
     }
     else
     {
+        BAMAngleToMatrix(tilt ? ~mo->vertical_angle_ : 0, &data.mouselook_x_vector_, &data.mouselook_z_vector_);
         BAMAngle ang = mo->angle_ + rotation;
         render_mirror_set.Angle(ang);
         BAMAngleToMatrix(~ang, &data.rotation_vector_x_, &data.rotation_vector_y_);


### PR DESCRIPTION
Restores the tilt interpolation that https://github.com/edge-classic/EDGE-classic/commit/9b11f4d4a262bc3f3a8b17b558f0b5d8c736ef77 removed, but only for weapons; there was a lot of jitter otherwise.