### PR TITLE
Renderer Default Updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,24 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 option(EDGE_SOKOL_GL "Sokol GL" OFF)
 option(EDGE_SOKOL_GLES3 "Sokol GLES3" OFF)
 option(EDGE_SOKOL_D3D11 "Sokol D3D11" OFF)
+option(EDGE_LEGACY_GL "Legacy GL Renderer" OFF)
+
+# If the legacy GL renderer has not been selected and
+# a Sokol backend is not already specified by CMake params, 
+# choose a default based on platform
+if (NOT EDGE_LEGACY_GL)
+  if (NOT EDGE_SOKOL_GL AND NOT EDGE_SOKOL_D3D11 AND NOT EDGE_SOKOL_GLES3)
+    if (WIN32 OR MINGW)
+      set (EDGE_SOKOL_D3D11 ON)
+    elseif (EMSCRIPTEN)
+      set (EDGE_SOKOL_GLES3 ON)
+  # Unix; Apple will eventually have a Metal backend but it should support 
+  # the level of GL in use by Sokol GFX/GL
+    else ()
+      set (EDGE_SOKOL_GL ON)
+    endif()
+  endif()
+endif()
 
 if (EDGE_SOKOL_GL OR EDGE_SOKOL_GLES3 OR EDGE_SOKOL_D3D11)
   set (EDGE_SOKOL ON)

--- a/source_files/edge/am_map.cc
+++ b/source_files/edge/am_map.cc
@@ -1092,7 +1092,7 @@ static void AutomapDrawPlayer(MapObject *mo)
 
     float mx, my, ma;
 
