### PR TITLE
Improve mikoportals/implement peccaflight

### DIFF
--- a/source_files/edge/p_inter.cc
+++ b/source_files/edge/p_inter.cc
@@ -1259,8 +1259,11 @@ void ThrustMapObject(MapObject *target, MapObject *inflictor, float thrust)
     {
         float dz    = MapObjectMidZ(target) - MapObjectMidZ(inflictor);
         float slope = ApproximateSlope(dx, dy, dz);
-
-        target->momentum_.Z += push * slope / 2;
+        float z_thrust = push * slope / 2;
+        // Don't apply downward Z momentum if the target is on the ground
+        // (this was screwing up mikoportal/peccaflight levels - Dasho)
+        if (z_thrust >= 0.0f || target->z > target->floor_z_)
+            target->momentum_.Z += push * slope / 2;
     }
 }
 

--- a/source_files/edge/p_mobj.cc
+++ b/source_files/edge/p_mobj.cc
@@ -1088,8 +1088,8 @@ static void P_XYMovement(MapObject *mo, const RegionProperties *props)
     }
 
     // when we are confident that a mikoportal is being used, do not apply
-    // friction or drag to the voodoo doll
-    if (!mo->is_voodoo_ || !AlmostEquals(mo->floor_z_, -32768.0f) || AlmostEquals(mo->momentum_.Z, 0.0f))
+    // friction or drag
+    if (!AlmostEquals(mo->floor_z_, -32768.0f) || AlmostEquals(mo->momentum_.Z, 0.0f))
     {
         mo->momentum_.X *= friction;
         mo->momentum_.Y *= friction;
@@ -1119,6 +1119,14 @@ static void P_XYMovement(MapObject *mo, const RegionProperties *props)
 //
 static void P_ZMovement(MapObject *mo, const RegionProperties *props)
 {
+    // A mobj that has achieved pecca flight retains it until/unless a teleport move occurs
+    if (mo->pecca_flight_)
+    {
+        mo->z = mo->ceiling_z_ - mo->height_;
+        TryMove(mo, mo->x, mo->y);
+        return;
+    }
+
     float dist;
     float delta;
     float zmove;
@@ -1167,10 +1175,13 @@ static void P_ZMovement(MapObject *mo, const RegionProperties *props)
     if (mo->z <= mo->floor_z_)
     {
         // Test for mikoportal
-        if (mo->is_voodoo_ && AlmostEquals(mo->floor_z_, -32768.0f))
+        if (AlmostEquals(mo->floor_z_, -32768.0f))
         {
             mo->z = mo->ceiling_z_ - mo->height_;
-            TryMove(mo, mo->x, mo->y);
+            if (TryMove(mo, mo->x, mo->y))
+                mo->momentum_.Z -= gravity / (mo->mbf21_flags_ & kMBF21FlagLowGravity ? 8 : 1);
+            if (mo->momentum_.Z < -65.535f)
+                mo->pecca_flight_ = true;
             return;
         }
 

--- a/source_files/edge/p_mobj.h
+++ b/source_files/edge/p_mobj.h
@@ -383,6 +383,8 @@ class MapObject : public Position
     // Uncapped test - Dasho
     bool interpolate_ = false;
 
+    bool pecca_flight_ = false;
+
   public:
     bool IsRemoved() const;
 

--- a/source_files/edge/p_telept.cc
+++ b/source_files/edge/p_telept.cc
@@ -251,6 +251,8 @@ bool TeleportMapObject(Line *line, int tag, MapObject *thing, const TeleportDefi
 
     if (!TeleportMove(thing, new_x, new_y, new_z))
         return false;
+    else // a successful teleport will cancel pecca flight
+        thing->pecca_flight_ = false;
 
     if (player)
     {

--- a/source_files/edge/p_user.cc
+++ b/source_files/edge/p_user.cc
@@ -201,7 +201,7 @@ static void CalcHeight(Player *player)
     // if ((player->map_object_->momentum_.z <=
     // -35.0)&&(player->map_object_->momentum_.z >= -40.0))
     if ((player->map_object_->momentum_.Z <= -35.0) && (player->map_object_->momentum_.Z >= -36.0))
-        if (player->map_object_->info_->falling_sound_)
+        if (player->map_object_->info_->falling_sound_ && !AlmostEquals(player->map_object_->floor_z_, -32768.0f))
         {
             int sfx_cat;
 

--- a/source_files/edge/sv_mobj.cc
+++ b/source_files/edge/sv_mobj.cc
@@ -195,6 +195,8 @@ static SaveField sv_fields_mobj[] = {
                     SaveGamePutInteger),
     EDGE_SAVE_FIELD(dummy_map_object, is_voodoo_, "is_voodoo", 1, kSaveFieldNumeric, 4, nullptr, SaveGameGetBoolean,
                     SaveGamePutBoolean),
+    EDGE_SAVE_FIELD(dummy_map_object, pecca_flight_, "pecca_flight", 1, kSaveFieldNumeric, 4, nullptr, SaveGameGetBoolean,
+                    SaveGamePutBoolean),
     // NOT HERE:
     //   subsector & region: these are regenerated.
     //   next,prev,snext,sprev,bnext,bprev: links are regenerated.


### PR DESCRIPTION
This makes the following changes to our existing mikoportal implementation:
- Applies to any mobj, not just voodoo dolls
- Will not cause the "falling player" scream to be played
- Allows "peccaflight" (https://www.doomworld.com/forum/topic/143370-achieving-flight-in-vanilla-boom-etc-a-new-technique) to be achieved if negative Z momentum reaches a certain threshold in a mikoportal sector

Compared to the vanilla peccaflight implementation, the player will always have at least a limited degree of air control