### PR TITLE
Disregard lines without a back sector in FindTeleportLine

### DIFF
--- a/source_files/edge/p_telept.cc
+++ b/source_files/edge/p_telept.cc
@@ -63,6 +63,9 @@ Line *FindTeleportLine(int tag, Line *original)
         if (level_lines + i == original)
             continue;
 
+        if (!level_lines[i].back_sector)
+            continue;
+
         return level_lines + i;
     }
 


### PR DESCRIPTION
This matches Boom behavior and fixes some situations in which things were being teleported to the wrong line