### PR TITLE
Update CMake/add CI for MinGW32+Legacy GL+No Mimalloc

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -50,37 +50,41 @@ jobs:
         retention-days: ${{env.RETENTION_DAYS}}
 
   build-mingw32:
-    runs-on: ubuntu-24.04
-
+    runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v4
-
-    - name: Install dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y libsdl2-dev mingw-w64
-
-    - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DEDGE_SOKOL_D3D11=ON -DCMAKE_TOOLCHAIN_FILE=cmake/Toolchain-mingw32.cmake
-
-    - name: Build
-      # Build your program with the given configuration
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
-
-    - uses: actions/upload-artifact@v4
-      with:
-        name: edge-classic-mingw32
-        path: |
-          ${{github.workspace}}/autoload
-          ${{github.workspace}}/edge_base
-          ${{github.workspace}}/edge_defs
-          ${{github.workspace}}/edge_fixes
-          ${{github.workspace}}/soundfont
-          ${{github.workspace}}/edge-classic.exe
-          ${{github.workspace}}/*.dll
-        retention-days: ${{env.RETENTION_DAYS}}
+      - uses: actions/checkout@v4
+      - name: Download w64devkit
+        run: invoke-webrequest https://github.com/skeeto/w64devkit/releases/download/v2.1.0/w64devkit-x86-2.1.0.exe -outfile ${{github.workspace}}\w64devkit.exe
+      - name: Extract w64devkit
+        run: ${{github.workspace}}\w64devkit.exe -y
+      - name: Download SDL2-devel
+        run: invoke-webrequest https://github.com/libsdl-org/SDL/releases/download/release-2.32.4/SDL2-devel-2.32.4-mingw.zip -outfile ${{github.workspace}}\sdl2-devel.zip
+      - name: Extract SDL2-devel
+        run: expand-archive -path ${{github.workspace}}\sdl2-devel.zip -destinationpath ${{github.workspace}}
+      - name: Copy SDL2-devel contents to w64devkit
+        run: |
+          robocopy ${{github.workspace}}\SDL2-2.32.4\i686-w64-mingw32 ${{github.workspace}}\w64devkit\i686-w64-mingw32 /s ; if ($lastexitcode -lt 8) { $global:LASTEXITCODE = $null }
+          robocopy ${{github.workspace}}\SDL2-2.32.4\i686-w64-mingw32 ${{github.workspace}}\w64devkit /s ; if ($lastexitcode -lt 8) { $global:LASTEXITCODE = $null }
+      - name: Set environment variables and build
+        run: |
+          $env:Path = "${{github.workspace}}\w64devkit\bin;" + $env:Path
+          cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DEDGE_LEGACY_GL=ON -DEDGE_MIMALLOC=OFF -DCMAKE_CXX_FLAGS="-isystem ${{github.workspace}}\w64devkit\include" -G "MinGW Makefiles"
+          cmake --build build --config ${{env.BUILD_TYPE}}
+          strip ${{github.workspace}}\edge-classic.exe
+      - name: Copy SDL2 DLL
+        run: copy-item -path ${{github.workspace}}\SDL2-2.32.4\i686-w64-mingw32\bin\SDL2.dll -destination ${{github.workspace}}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: edge-classic-mingw32
+          path: |
+            autoload
+            edge_base
+            edge_defs
+            edge_fixes
+            soundfont
+            edge-classic.exe
+            *.dll
+          retention-days: ${{env.RETENTION_DAYS}}
 
   build-msvc:
     runs-on: windows-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,8 @@ if (EMSCRIPTEN)
   include("${CMAKE_SOURCE_DIR}/cmake/Emscripten.cmake")  
 endif()
 
-if (WIN32 OR MINGW)
+# Set WIN32_WINNT to Windows 7 if using the new renderer or mimalloc
+if ((WIN32 OR MINGW) AND (EDGE_SOKOL OR EDGE_MIMALLOC))
   add_definitions(-D_WIN32_WINNT=0x601)
 endif()
 

--- a/libraries/miniaudio/miniaudio.cc
+++ b/libraries/miniaudio/miniaudio.cc
@@ -1,8 +1,6 @@
 #define MA_NO_ENCODING
 #define MA_NO_GENERATION
 #define MA_NO_RESOURCE_MANAGER
-#define MA_NO_WINMM
-#define MA_NO_DSOUND
 // We use our own custom minivorbis decoder
 #define MA_NO_VORBIS
 #define MINIAUDIO_IMPLEMENTATION


### PR DESCRIPTION
Add CI coverage for "legacy" oriented builds that disable newer rendering and memory management options