### PR TITLE
Sky fog density fixes

### DIFF
--- a/source_files/edge/r_sky.cc
+++ b/source_files/edge/r_sky.cc
@@ -374,7 +374,11 @@ static void RenderSkyCylinder(void)
     }
     else if (fc_to_use != kRGBANoValue)
     {
+#ifdef EDGE_SOKOL
+        fd_to_use *= (current_sky_stretch == kSkyStretchVanilla ? 0.009f : 0.003f);
+#else
         fd_to_use *= (current_sky_stretch == kSkyStretchVanilla ? 0.015f : 0.005f);
+#endif
     }
 
     // Render top cap

--- a/source_files/edge/render/gl/gl_units.cc
+++ b/source_files/edge/render/gl/gl_units.cc
@@ -354,7 +354,7 @@ void RenderCurrentUnits(void)
                 active_fog_density = unit->fog_density;
                 state->FogDensity(std::log1p(active_fog_density));
             }
-            if (active_fog_density > 0.00009f)
+            if (!AlmostEquals(active_fog_density, 0.0f))
                 state->Enable(GL_FOG);
             else
                 state->Disable(GL_FOG);


### PR DESCRIPTION
This fixes the following issues with sky fog:
- Legacy GL renderer was still using a minimum threshold for fog density (instead of checking AlmostEquals for not being 0.0f), causing sky fog to be disabled as it wasn't meeting said threshold
- Sky fog densities have been adjusted per renderer to be consistent with each other