### PR TITLE
Tweak sky fog density when using Vanilla sky stretch option

### DIFF
--- a/source_files/edge/r_sky.cc
+++ b/source_files/edge/r_sky.cc
@@ -374,7 +374,7 @@ static void RenderSkyCylinder(void)
     }
     else if (fc_to_use != kRGBANoValue)
     {
-        fd_to_use *= 0.005f;
+        fd_to_use *= (current_sky_stretch == kSkyStretchVanilla ? 0.015f : 0.005f);
     }
 
     // Render top cap


### PR DESCRIPTION
Fixes https://github.com/edge-classic/EDGE-classic/issues/769