### PR TITLE
Fix Dehacked-provided x offsets and Boom carry scrollers

### DIFF
--- a/source_files/ddf/ddf_thing.cc
+++ b/source_files/ddf/ddf_thing.cc
@@ -1889,7 +1889,7 @@ static void DDFMobjStateGetDEHSpawn(const char *arg, State *cur_state)
     {
         int x_offset = 0;
         if (sscanf(args[2].c_str(), "%d", &x_offset) == 1 && x_offset != 0)
-            params->x_offset = (float)x_offset / 65536.0f;
+            params->x_offset = (float)x_offset / -65536.0f;
     }
     if (arg_size > 3)
     {
@@ -2044,7 +2044,7 @@ static void DDFMobjStateGetDEHProjectile(const char *arg, State *cur_state)
     {
         int xoffset = 0;
         if (sscanf(args[3].c_str(), "%d", &xoffset) == 1 && xoffset != 0)
-            atk->xoffset_ = (float)xoffset / 65536.0f;
+            atk->xoffset_ = (float)xoffset / -65536.0f;
     }
     if (arg_size > 4)
     {

--- a/source_files/ddf/ddf_weapon.cc
+++ b/source_files/ddf/ddf_weapon.cc
@@ -883,7 +883,7 @@ static void DDFWStateGetDEHProjectile(const char *arg, State *cur_state)
     {
         int xoffset = 0;
         if (sscanf(args[3].c_str(), "%d", &xoffset) == 1 && xoffset != 0)
-            atk->xoffset_ = (float)xoffset / 65536.0f;
+            atk->xoffset_ = (float)xoffset / -65536.0f;
     }
     if (arg_size > 4)
     {

--- a/source_files/edge/p_mobj.cc
+++ b/source_files/edge/p_mobj.cc
@@ -657,7 +657,7 @@ static inline void AddRegionProperties(const MapObject *mo, float bz, float tz, 
                                        float floor_height, float ceiling_height, const RegionProperties *p,
                                        bool iterate_pushers)
 {
-    int flags = p->special ? p->special->special_flags_ : kSectorFlagPushConstant;
+    int flags = p->special ? p->special->special_flags_ : kSectorFlagNone;
 
     float factor = 1.0f;
     float push_mul;
@@ -693,14 +693,14 @@ static inline void AddRegionProperties(const MapObject *mo, float bz, float tz, 
                 }
                 if (tn_props.push.X || tn_props.push.Y || tn_props.push.Z)
                 {
-                    SectorFlag tn_flags = tn_props.special ? tn_props.special->special_flags_ : kSectorFlagPushConstant;
+                    SectorFlag tn_flags = tn_props.special ? tn_props.special->special_flags_ : kSectorFlagNone;
 
                     if (!(tn_flags & kSectorFlagWholeRegion) && !AlmostEquals(bz, tn->sector->floor_height))
                         continue;
 
                     push_mul = 1.0f;
 
-                    if (!(tn_flags & kSectorFlagPushConstant))
+                    if (!tn_props.push_constant)
                     {
                         EPI_ASSERT(mo->info_->mass_ > 0);
                         push_mul = 100.0f / mo->info_->mass_;
@@ -728,7 +728,7 @@ static inline void AddRegionProperties(const MapObject *mo, float bz, float tz, 
 
             push_mul = 1.0f;
 
-            if (!(flags & kSectorFlagPushConstant))
+            if (!p->push_constant)
             {
                 EPI_ASSERT(mo->info_->mass_ > 0);
                 push_mul = 100.0f / mo->info_->mass_;
@@ -1491,16 +1491,18 @@ static void P_MobjThinker(MapObject *mobj)
                 }
                 if (tn_props.push.X || tn_props.push.Y || tn_props.push.Z)
                 {
-                    SectorFlag flags = tn_props.special ? tn_props.special->special_flags_ : kSectorFlagPushConstant;
+                    SectorFlag flags = tn_props.special ? tn_props.special->special_flags_ : kSectorFlagNone;
 
                     if (!((mobj->flags_ & kMapObjectFlagNoGravity) || (flags & kSectorFlagPushAll)) &&
                         (AlmostEquals(mobj->z, mobj->floor_z_) || (flags & kSectorFlagWholeRegion)))
                     {
                         float push_mul = 1.0f;
 
-                        EPI_ASSERT(mobj->info_->mass_ > 0);
-                        if (!(flags & kSectorFlagPushConstant))
+                        if (!tn_props.push_constant)
+                        {
+                            EPI_ASSERT(mobj->info_->mass_ > 0);
                             push_mul = 100.0f / mobj->info_->mass_;
+                        }
 
                         if (tn_props.push.X)
                             mobj->momentum_.X += push_mul * tn_props.push.X;

--- a/source_files/edge/p_spec.cc
+++ b/source_files/edge/p_spec.cc
@@ -870,6 +870,8 @@ static void SectorEffect(Sector *target, Line *source, const LineType *special)
                 anim.last_height = anim.scroll_sector_reference->original_height;
             }
         }
+        if (special->sector_effect_ & kSectorEffectTypePushThings)
+            target->properties.push_constant = true;
         sector_animations.push_back(anim);
         AddSpecialSector(target);
     }
@@ -2605,6 +2607,8 @@ void SpawnMapSpecials2(int autotag)
             sector->properties.push.X += epi::BAMCos(secSpecial->push_angle_) * mul;
             sector->properties.push.Y += epi::BAMSin(secSpecial->push_angle_) * mul;
             sector->properties.push.Z += secSpecial->push_zspeed_ / 100.0f;
+            if (secSpecial->special_flags_ & kSectorFlagPushConstant)
+                sector->properties.push_constant = true;
         }
 
         // Scrollers

--- a/source_files/edge/r_defs.h
+++ b/source_files/edge/r_defs.h
@@ -107,6 +107,7 @@ struct RegionProperties
 
     // pushing sector information (normally all zero)
     HMM_Vec3 push;
+    bool     push_constant = false;
 
     HMM_Vec3 net_push = {{0, 0, 0}};
 

--- a/source_files/edge/sv_level.cc
+++ b/source_files/edge/sv_level.cc
@@ -249,6 +249,8 @@ static SaveField sv_fields_regprops[] = {
                     SaveGamePutFloat),
     EDGE_SAVE_FIELD(dummy_region_properties, push, "push", 1, kSaveFieldNumeric, 12, nullptr, SaveGameGetVec3,
                     SaveGamePutVec3),
+    EDGE_SAVE_FIELD(dummy_region_properties, push_constant, "push_constant", 1, kSaveFieldNumeric, 12, nullptr, SaveGameGetBoolean,
+                    SaveGamePutBoolean),
     EDGE_SAVE_FIELD(dummy_region_properties, net_push, "net_push", 1, kSaveFieldNumeric, 12, nullptr, SaveGameGetVec3,
                     SaveGamePutVec3),
     EDGE_SAVE_FIELD(dummy_region_properties, old_push, "old_push", 1, kSaveFieldNumeric, 12, nullptr, SaveGameGetVec3,


### PR DESCRIPTION
Made it easier to determine if carry scrollers are meant to be constant vs. proportional; flipped x offsets provided by MBF21 codepointers to match DDF behavior