### PR TITLE
Fix projectile angle in DoLaunchProjectile for non-MBF21 projectiles

### DIFF
--- a/source_files/edge/p_action.cc
+++ b/source_files/edge/p_action.cc
@@ -1450,6 +1450,8 @@ static MapObject *DoLaunchProjectile(MapObject *source, float tx, float ty, floa
 
         projectile = CreateMapObject(projx, projy, projz, type);
 
+        angle = PointToAngle(projx, projy, tx, ty);
+
         if (!target)
         {
             tz += attack->height_;


### PR DESCRIPTION
Restores a setting of the projectile angle that was accidentally dropped when implementing the OFFSETS_LAST and Z_OFFSET DDFATK specials