-    if (uncapped_frames.d_ && !paused && !menu_active)
+    if (!paused && !menu_active)
     {
         mx = HMM_Lerp(mo->old_x_, fractional_tic, mo->x);
         my = HMM_Lerp(mo->old_y_, fractional_tic, mo->y);
@@ -1162,7 +1162,7 @@ static void AutomapWalkThing(MapObject *mo)
 
     float mx, my, ma;
 
-    if (uncapped_frames.d_ && !paused && !menu_active)
+    if (!paused && !menu_active)
     {
         mx = HMM_Lerp(mo->old_x_, fractional_tic, mo->x);
         my = HMM_Lerp(mo->old_y_, fractional_tic, mo->y);
@@ -1304,7 +1304,7 @@ void AutomapRender(float x, float y, float w, float h, MapObject *focus)
 
     if (follow_player)
     {
-        if (uncapped_frames.d_ && !paused && !menu_active)
+        if (!paused && !menu_active)
         {
             map_center_x = HMM_Lerp(frame_focus->old_x_, fractional_tic, frame_focus->x);
             map_center_y = HMM_Lerp(frame_focus->old_y_, fractional_tic, frame_focus->y);

--- a/source_files/edge/con_con.cc
+++ b/source_files/edge/con_con.cc
@@ -860,12 +860,9 @@ void ConsoleDrawer(void)
 
     if (console_wipe_active)
     {
-        if (uncapped_frames.d_)
-            y = (int)((float)y - CON_GFX_HT *
-                                     HMM_Lerp(old_console_wipe_position, fractional_tic, console_wipe_position) /
-                                     kConsoleWipeTics);
-        else
-            y = y - CON_GFX_HT * console_wipe_position / kConsoleWipeTics;
+        y = (int)((float)y - CON_GFX_HT *
+                                    HMM_Lerp(old_console_wipe_position, fractional_tic, console_wipe_position) /
+                                    kConsoleWipeTics);
     }
     else
         y = y - CON_GFX_HT;

--- a/source_files/edge/i_video.cc
+++ b/source_files/edge/i_video.cc
@@ -435,7 +435,7 @@ void FinishFrame(void)
             GrabCursor(true);
     }
 
-    if (uncapped_frames.d_ && !single_tics)
+    if (!single_tics)
     {
         if (framerate_limit.d_ >= kTicRate)
         {
@@ -464,8 +464,7 @@ void FinishFrame(void)
         }
     }
 
-    if (uncapped_frames.d_)
-        fractional_tic = (float)(GetMilliseconds() * kTicRate % 1000) / 1000;
+    fractional_tic = (float)(GetMilliseconds() * kTicRate % 1000) / 1000;
 
     if (vsync.CheckModified())
     {

--- a/source_files/edge/n_network.cc
+++ b/source_files/edge/n_network.cc
@@ -51,7 +51,6 @@ bool network_game = false;
 
 EDGE_DEFINE_CONSOLE_VARIABLE(busy_wait, "1",
                              kConsoleVariableFlagReadOnly) // Not sure what to rename this yet - Dasho
-EDGE_DEFINE_CONSOLE_VARIABLE(uncapped_frames, "1", kConsoleVariableFlagArchive)
 
 #if !defined(__MINGW32__) && (defined(WIN32) || defined(_WIN32) || defined(_WIN64))
 HANDLE windows_timer = nullptr;
@@ -262,7 +261,7 @@ int TryRunTicCommands()
     // decide how many tics to run...
     int tics = make_tic - game_tic;
 
-    if (tics == 0 && game_tic && uncapped_frames.d_)
+    if (tics == 0 && game_tic)
         return 0;
 
     if (tics < 0)

--- a/source_files/edge/n_network.h
+++ b/source_files/edge/n_network.h
@@ -23,7 +23,6 @@
 extern bool            network_game;
 extern int             game_tic;
 extern float           fractional_tic;
-extern ConsoleVariable uncapped_frames;
 
 void NetworkInitialize(void);
 void NetworkShutdown(void);

--- a/source_files/edge/p_enemy.cc
+++ b/source_files/edge/p_enemy.cc
@@ -44,8 +44,6 @@
 #include "s_sound.h"
 #include "w_wad.h"
 
-extern ConsoleVariable uncapped_frames;
-
 DirectionType opposite[] = {kDirectionWest,      kDirectionSouthwest, kDirectionSouth,
                             kDirectionSoutheast, kDirectionEast,      kDirectionNorthEast,
                             kDirectionNorth,     kDirectionNorthWest, kDirectionNone};
@@ -269,7 +267,7 @@ bool DoMove(MapObject *actor, bool path)
     // -AJA- 2008/01/16: position interpolation
     if ((actor->state_->flags & kStateFrameFlagModel) || (actor->flags_ & kMapObjectFlagFloat))
     {
-        if (!uncapped_frames.d_ || actor->old_x_ != kInvalidPosition)
+        if (actor->old_x_ != kInvalidPosition)
         {
             actor->interpolation_number_   = HMM_Clamp(2, actor->state_->tics, 10);
             actor->interpolation_position_ = 1;

--- a/source_files/edge/r_bsp.cc
+++ b/source_files/edge/r_bsp.cc
@@ -128,7 +128,7 @@ static Subsector *bsp_current_subsector;
 
 static void UpdateSectorInterpolation(Sector *sector)
 {
-    if (uncapped_frames.d_ && !time_stop_active && !paused && !erraticism_active && !menu_active && !rts_menu_active)
+    if (!time_stop_active && !paused && !erraticism_active && !menu_active && !rts_menu_active)
     {
         // Interpolate between current and last floor/ceiling position.
         if (!AlmostEquals(sector->floor_height, sector->old_floor_height))

--- a/source_files/edge/r_effects.cc
+++ b/source_files/edge/r_effects.cc
@@ -305,16 +305,8 @@ void FuzzUpdate(void)
 
 void FuzzAdjust(HMM_Vec2 *tc, MapObject *mo)
 {
-    if (uncapped_frames.d_)
-    {
-        tc->X += fmod(HMM_Lerp(mo->old_x_, fractional_tic, mo->x) / 520.0, 1.0);
-        tc->Y += fmod(HMM_Lerp(mo->old_y_, fractional_tic, mo->y) / 520.0, 1.0) + fuzz_y_offset;
-    }
-    else
-    {
-        tc->X += fmod(mo->x / 520.0, 1.0);
-        tc->Y += fmod(mo->y / 520.0, 1.0) + fuzz_y_offset;
-    }
+    tc->X += fmod(HMM_Lerp(mo->old_x_, fractional_tic, mo->x) / 520.0, 1.0);
+    tc->Y += fmod(HMM_Lerp(mo->old_y_, fractional_tic, mo->y) / 520.0, 1.0) + fuzz_y_offset;
 }
 
 //--- editor settings ---

--- a/source_files/edge/r_render.cc
+++ b/source_files/edge/r_render.cc
@@ -695,7 +695,7 @@ static void DrawSlidingDoor(DrawFloor *dfloor, float c, float f, float tex_top_h
 
     if (smov)
     {
-        if (uncapped_frames.d_ && !menu_active && !paused && !time_stop_active && !erraticism_active &&
+        if (!menu_active && !paused && !time_stop_active && !erraticism_active &&
             !rts_menu_active)
             opening = HMM_Lerp(smov->old_opening, fractional_tic, smov->opening);
         else
@@ -871,12 +871,12 @@ static void DrawTile(Seg *seg, DrawFloor *dfloor, float lz1, float lz2, float rz
 
     float offx, offy;
 
-    if (uncapped_frames.d_ && !AlmostEquals(surf->old_offset.X, surf->offset.X) && !paused && !menu_active &&
+    if (!AlmostEquals(surf->old_offset.X, surf->offset.X) && !paused && !menu_active &&
         !time_stop_active && !erraticism_active)
         offx = fmod(HMM_Lerp(surf->old_offset.X, fractional_tic, surf->offset.X), surf->image->actual_width_);
     else
         offx = surf->offset.X;
-    if (uncapped_frames.d_ && !AlmostEquals(surf->old_offset.Y, surf->offset.Y) && !paused && !menu_active &&
+    if (!AlmostEquals(surf->old_offset.Y, surf->offset.Y) && !paused && !menu_active &&
         !time_stop_active && !erraticism_active)
         offy = fmod(HMM_Lerp(surf->old_offset.Y, fractional_tic, surf->offset.Y), surf->image->actual_height_);
     else
@@ -1670,12 +1670,12 @@ static void RenderPlane(DrawFloor *dfloor, float h, MapSurface *surf, int face_d
     data.v_count  = v_count;
     data.vertices = vertices;
     data.R = data.G = data.B = 255;
-    if (uncapped_frames.d_ && !AlmostEquals(surf->old_offset.X, surf->offset.X) && !paused && !menu_active &&
+    if (!AlmostEquals(surf->old_offset.X, surf->offset.X) && !paused && !menu_active &&
         !time_stop_active && !erraticism_active)
         data.tx0 = fmod(HMM_Lerp(surf->old_offset.X, fractional_tic, surf->offset.X), surf->image->actual_width_);
     else
         data.tx0 = surf->offset.X;
-    if (uncapped_frames.d_ && !AlmostEquals(surf->old_offset.Y, surf->offset.Y) && !paused && !menu_active &&
+    if (!AlmostEquals(surf->old_offset.Y, surf->offset.Y) && !paused && !menu_active &&
         !time_stop_active && !erraticism_active)
         data.ty0 = fmod(HMM_Lerp(surf->old_offset.Y, fractional_tic, surf->offset.Y), surf->image->actual_height_);
     else
@@ -1885,7 +1885,7 @@ static void InitializeCamera(MapObject *mo, bool full_height, float expand_w)
 
     view_x_slope *= widescreen_view_width_multiplier;
 
-    if (uncapped_frames.d_ && level_time_elapsed && mo->player_ && mo->interpolate_ && !paused && !menu_active &&
+    if (level_time_elapsed && mo->player_ && mo->interpolate_ && !paused && !menu_active &&
         !rts_menu_active)
     {
         view_x     = HMM_Lerp(mo->old_x_, fractional_tic, mo->x);

--- a/source_files/edge/r_things.cc
+++ b/source_files/edge/r_things.cc
@@ -229,7 +229,7 @@ static void RenderPSprite(PlayerSprite *psp, int which, Player *player, RegionPr
 
     float psp_x, psp_y;
 
-    if (uncapped_frames.d_ && !paused && !menu_active && !rts_menu_active)
+    if (!paused && !menu_active && !rts_menu_active)
     {
         psp_x = HMM_Lerp(psp->old_screen_x, fractional_tic, psp->screen_x);
         psp_y = HMM_Lerp(psp->old_screen_y, fractional_tic, psp->screen_y);
@@ -636,7 +636,7 @@ void RenderWeaponModel(Player *p)
 
     float psp_x, psp_y;
 
-    if (uncapped_frames.d_ && !paused && !menu_active && !erraticism_active && !rts_menu_active)
+    if (!paused && !menu_active && !erraticism_active && !rts_menu_active)
     {
         psp_x = HMM_Lerp(psp->old_screen_x, fractional_tic, psp->screen_x);
         psp_y = HMM_Lerp(psp->old_screen_y, fractional_tic, psp->screen_y);
@@ -745,7 +745,7 @@ static const Image *RendererGetThingSprite2(MapObject *mo, float mx, float my, b
     {
         BAMAngle ang;
 
-        if (uncapped_frames.d_ && mo->interpolate_ && !paused && !menu_active && !erraticism_active && !rts_menu_active)
+        if (mo->interpolate_ && !paused && !menu_active && !erraticism_active && !rts_menu_active)
             ang = epi::BAMInterpolate(mo->old_angle_, mo->angle_, fractional_tic);
         else
             ang = mo->angle_;
@@ -849,7 +849,7 @@ void BSPWalkThing(DrawSubsector *dsub, MapObject *mo)
     float mx, my, mz, fz;
 
     // position interpolation
-    if (uncapped_frames.d_ && mo->interpolate_ && !paused && !menu_active && !erraticism_active && !rts_menu_active)
+    if (mo->interpolate_ && !paused && !menu_active && !erraticism_active && !rts_menu_active)
     {
         mx = HMM_Lerp(mo->old_x_, fractional_tic, mo->x);
         my = HMM_Lerp(mo->old_y_, fractional_tic, mo->y);

--- a/source_files/edge/r_wipe.cc
+++ b/source_files/edge/r_wipe.cc
@@ -248,12 +248,7 @@ static void RendererWipeMelt(void)
 
     for (int x = 0; x <= kMeltSections; x++, glvert++)
     {
-        int yoffs = 0;
-
-        if (uncapped_frames.d_)
-            yoffs = HMM_MAX(0, HMM_Lerp(old_melt_yoffs[x], fractional_tic, melt_yoffs[x]));
-        else
-            yoffs = HMM_MAX(0, melt_yoffs[x]);
+        int yoffs = HMM_MAX(0, HMM_Lerp(old_melt_yoffs[x], fractional_tic, melt_yoffs[x]));
 
         float sx = (float)x * current_screen_width / kMeltSections;
         float sy = (float)(200 - yoffs) * current_screen_height / 200.0f;
@@ -369,7 +364,7 @@ bool DoWipe(void)
 
     float how_far = 0.0f;
 
-    if (uncapped_frames.d_ && tics == 0)
+    if (tics == 0)
         how_far = ((float)current_wipe_progress + fractional_tic) / 40.0f;
     else
         how_far = (float)current_wipe_progress / 40.0f;

--- a/source_files/edge/render/gl/gl_md2.cc
+++ b/source_files/edge/render/gl/gl_md2.cc
@@ -1062,7 +1062,7 @@ void MD2RenderModel(MD2Model *md, const Image *skin_img, bool is_weapon, int fra
 
     bool tilt = is_weapon || (mo->flags_ & kMapObjectFlagMissile) || (mo->hyper_flags_ & kHyperFlagForceModelTilt);
 
-    if (uncapped_frames.d_ && !paused && !menu_active && !rts_menu_active &&
+    if (!paused && !menu_active && !rts_menu_active &&
         (is_weapon || (!time_stop_active && !erraticism_active)))
     {
         if (is_weapon)

--- a/source_files/edge/render/gl/gl_mdl.cc
+++ b/source_files/edge/render/gl/gl_mdl.cc
@@ -729,7 +729,7 @@ void MDLRenderModel(MDLModel *md, bool is_weapon, int frame1, int frame2, float 
 
     bool tilt = is_weapon || (mo->flags_ & kMapObjectFlagMissile) || (mo->hyper_flags_ & kHyperFlagForceModelTilt);
 
-    if (uncapped_frames.d_ && !paused && !menu_active && !rts_menu_active &&
+    if (!paused && !menu_active && !rts_menu_active &&
         (is_weapon || (!time_stop_active && !erraticism_active)))
     {
         if (is_weapon)

--- a/source_files/edge/render/sokol/sokol_md2.cc
+++ b/source_files/edge/render/sokol/sokol_md2.cc
@@ -1067,7 +1067,7 @@ void MD2RenderModel(MD2Model *md, const Image *skin_img, bool is_weapon, int fra
 
     bool tilt = is_weapon || (mo->flags_ & kMapObjectFlagMissile) || (mo->hyper_flags_ & kHyperFlagForceModelTilt);
 
-    if (uncapped_frames.d_ && !paused && !menu_active && !rts_menu_active &&
+    if (!paused && !menu_active && !rts_menu_active &&
         (is_weapon || (!time_stop_active && !erraticism_active)))
     {
         if (is_weapon)

--- a/source_files/edge/render/sokol/sokol_mdl.cc
+++ b/source_files/edge/render/sokol/sokol_mdl.cc
@@ -734,7 +734,7 @@ void MDLRenderModel(MDLModel *md, bool is_weapon, int frame1, int frame2, float 
 
     BAMAngleToMatrix(tilt ? ~mo->vertical_angle_ : 0, &data.mouselook_x_vector_, &data.mouselook_z_vector_);
 
-    if (uncapped_frames.d_ && !paused && !menu_active && !rts_menu_active &&
+    if (!paused && !menu_active && !rts_menu_active &&
         (is_weapon || (!time_stop_active && !erraticism_active)))
     {
         if (is_weapon)


### PR DESCRIPTION
This removes the "uncapped_frames" CVAR and sets all behavior as if it was enabled. Additionally, this will set the Sokol render path as the default, with a platform-appropriate backend selected (D3D11/GLES3/GL) unless the EDGE_LEGACY_GL CMake option is set to ON. Sokol backend preferences passed to CMake will be respected as well (i.e., specifying the GLES3 backend on a platform that would normally default to GL, etc).