### PR TITLE
Fix MBF21 issues discovered with Hardfest III

### DIFF
--- a/source_files/ddf/ddf_types.h
+++ b/source_files/ddf/ddf_types.h
@@ -449,17 +449,17 @@ enum AmmunitionType
 // -AJA- 2000/01/12: Weapon special flags
 enum WeaponFlag
 {
-    WeaponFlagNone             = 0,
-    WeaponFlagSilentToMonsters = (1 << 0), // monsters cannot hear this weapon
-    WeaponFlagAnimated         = (1 << 1), // raise/lower states are animated
-    WeaponFlagSwitchAway       = (1 << 4), // select new weapon when we run out of ammo
+    WeaponFlagNone               = 0,
+    WeaponFlagSilentToMonsters   = (1 << 0), // monsters cannot hear this weapon
+    WeaponFlagAnimated           = (1 << 1), // raise/lower states are animated
+    WeaponFlagSwitchAway         = (1 << 4), // select new weapon when we run out of ammo
     // reload flags:
     WeaponFlagReloadWhileTrigger = (1 << 8),  // allow reload while holding trigger
     WeaponFlagFreshReload        = (1 << 9),  // automatically reload when new ammo is avail
     WeaponFlagManualReload       = (1 << 10), // enables the manual reload key
     WeaponFlagPartialReload      = (1 << 11), // manual reload: allow partial refill
     // MBF21 flags:
-    WeaponFlagNoAutoFire = (1 << 12), // Do not fire if switched to while trigger is held
+    WeaponFlagNoAutoFire         = (1 << 12), // Do not fire if switched to while trigger is held
 };
 
 constexpr WeaponFlag kDefaultWeaponFlags = (WeaponFlag)(WeaponFlagReloadWhileTrigger | WeaponFlagManualReload |

--- a/source_files/dehacked/deh_things.cc
+++ b/source_files/dehacked/deh_things.cc
@@ -581,10 +581,12 @@ void things::MarkThing(int mt_num)
         entry->doomednum = -1;
 
         // DEHEXTRA things have a default doomednum
-        if (kMT_EXTRA00 <= mt_num && mt_num <= kMT_EXTRA99)
+        // Dasho: Only specify a doomed number if the "ID #" field
+        // is used
+        /*if (kMT_EXTRA00 <= mt_num && mt_num <= kMT_EXTRA99)
         {
             entry->doomednum = mt_num;
-        }
+        }*/
 
         // Set some default MBF21 values to be non-applicable unless actually set
         entry->proj_group = entry->splash_group = entry->infight_group = entry->fast_speed = entry->melee_range = -2;

--- a/source_files/dehacked/deh_weapons.cc
+++ b/source_files/dehacked/deh_weapons.cc
@@ -304,6 +304,10 @@ void ConvertWeapon(int w_num)
     }
     else if (info->ammo_per_shot != 0)
         wad::Printf("AMMOPERSHOT = %d;\n", info->ammo_per_shot);
+    else if (w_num == kwp_supershotgun)
+        wad::Printf("AMMOPERSHOT = 2;\n");
+    else
+        wad::Printf("AMMOPERSHOT = 1;\n");
 
     wad::Printf("AUTOMATIC = TRUE;\n");
 

--- a/source_files/edge/p_action.cc
+++ b/source_files/edge/p_action.cc
@@ -2409,16 +2409,27 @@ static void LaunchTracker(MapObject *object)
 //
 void A_EffectTracker(MapObject *object)
 {
-    MapObject              *tracker;
-    MapObject              *target;
-    const AttackDefinition *attack;
+    MapObject              *tracker = nullptr;
+    MapObject              *target = nullptr;
+    const AttackDefinition *attack = nullptr;
     BAMAngle                angle;
     float                   damage;
 
-    if (!object->target_ || !object->current_attack_)
+    if (!object->target_)
         return;
 
-    attack = object->current_attack_;
+    if (object->current_attack_)     
+        attack = object->current_attack_;
+    else
+    {
+        // If the object's current attack is null, hope that this is Dehacked using
+        // A_VileAttack directly and that ARCHVILE_FIRE is the intended attack - Dasho
+        attack = atkdefs.Lookup("ARCHVILE_FIRE");
+    }
+
+    if (!attack)
+        return;
+
     target = object->target_;
 
     if (attack->flags_ & kAttackFlagFaceTarget)
@@ -5020,7 +5031,7 @@ void A_SpawnObject(MapObject *mo)
                         mo->y + (ref->x_offset * newsin + ref->y_offset * newcos), mo->z + ref->z_offset, type);
     EPI_ASSERT(spawn);
 
-    MapObjectSetDirectionAndSpeed(spawn, newangle, 0, type->speed_);
+    spawn->angle_ = newangle;
     spawn->momentum_.X += newcos * ref->x_velocity - ref->y_velocity * newsin;
     spawn->momentum_.Y += newsin * ref->x_velocity + newcos * ref->y_velocity;
     spawn->momentum_.Z += ref->z_velocity;

--- a/source_files/edge/p_weapon.cc
+++ b/source_files/edge/p_weapon.cc
@@ -1742,7 +1742,8 @@ void A_ConsumeAmmo(MapObject *mo)
     int count = args[0] == 0 ? info->ammopershot_[0] : args[0];
 
     p->ammo_[ammotype].count -= count;
-    EPI_ASSERT(p->ammo_[ammotype].count >= 0);
+    if (p->ammo_[ammotype].count < 0)
+        p->ammo_[ammotype].count = 0;
 }
 
 void A_CheckAmmo(MapObject *mo)


### PR DESCRIPTION
This is a rollup of various fixes for things observed when playing the "Intro" episode of [Hardfest III](https://www.doomworld.com/forum/topic/151578-rc2-hardfest-3/):

- Removed auto-assigning of DoomEd numbers to DEHEXTRA mobjs (fixed certain monsters in the monster gallery being replaced by their projectile attack projectiles due to colliding IDs)
- Added default "ammo per shot" for weapons if they were not otherwise specified (fixed the chainsaw replacement/ultra rocket launcher being able to fire with zero ammunition)
- A_EffectTracker will now use the ARCHVILE_FIRE DDFATK definition if the mobj does not have a current attack specified (fixed the jump orbs dying but not launching the player upward or damaging them)
- Replaced use of MobjSetDirectionAndSpeed with simply setting the new angle in A_SpawnObject (fixed jump orbs drifting after 'respawn', incidentally fixes https://github.com/edge-classic/EDGE-classic/issues/768)
- Fixed A_ConsumeAmmo triggering an assertion failure for negative ammo count instead of clamping to zero