### PR TITLE
Adjust Miniaudio SFX attenuation/flags

### DIFF
--- a/source_files/edge/i_movie.cc
+++ b/source_files/edge/i_movie.cc
@@ -69,7 +69,7 @@ static bool MovieSetupAudioStream(int rate)
         return false;
     }
     ma_pcm_rb_set_sample_rate(&movie_ring_buffer, rate);
-    if (ma_sound_init_from_data_source(&music_engine, &movie_ring_buffer, MA_SOUND_FLAG_NO_SPATIALIZATION, NULL,
+    if (ma_sound_init_from_data_source(&music_engine, &movie_ring_buffer, MA_SOUND_FLAG_NO_PITCH|MA_SOUND_FLAG_NO_SPATIALIZATION, NULL,
                                        &movie_sound_buffer) != MA_SUCCESS)
     {
         ma_pcm_rb_uninit(&movie_ring_buffer);

--- a/source_files/edge/s_flac.cc
+++ b/source_files/edge/s_flac.cc
@@ -86,7 +86,7 @@ bool FLACPlayer::OpenMemory(uint8_t *data, int length)
     }
 
     if (ma_sound_init_from_data_source(&music_engine, &flac_decoder,
-                                       MA_SOUND_FLAG_STREAM | MA_SOUND_FLAG_NO_SPATIALIZATION, NULL,
+                                       MA_SOUND_FLAG_NO_PITCH | MA_SOUND_FLAG_STREAM | MA_SOUND_FLAG_NO_SPATIALIZATION, NULL,
                                        &flac_stream) != MA_SUCCESS)
     {
         ma_decoder_uninit(&flac_decoder);

--- a/source_files/edge/s_mp3.cc
+++ b/source_files/edge/s_mp3.cc
@@ -84,7 +84,7 @@ bool MP3Player::OpenMemory(const uint8_t *data, int length)
     }
 
     if (ma_sound_init_from_data_source(&music_engine, &mp3_decoder,
-                                       MA_SOUND_FLAG_STREAM | MA_SOUND_FLAG_NO_SPATIALIZATION, NULL,
+                                       MA_SOUND_FLAG_NO_PITCH | MA_SOUND_FLAG_STREAM | MA_SOUND_FLAG_NO_SPATIALIZATION, NULL,
                                        &mp3_stream) != MA_SUCCESS)
     {
         ma_decoder_uninit(&mp3_decoder);

--- a/source_files/edge/s_ogg.cc
+++ b/source_files/edge/s_ogg.cc
@@ -589,7 +589,7 @@ bool OGGPlayer::OpenMemory(const uint8_t *data, int length)
     }
 
     if (ma_sound_init_from_data_source(&music_engine, &ogg_decoder,
-                                       MA_SOUND_FLAG_STREAM | MA_SOUND_FLAG_NO_SPATIALIZATION, NULL,
+                                       MA_SOUND_FLAG_NO_PITCH | MA_SOUND_FLAG_STREAM | MA_SOUND_FLAG_NO_SPATIALIZATION, NULL,
                                        &ogg_stream) != MA_SUCCESS)
     {
         ma_decoder_uninit(&ogg_decoder);


### PR DESCRIPTION
This adds some missing NO_PITCH flags and also adjusts the sound attenuation behavior to be closer to pre-Miniaudio parameters