### PR TITLE
Sector damage fixes

### DIFF
--- a/source_files/ddf/ddf_attack.cc
+++ b/source_files/ddf/ddf_attack.cc
@@ -54,7 +54,7 @@ const DDFCommandList damage_commands[] = {
     DDF_FIELD("DAMAGE_IF_BENEFIT", dummy_damage, damage_if_, DDFMobjGetBenefit),
     DDF_FIELD("ALL_PLAYERS", dummy_damage, all_players_,
               DDFMainGetBoolean), // Doesn't do anything (yet)
-    DDF_FIELD("GROUNDED_MONSTERS_ONLY", dummy_damage, grounded_monsters_, DDFMainGetBoolean),
+    DDF_FIELD("ONLY_AFFECTS", dummy_damage, only_affects_, DDFMainGetBitSet),
     DDF_FIELD("FLASH_COLOUR", dummy_damage, damage_flash_colour_, DDFMainGetRGB),
 
     DDF_FIELD("OBITUARY", dummy_damage, obituary_, DDFMainGetString),

--- a/source_files/ddf/ddf_boom.cc
+++ b/source_files/ddf/ddf_boom.cc
@@ -156,6 +156,7 @@ void DDFBoomMakeGeneralizedSector(SectorType *sec, int number)
     // handle bit 12: Alternate damage mode (MBF21)
     if ((number >> 12) & 1)
     {
+        sec->damage_.only_affects_ |= epi::BitSetFromChar('P');
         switch ((number >> 5) & 0x3)
         {
         case 0: // Kill player if no radsuit or invul status
@@ -199,7 +200,7 @@ void DDFBoomMakeGeneralizedSector(SectorType *sec, int number)
     {
         sec->damage_.delay_             = 0;
         sec->damage_.instakill_         = true;
-        sec->damage_.grounded_monsters_ = true;
+        sec->damage_.only_affects_     |= epi::BitSetFromChar('M');
     }
 }
 

--- a/source_files/ddf/ddf_main.cc
+++ b/source_files/ddf/ddf_main.cc
@@ -1784,7 +1784,7 @@ void DamageClass::Copy(const DamageClass &src)
         damage_if_  = new Benefit;
         *damage_if_ = *src.damage_if_;
     }
-    grounded_monsters_ = src.grounded_monsters_;
+    only_affects_      = src.only_affects_;
     all_players_       = src.all_players_;
 }
 
@@ -1808,7 +1808,7 @@ void DamageClass::Default(DamageClassDefault def)
         instakill_           = false;
         damage_unless_       = nullptr;
         damage_if_           = nullptr;
-        grounded_monsters_   = false;
+        only_affects_        = 0;
         damage_flash_colour_ = kRGBANoValue;
         all_players_         = false;
         break;
@@ -1824,7 +1824,7 @@ void DamageClass::Default(DamageClassDefault def)
         instakill_           = false;
         damage_unless_       = nullptr;
         damage_if_           = nullptr;
-        grounded_monsters_   = false;
+        only_affects_        = 0;
         damage_flash_colour_ = kRGBANoValue;
         all_players_         = false;
         break;
@@ -1842,7 +1842,7 @@ void DamageClass::Default(DamageClassDefault def)
         instakill_           = false;
         damage_unless_       = nullptr;
         damage_if_           = nullptr;
-        grounded_monsters_   = false;
+        only_affects_        = 0;
         damage_flash_colour_ = kRGBANoValue;
         all_players_         = false;
         break;

--- a/source_files/ddf/ddf_types.h
+++ b/source_files/ddf/ddf_types.h
@@ -211,8 +211,11 @@ class DamageClass
     Benefit *damage_unless_;
     // Apply damage if one of these benefits is in effect
     Benefit *damage_if_;
-    // Apply to (grounded) monsters instead (MBF21)
-    bool grounded_monsters_;
+    // What (broad) class of things this damage affects; introduced
+    // to help integrate MBF21 instakill sector damage. Only considered
+    // if non-zero for backwards compatability. "P" indicates players,
+    // "M" indicates monsters, and "O" indicates other
+    BitSet only_affects_;
 };
 
 enum AttackStyle

--- a/source_files/edge/p_inter.cc
+++ b/source_files/edge/p_inter.cc
@@ -1416,10 +1416,12 @@ void DamageMapObject(MapObject *target, MapObject *inflictor, MapObject *source,
     {
         int i;
 
-        // Don't damage player if sector type should only affect grounded
-        // monsters Note: flesh this out be be more versatile - Dasho
-        if (damtype && damtype->grounded_monsters_)
-            return;
+        // Don't damage player if sector type shouldn't affect players
+        if (damtype && damtype->only_affects_)
+        {
+            if (!(damtype->only_affects_ & epi::BitSetFromChar('P')))
+                return;
+        }
 
         // ignore damage in GOD mode, or with INVUL powerup
         if ((player->cheats_ & kCheatingGodMode) || player->powers_[kPowerTypeInvulnerable] > 0)

--- a/source_files/edge/p_mobj.cc
+++ b/source_files/edge/p_mobj.cc
@@ -1519,10 +1519,16 @@ static void P_MobjThinker(MapObject *mobj)
         if (mobj_props.friction < 0.0f)
             mobj_props.friction = mobj->region_properties_->friction;
 
-        // Only damage grounded monsters (not players)
-        if (props->special && props->special->damage_.grounded_monsters_ && AlmostEquals(mobj->z, mobj->floor_z_))
+        // Damage mobj if applicable
+        // Dasho - So far this is just for MBF21 instakill sectors
+        if (props->special && props->special->damage_.only_affects_)
         {
-            DamageMapObject(mobj, nullptr, nullptr, 5.0, &props->special->damage_, false);
+            if (((props->special->damage_.only_affects_ & epi::BitSetFromChar('M')) && (mobj->info_->extended_flags_ & kExtendedFlagMonster))
+                || (!(mobj->info_->extended_flags_ & kExtendedFlagMonster) && (props->special->damage_.only_affects_ & epi::BitSetFromChar('O'))))
+            {
+                if (AlmostEquals(mobj->z, mobj->floor_z_) || (props->special->special_flags_ & kSectorFlagWholeRegion))
+                    DamageMapObject(mobj, nullptr, nullptr, props->special->damage_.nominal_, &props->special->damage_, false);
+            }
         }
     }
 


### PR DESCRIPTION
This makes sector damage a little more robust; this fixes (for instance) MBF21 instakill sectors that have the player-affecting and monster-affecting bits set at the same time.