### PR TITLE
Remove implicit "INCLUDE" from LOSURROUNDINGFLOOR command

### DIFF
--- a/source_files/ddf/ddf_sector.cc
+++ b/source_files/ddf/ddf_sector.cc
@@ -360,13 +360,10 @@ static DDFSpecialFlags reference_types[] = {
     {"TRIGGERFLOOR", kTriggerHeightReferenceTriggeringLinedef, false},
     {"TRIGGERCEILING", kTriggerHeightReferenceTriggeringLinedef + kTriggerHeightReferenceCeiling, false},
 
-    // Note that LOSURROUNDINGFLOOR has the kTriggerHeightReferenceInclude flag,
-    // but the others do not.  It's there to maintain backwards compatibility.
-    //
     {"LOSURROUNDINGCEILING", kTriggerHeightReferenceSurrounding + kTriggerHeightReferenceCeiling, false},
     {"HISURROUNDINGCEILING",
      kTriggerHeightReferenceSurrounding + kTriggerHeightReferenceCeiling + kTriggerHeightReferenceHighest, false},
-    {"LOSURROUNDINGFLOOR", kTriggerHeightReferenceSurrounding + kTriggerHeightReferenceInclude, false},
+    {"LOSURROUNDINGFLOOR", kTriggerHeightReferenceSurrounding, false},
     {"HISURROUNDINGFLOOR", kTriggerHeightReferenceSurrounding + kTriggerHeightReferenceHighest, false},
 
     // Note that kTriggerHeightReferenceHighest is used for the NextLowest


### PR DESCRIPTION
This broke behavior of various lifts; notable example is making the red key in MAP05 of DBP61 inaccessible