### PR TITLE
Automap Rendering Improvements

### DIFF
--- a/source_files/edge/am_map.h
+++ b/source_files/edge/am_map.h
@@ -25,41 +25,11 @@
 
 #pragma once
 
+#include <vector>
+
 #include "con_var.h"
 #include "e_event.h"
 #include "p_mobj.h"
-
-extern bool            automap_active;
-extern bool            rotate_map;
-extern bool            automap_keydoor_blink;
-extern ConsoleVariable automap_keydoor_text;
-
-struct AutomapPoint
-{
-    float x, y;
-};
-
-struct AutomapLine
-{
-    AutomapPoint a, b;
-};
-
-void AutomapInitLevel(void);
-
-// Called by main loop.
-bool AutomapResponder(InputEvent *ev);
-
-// Called by main loop.
-void AutomapTicker(void);
-
-// Called to draw the automap on the screen.
-void AutomapRender(float x, float y, float w, float h, MapObject *focus);
-
-// Called to force the automap to quit
-// if the level is completed while it is up.
-void AutomapStop(void);
-
-// color setting API
 
 // NOTE: these numbers here must match the COAL API script
 enum AutomapColor
@@ -80,8 +50,6 @@ enum AutomapColor
     kTotalAutomapColors
 };
 
-void AutomapSetColor(int which, RGBAColor color);
-
 // NOTE: the bit numbers here must match the COAL API script
 enum AutomapState
 {
@@ -100,6 +68,34 @@ enum AutomapArrowStyle
     kAutomapArrowStyleHeretic,
     kTotalAutomapArrowStyles
 };
+struct AutomapLine
+{
+    HMM_Vec4 points;
+    RGBAColor color;
+};
+
+extern std::vector<AutomapLine *> automap_lines;
+extern bool            automap_active;
+extern bool            rotate_map;
+extern bool            automap_keydoor_blink;
+extern ConsoleVariable automap_keydoor_text;
+
+void AutomapInitLevel(void);
+
+// Called by main loop.
+bool AutomapResponder(InputEvent *ev);
+
+// Called by main loop.
+void AutomapTicker(void);
+
+// Called to draw the automap on the screen.
+void AutomapRender(float x, float y, float w, float h, MapObject *focus);
+
+// Called to force the automap to quit
+// if the level is completed while it is up.
+void AutomapStop(void);
+
+void AutomapSetColor(int which, RGBAColor color);
 
 void AutomapSetArrow(AutomapArrowStyle type);
 

--- a/source_files/edge/hu_draw.cc
+++ b/source_files/edge/hu_draw.cc
@@ -85,12 +85,12 @@ std::vector<std::string> hud_overlays = {
     "OVERLAY_GRILL_2X",
 };
 
-static inline float HUDToRealCoordinatesX(float x)
+float HUDToRealCoordinatesX(float x)
 {
     return margin_x + x * margin_x_multiplier;
 }
 
-static inline float HUDToRealCoordinatesY(float y)
+float HUDToRealCoordinatesY(float y)
 {
     return margin_y - y * margin_y_multiplier;
 }
@@ -792,21 +792,14 @@ void HUDSolidBox(float x1, float y1, float x2, float y2, RGBAColor col)
     FinishUnitBatch();
 }
 
