### PR TITLE
Revert COAL memory blocks to use char instead of double

### DIFF
--- a/source_files/coal/c_local.h
+++ b/source_files/coal/c_local.h
@@ -38,7 +38,7 @@ struct MemoryBlock
 {
     int used = 0;
 
-    double data[4096];
+    char data[4096];
 };
 
 class MemoryBlockGroup


### PR DESCRIPTION
Addresses https://github.com/edge-classic/EDGE-classic/issues/883