### PR TITLE
Adjust miniaudio sound/music params

### DIFF
--- a/libraries/opalmidi/opal.cpp
+++ b/libraries/opalmidi/opal.cpp
@@ -438,8 +438,8 @@ void Opal::Output(int16_t &left, int16_t &right)
         int16_t chanleft, chanright;
         Chan[i].Output(chanleft, chanright);
 
-        leftmix += chanleft;
-        rightmix += chanright;
+        leftmix += chanleft << 1;
+        rightmix += chanright << 1;
     }
 
     // Clamp

--- a/source_files/edge/i_movie.cc
+++ b/source_files/edge/i_movie.cc
@@ -318,7 +318,7 @@ static void EndMovie()
     ma_sound_stop(&movie_sound_buffer);
     ma_sound_uninit(&movie_sound_buffer);
     ma_pcm_rb_uninit(&movie_ring_buffer);
-    ma_engine_set_volume(&music_engine, music_volume.f_ * 0.25f);
+    ma_engine_set_volume(&music_engine, music_volume.f_);
     ResumeMusic();
 }
 

--- a/source_files/edge/i_sound.cc
+++ b/source_files/edge/i_sound.cc
@@ -77,7 +77,7 @@ void StartupAudio(void)
     {
         sound_device_frequency = ma_engine_get_sample_rate(&sound_engine);
         ma_uint32 channels     = ma_engine_get_channels(&sound_engine);
-        ma_engine_set_volume(&sound_engine, sound_effect_volume.f_ * 0.25f);
+        ma_engine_set_volume(&sound_engine, sound_effect_volume.f_ * 0.5f);
         // configure FX nodes
 
         // Underwater/Submerged
@@ -112,7 +112,7 @@ void StartupAudio(void)
             no_music = true;
         }
         else
-            ma_engine_set_volume(&music_engine, music_volume.f_ * 0.25f);
+            ma_engine_set_volume(&music_engine, music_volume.f_);
     }
 
     // display some useful stuff

--- a/source_files/edge/s_blit.cc
+++ b/source_files/edge/s_blit.cc
@@ -41,8 +41,6 @@
 #include "s_music.h"
 #include "s_sound.h"
 
-static constexpr uint16_t kMaximumSoundChannels = 256;
-
 SoundChannel *mix_channels[kMaximumSoundChannels];
 int           total_channels;
 
@@ -98,7 +96,7 @@ void FreeSoundChannels(void)
         delete chan;
     }
 
-    EPI_CLEAR_MEMORY(mix_channels, SoundChannel *, 256);
+    EPI_CLEAR_MEMORY(mix_channels, SoundChannel *, total_channels);
 }
 
 void KillSoundChannel(int k)
@@ -120,7 +118,7 @@ void UpdateSounds(MapObject *listener, BAMAngle angle)
 {
     EDGE_ZoneScoped;
 
-    ma_engine_set_volume(&sound_engine, sound_effect_volume.f_ * 0.25f);
+    ma_engine_set_volume(&sound_engine, sound_effect_volume.f_ * 0.5f);
 
     listen_x = listener ? listener->x : 0;
     listen_y = listener ? listener->y : 0;

--- a/source_files/edge/s_blit.h
+++ b/source_files/edge/s_blit.h
@@ -66,6 +66,8 @@ class SoundChannel
     ~SoundChannel();
 };
 
+constexpr uint16_t kMaximumSoundChannels = 32;
+
 extern ConsoleVariable sound_effect_volume;
 
 extern SoundChannel *mix_channels[];

--- a/source_files/edge/s_flac.cc
+++ b/source_files/edge/s_flac.cc
@@ -173,7 +173,7 @@ void FLACPlayer::Ticker()
 {
     if (status_ == kPlaying)
     {
-        ma_engine_set_volume(&music_engine, music_volume.f_ * 0.25f);
+        ma_engine_set_volume(&music_engine, music_volume.f_);
 
         if (pc_speaker_mode)
             Stop();

--- a/source_files/edge/s_m4p.cc
+++ b/source_files/edge/s_m4p.cc
@@ -566,7 +566,7 @@ void M4PPlayer::Ticker()
 {
     if (status_ == kPlaying)
     {
-        ma_engine_set_volume(&music_engine, music_volume.f_ * 0.25f);
+        ma_engine_set_volume(&music_engine, music_volume.f_);
 
         if (pc_speaker_mode)
             Stop();

--- a/source_files/edge/s_midi.cc
+++ b/source_files/edge/s_midi.cc
@@ -888,7 +888,7 @@ class MIDIPlayer : public AbstractMusicPlayer
 
         if (status_ == kPlaying)
         {
-            ma_engine_set_volume(&music_engine, music_volume.f_ * 0.25f);
+            ma_engine_set_volume(&music_engine, music_volume.f_);
 
             if (pc_speaker_mode)
                 Stop();

--- a/source_files/edge/s_midi_ec.cc
+++ b/source_files/edge/s_midi_ec.cc
@@ -976,7 +976,7 @@ class MIDIPlayer : public AbstractMusicPlayer
 
         if (status_ == kPlaying)
         {
-            ma_engine_set_volume(&music_engine, music_volume.f_ * (opl_playback ? 0.75f : 0.25f));
+            ma_engine_set_volume(&music_engine, music_volume.f_);
 
             if (pc_speaker_mode)
                 Stop();

--- a/source_files/edge/s_mp3.cc
+++ b/source_files/edge/s_mp3.cc
@@ -171,7 +171,7 @@ void MP3Player::Ticker()
 {
     if (status_ == kPlaying)
     {
-        ma_engine_set_volume(&music_engine, music_volume.f_ * 0.25f);
+        ma_engine_set_volume(&music_engine, music_volume.f_);
 
         if (pc_speaker_mode)
             Stop();

--- a/source_files/edge/s_ogg.cc
+++ b/source_files/edge/s_ogg.cc
@@ -676,7 +676,7 @@ void OGGPlayer::Ticker()
 {
     if (status_ == kPlaying)
     {
-        ma_engine_set_volume(&music_engine, music_volume.f_ * 0.25f);
+        ma_engine_set_volume(&music_engine, music_volume.f_);
 
         if (pc_speaker_mode)
             Stop();


### PR DESCRIPTION
This makes the following fixes/tweaks to audio stuff:
- OPL emulation output volume better matches SF2/Fluidlite output
- SFX/Music max gain increased
- Attenuation model fixed for sound effects playing "in-world", now using linear attenuation and the traditional S_CLOSE_DIST and S_CLIPPING_DIST values (200/1200)
- Boss monsters are now attenuated based on "in-world" position
  - Unlike regular sounds, they use the exponential attenuation model so that they are not completely silenced
  - Will still play at full volume regardless of the 'VOLUME' special in DDFSFX
- Reduced max sound channels from 256 to 32 pending other miniaudio work