-void HUDSolidLine(float x1, float y1, float x2, float y2, RGBAColor col, float thickness, bool smooth, float dx,
-                  float dy)
+void HUDSolidLine(float x1, float y1, float x2, float y2, RGBAColor col)
 {
     x1 = HUDToRealCoordinatesX(x1);
     y1 = HUDToRealCoordinatesY(y1);
     x2 = HUDToRealCoordinatesX(x2);
     y2 = HUDToRealCoordinatesY(y2);
 
-    dx = HUDToRealCoordinatesX(dx) - HUDToRealCoordinatesX(0);
-    dy = HUDToRealCoordinatesY(0) - HUDToRealCoordinatesY(dy);
-
-    render_state->LineWidth(thickness);
-
-    if (smooth)
-        render_state->Enable(GL_LINE_SMOOTH);
+    render_state->Enable(GL_LINE_SMOOTH);
 
     StartUnitBatch(false);
 
@@ -814,22 +807,21 @@ void HUDSolidLine(float x1, float y1, float x2, float y2, RGBAColor col, float t
     epi::SetRGBAAlpha(unit_col, current_alpha);
     BlendingMode blend = kBlendingNone;
 
-    if (smooth || current_alpha < 0.99f)
+    if (current_alpha < 0.99f)
         blend = kBlendingAlpha;
 
     RendererVertex *glvert =
         BeginRenderUnit(GL_LINES, 2, GL_MODULATE, 0, (GLuint)kTextureEnvironmentDisable, 0, 0, blend);
 
     glvert->rgba       = unit_col;
-    glvert++->position = {{x1 + dx, y1 + dy, 0}};
+    glvert++->position = {{x1, y1, 0}};
     glvert->rgba       = unit_col;
-    glvert->position   = {{x2 + dx, y2 + dy, 0}};
+    glvert->position   = {{x2, y2, 0}};
 
     EndRenderUnit(2);
 
     FinishUnitBatch();
     render_state->Disable(GL_LINE_SMOOTH);
-    render_state->LineWidth(1.0f);
 }
 
 void HUDThinBox(float x1, float y1, float x2, float y2, RGBAColor col, float thickness, BlendingMode special_blend)

--- a/source_files/edge/hu_draw.h
+++ b/source_files/edge/hu_draw.h
@@ -38,6 +38,8 @@ extern float                    hud_visible_bottom;
 extern std::vector<std::string> hud_overlays;
 
 void HUDSetCoordinateSystem(int width, int height);
+float HUDToRealCoordinatesX(float x);
+float HUDToRealCoordinatesY(float y);
 
 void  HUDSetFont(Font *font = nullptr);
 void  HUDSetScale(float scale = 1.0f);
@@ -69,10 +71,8 @@ void HUDSolidBox(float x1, float y1, float x2, float y2, RGBAColor col);
 
 // Draw a solid colour line (possibly translucent) between the two
 // end points.  Coordinates are inclusive.  Drawing will be clipped
-// to the current scissor rectangle.  The dx/dy fields are used by
-// the automap code to reduce the wobblies.
-void HUDSolidLine(float x1, float y1, float x2, float y2, RGBAColor col, float thickness = 1, bool smooth = true,
-                  float dx = 0, float dy = 0);
+// to the current scissor rectangle.
+void HUDSolidLine(float x1, float y1, float x2, float y2, RGBAColor col);
 
 // Draw a thin outline of a box.
 void HUDThinBox(float x1, float y1, float x2, float y2, RGBAColor col, float thickness = 0.0f,

--- a/source_files/edge/r_misc.cc
+++ b/source_files/edge/r_misc.cc
@@ -31,6 +31,7 @@
 #include <math.h>
 
 #include "AlmostEquals.h"
+#include "am_map.h"
 #include "dm_defs.h"
 #include "dm_state.h"
 #include "e_main.h"
@@ -319,12 +320,14 @@ void AllocateDrawStructs(void)
     size += sizeof(DrawSeg) * kDefaultDrawSegs;
     size += sizeof(DrawSubsector) * kDefaultDrawSubsectors;
     size += sizeof(DrawMirror) * kDefaultDrawMirrors;
+    size += sizeof(AutomapLine) * kDefaultAutomapLines;
 
     draw_things.reserve(kDefaultDrawThings);
     draw_floors.reserve(kDefaultDrawFloors);
     draw_segs.reserve(kDefaultDrawSegs);
     draw_subsectors.reserve(kDefaultDrawSubsectors);
     draw_mirrors.reserve(kDefaultDrawMirrors);
+    automap_lines.reserve(kDefaultAutomapLines);
 
     draw_memory_buffer = malloc(size);
 
@@ -353,6 +356,11 @@ void AllocateDrawStructs(void)
     for (uint32_t i = 0; i < kDefaultDrawMirrors; i++, dst += sizeof(DrawMirror))
     {
         draw_mirrors.emplace_back(new (dst) DrawMirror());
+    }
+
+    for (uint32_t i = 0; i < kDefaultAutomapLines; i++, dst += sizeof(AutomapLine))
+    {
+        automap_lines.emplace_back(new (dst) AutomapLine());
     }
 }
 
@@ -402,11 +410,17 @@ void FreeBSP(void)
         free(draw_mirrors[i]);
     } 
 
