### PR TITLE
Add fallback for DDFATK entries that spawn a thing which has been modified

### DIFF
--- a/source_files/ddf/ddf_attack.cc
+++ b/source_files/ddf/ddf_attack.cc
@@ -391,7 +391,13 @@ void DDFAttackCleanUp(void)
             if (a->objinitstate_ref_.empty())
                 a->objinitstate_ = a->spawnedobj_->spawn_state_;
             else
+            {
                 a->objinitstate_ = DDFMainLookupDirector(a->spawnedobj_, a->objinitstate_ref_.c_str());
+                // Fallback to spawn state if objinitstate isn't valid (could be a DDFTHING entry modified
+                // via mods or Dehacked)
+                if (a->objinitstate_ == 0)
+                    a->objinitstate_ = a->spawnedobj_->spawn_state_;
+            }
         }
 
         cur_ddf_entryname.clear();

--- a/source_files/ddf/ddf_main.cc
+++ b/source_files/ddf/ddf_main.cc
@@ -1189,7 +1189,8 @@ int DDFMainLookupDirector(const MapObjectDefinition *info, const char *ref)
 
     std::string director(ref, len);
 
-    int state  = DDFStateFindLabel(info->state_grp_, director.c_str());
+    int state  = DDFStateFindLabel(info->state_grp_, director.c_str(), true);
+    if (state == 0) return state;
     int offset = p ? HMM_MAX(0, atoi(p + 1) - 1) : 0;
 
     // FIXME: check for overflow


### PR DESCRIPTION
A thing whose DDFTHING entry has been modified from the default may no longer have things like a CHASE state, so instead of being a fatal error attempt to fall back to the spawn state in these cases. This function is only used during the AttackCleanUp function when parsing DDF, so should hopefully have minimal impact.