### PR TITLE
Fixes for Dehacked-related explosions and BORE special

### DIFF
--- a/source_files/ddf/ddf_attack.cc
+++ b/source_files/ddf/ddf_attack.cc
@@ -368,8 +368,8 @@ void DDFAttackCleanUp(void)
             a->atk_mobj_ = mobjtypes.Lookup(a->atk_mobj_ref_.c_str());
             if (a->atk_mobj_)
             {
-                a->damage_.nominal_          = a->atk_mobj_->explode_damage_.nominal_;
-                a->damage_.linear_max_       = a->atk_mobj_->explode_damage_.linear_max_;
+                a->damage_.nominal_          = a->atk_mobj_->proj_damage_.nominal_;
+                a->damage_.linear_max_       = a->atk_mobj_->proj_damage_.linear_max_;
                 MapObjectDefinition *atk_mod = (MapObjectDefinition *)a->atk_mobj_; // const override
                 if (atk_mod->dlight_.type_ == kDynamicLightTypeNone)
                 {

--- a/source_files/ddf/ddf_thing.cc
+++ b/source_files/ddf/ddf_thing.cc
@@ -217,6 +217,7 @@ const DDFCommandList thing_commands[] = {
     DDF_FIELD("FAST_SPEED", dummy_mobj, fast_speed_, DDFMainGetNumeric),
     DDF_FIELD("MELEE_RANGE", dummy_mobj, melee_range_, DDFMainGetFloat),
     DDF_FIELD("DEH_THING_ID", dummy_mobj, deh_thing_id_, DDFMainGetNumeric),
+    DDF_SUB_LIST("PROJECTILE_DAMAGE", dummy_mobj, proj_damage_, damage_commands),
 
     // -AJA- backwards compatibility cruft...
     DDF_FIELD("EXPLOD_DAMAGE", dummy_mobj, explode_damage_.nominal_, DDFMainGetFloat),
@@ -2662,6 +2663,7 @@ void MapObjectDefinition::Default()
     splash_group_  = -2;
     fast_speed_    = -1;
     melee_range_   = -1;
+    proj_damage_.Default(DamageClass::kDamageClassDefaultMobj);
     deh_thing_id_  = 0;
 }
 

--- a/source_files/ddf/ddf_thing.h
+++ b/source_files/ddf/ddf_thing.h
@@ -893,6 +893,7 @@ class MapObjectDefinition
     int   splash_group_;
     int   fast_speed_;
     float melee_range_;
+    DamageClass proj_damage_;
 
     int deh_thing_id_;
 

--- a/source_files/dehacked/deh_things.cc
+++ b/source_files/dehacked/deh_things.cc
@@ -491,8 +491,10 @@ void Attacks::ConvertAttack(const DehackedMapObjectDefinition *info, int mt_num,
         wad::Printf("EXPLODE_DAMAGE.VAL = 128;\n");
     else if (info->damage)
     {
-        wad::Printf("EXPLODE_DAMAGE.VAL = %d;\n", info->damage);
-        wad::Printf("EXPLODE_DAMAGE.MAX = %d;\n", info->damage * 8);
+        if (frames::act_flags & kActionFlagDetonate)
+            wad::Printf("EXPLODE_DAMAGE.VAL = %d;\n", info->damage);
+        wad::Printf("PROJECTILE_DAMAGE.VAL = %d;\n", info->damage);
+        wad::Printf("PROJECTILE_DAMAGE.MAX = %d;\n", info->damage * 8);
     }
 
     wad::Printf("\n");
@@ -1757,8 +1759,10 @@ void things::ConvertMobj(const DehackedMapObjectDefinition *info, int mt_num, in
         wad::Printf("EXPLODE_DAMAGE.VAL = 128;\n");
     else if (info->damage)
     {
-        wad::Printf("EXPLODE_DAMAGE.VAL = %d;\n", info->damage);
-        wad::Printf("EXPLODE_DAMAGE.MAX = %d;\n", info->damage * 8);
+        if (frames::act_flags & kActionFlagDetonate)
+            wad::Printf("EXPLODE_DAMAGE.VAL = %d;\n", info->damage);
+        wad::Printf("PROJECTILE_DAMAGE.VAL = %d;\n", info->damage);
+        wad::Printf("PROJECTILE_DAMAGE.MAX = %d;\n", info->damage * 8);
     }
 
     if ((frames::act_flags & kActionFlagKeenDie))

--- a/source_files/edge/p_action.cc
+++ b/source_files/edge/p_action.cc
@@ -1796,11 +1796,10 @@ int MissileContact(MapObject *object, MapObject *target)
 
     const DamageClass *damtype;
 
-    // transitional hack
     if (object->current_attack_)
         damtype = &object->current_attack_->damage_;
     else
-        damtype = &object->info_->explode_damage_;
+        damtype = &object->info_->proj_damage_;
 
     float damage;
     EDGE_DAMAGE_COMPUTE(damage, damtype);
@@ -1828,18 +1827,14 @@ int MissileContact(MapObject *object, MapObject *target)
     // the first impact.
     if (object->extended_flags_ & kExtendedFlagTunnel)
     {
-        // unless it uses the new BORE special - Dasho
-        if (!(object->extended_flags_ & kExtendedFlagBore))
-        {
-            // this hash is very basic, but should work OK
-            uint32_t hash = (uint32_t)(long long)target;
+        // this hash is very basic, but should work OK
+        uint32_t hash = (uint32_t)(long long)target;
 
-            if (object->tunnel_hash_[0] == hash || object->tunnel_hash_[1] == hash)
-                return -1;
+        if (object->tunnel_hash_[0] == hash || object->tunnel_hash_[1] == hash)
+            return -1;
 
-            object->tunnel_hash_[0] = object->tunnel_hash_[1];
-            object->tunnel_hash_[1] = hash;
-        }
+        object->tunnel_hash_[0] = object->tunnel_hash_[1];
+        object->tunnel_hash_[1] = hash;
         if (object->info_->rip_sound_)
             StartSoundEffect(object->info_->rip_sound_, kCategoryObject, object, 0);
     }
@@ -1862,6 +1857,7 @@ int MissileContact(MapObject *object, MapObject *target)
         return 0;
     }
 
+    LogPrint("DAMAGE: %f\n", damage);
     DamageMapObject(target, object, object->source_, damage, damtype, weak_spot);
     return 1;
 }
@@ -5131,8 +5127,8 @@ void A_Mushroom(MapObject *mo)
 
     // Spread is determined by the 'missile damage' mobj property,
     // which from our Dehacked conversion equates to nominal
-    // explode damage
-    int i,j,spread = mo->info_->explode_damage_.nominal_;
+    // projectile damage
+    int i,j,spread = mo->info_->proj_damage_.nominal_;
 
     for (i = -spread; i <= spread; i += 8)
     {

--- a/source_files/edge/p_mobj.cc
+++ b/source_files/edge/p_mobj.cc
@@ -1475,6 +1475,13 @@ static void P_MobjThinker(MapObject *mobj)
     }
     else
     {
+        // Reset tunnel hashes for BORE special so it can damage the same
+        // mobj again if appropriate
+        if (mobj->extended_flags_ & kExtendedFlagBore)
+        {
+            mobj->tunnel_hash_[0] = 0;
+            mobj->tunnel_hash_[1] = 0;
+        }
         mobj_props = *mobj->region_properties_;
         mobj_props.friction = -1.0f;
         // handle push sectors and friction


### PR DESCRIPTION
This fixes the BORE special so that it does not continue to damage the same mobj within the same tic, as well as decoupling Dehacked projectile damage from explosion damage which fixes radius issues with A_Detonate