+    for (size_t i = kDefaultAutomapLines; i < automap_lines.size(); i++)
+    {
+        free(automap_lines[i]);
+    } 
+
     draw_things.clear();
     draw_floors.clear();
     draw_segs.clear();
     draw_subsectors.clear();
     draw_mirrors.clear();
+    automap_lines.clear();
 
     ClearBSP();
 }

--- a/source_files/edge/r_units.h
+++ b/source_files/edge/r_units.h
@@ -32,6 +32,11 @@
 constexpr uint16_t kDummyClamp             = 789;
 constexpr uint8_t  kMaximumPolygonVertices = 64;
 constexpr uint16_t kMaximumLocalVertices   = 65535;
+#ifndef EDGE_SOKOL
+constexpr uint16_t kDefaultAutomapLines = kMaximumLocalVertices / 2;
+#else
+constexpr uint16_t kDefaultAutomapLines = kMaximumLocalVertices / 4;
+#endif
 
 // a single vertex to pass to the GPU
 struct RendererVertex

--- a/source_files/edge/render/sokol/sokol_units.cc
+++ b/source_files/edge/render/sokol/sokol_units.cc
@@ -268,7 +268,7 @@ static void RenderFlush()
             num_vertices += unit->count;
             break;
         case GL_LINES:
-            num_vertices += unit->count;
+            num_vertices += unit->count * 2; // quads
             break;
         }
     }
@@ -565,7 +565,7 @@ void RenderCurrentUnits(void)
                 // so can have a shader specifically for lines
 
                 sgl_enable_line();
-                sgl_begin_triangles();
+                sgl_begin_quads();
 
                 const RendererVertex *V = local_verts + unit->first;
 
@@ -603,23 +603,17 @@ void RenderCurrentUnits(void)
 
                     float factor = 0.5f;
 
+                    sgl_v3f_t4f_c4b(a1.X, a1.Y, src_v0->position.Z, line_width, -factor * line_length, line_width,
+                        factor * line_length, red, green, blue, alpha);
+
                     sgl_v3f_t4f_c4b(a0.X, a0.Y, src_v0->position.Z, -line_width, -factor * line_length, line_width,
-                                    factor * line_length, red, green, blue, alpha);
-
-                    sgl_v3f_t4f_c4b(a1.X, a1.Y, src_v0->position.Z, line_width, -factor * line_length, line_width,
-                                    factor * line_length, red, green, blue, alpha);
+                        factor * line_length, red, green, blue, alpha);
 
                     sgl_v3f_t4f_c4b(b0.X, b0.Y, src_v1->position.Z, -line_width, factor * line_length, line_width,
-                                    factor * line_length, red, green, blue, alpha);
+                        factor * line_length, red, green, blue, alpha);
 
-                    sgl_v3f_t4f_c4b(a1.X, a1.Y, src_v0->position.Z, line_width, -factor * line_length, line_width,
-                                    factor * line_length, red, green, blue, alpha);
-
-                    sgl_v3f_t4f_c4b(b0.X, b0.Y, src_v1->position.Z, -line_width, factor * line_length, line_width,
-                                    factor * line_length, red, green, blue, alpha);
-
-                    sgl_v3f_t4f_c4b(b1.X, b1.Y, src_v1->position.Z, line_width, factor * line_length, line_width,
-                                    factor * line_length, red, green, blue, alpha);
+                    sgl_v3f_t4f_c4b(b1.X, b1.Y, src_v1->position.Z, line_width, -factor * line_length, line_width,
+                        factor * line_length, red, green, blue, alpha);
                 }
 
                 sgl_end();


### PR DESCRIPTION
This strives to improve the performance of the automap, which in very complex maps (especially when cheating via IDDT) can bottleneck easily, with the following changes:
- BSP-based seg walk replaced with iteration of mapped linedefs (or all linedefs + things if cheating) while clipping to the automap frame boundary
  - As a side effect, the "automap_debug_bsp" CVAR and its functionality have been removed
- Automap lines are grouped into buckets for batch rendering based on line width to reduce render state changes
- Sokol rendering now uses quads for line drawing instead of triangle strips
- (Incidental) fixes for interpolation of collision debug bounding boxes and when map rotation is enabled