### PR TITLE
Fixes for automap key graphic/text overlays

### DIFF
--- a/source_files/edge/hu_draw.cc
+++ b/source_files/edge/hu_draw.cc
@@ -1132,7 +1132,7 @@ void HUDDrawText(float x, float y, const char *str, float size)
 
     if (current_y_alignment >= 0)
     {
-        float total_h = HUDStringHeight(str);
+        float total_h = size > 0 ? size : HUDStringHeight(str);
 
         if (current_y_alignment == 0)
             total_h /= 2.0f;


### PR DESCRIPTION
This fixes the graphic/text key overlays mentioned in https://github.com/edge-classic/EDGE-classic/issues/935

This was a result of the automap lines now using raw screen coordinates instead of HUD coordinates, which was throwing off the HUD drawing functions when it came time to do the overlay