### PR TITLE
Sound channel/plane mover/BOOM line fixes; implement sky scrolling

### DIFF
--- a/source_files/ddf/ddf_level.cc
+++ b/source_files/ddf/ddf_level.cc
@@ -68,6 +68,8 @@ static const DDFCommandList level_commands[] = {
     DDF_FIELD("NAME_GRAPHIC", dummy_level, namegraphic_, DDFMainGetLumpName),
     DDF_FIELD("SKY_TEXTURE", dummy_level, sky_, DDFMainGetLumpName),
     DDF_FIELD("SKY_STRETCH", dummy_level, forced_skystretch_, DDFLevelGetSkyStretch),
+    DDF_FIELD("SKY_SCROLL_X", dummy_level, sky_scroll_x_, DDFMainGetPercentAny),
+    DDF_FIELD("SKY_SCROLL_Y", dummy_level, sky_scroll_y_, DDFMainGetPercentAny),
     DDF_FIELD("MUSIC_ENTRY", dummy_level, music_, DDFMainGetNumeric),
     DDF_FIELD("SURROUND_FLAT", dummy_level, surround_, DDFMainGetLumpName),
     DDF_FIELD("NEXT_MAP", dummy_level, next_mapname_, DDFMainGetLumpName),
@@ -453,6 +455,8 @@ void MapDefinition::CopyDetail(const MapDefinition &src)
     f_end_ = src.f_end_;
 
     forced_skystretch_ = src.forced_skystretch_;
+    sky_scroll_x_      = src.sky_scroll_x_;
+    sky_scroll_y_      = src.sky_scroll_y_;
 
     indoor_fog_cmap_     = src.indoor_fog_cmap_;
     indoor_fog_color_    = src.indoor_fog_color_;
@@ -494,6 +498,8 @@ void MapDefinition::Default()
     f_end_.Default();
 
     forced_skystretch_ = kSkyStretchUnset;
+    sky_scroll_x_      = 0;
+    sky_scroll_y_      = 0;
 
     indoor_fog_cmap_     = nullptr;
     indoor_fog_color_    = kRGBANoValue;

--- a/source_files/ddf/ddf_level.h
+++ b/source_files/ddf/ddf_level.h
@@ -164,6 +164,8 @@ class MapDefinition
 
     // sky stretch override
     SkyStretch forced_skystretch_;
+    float      sky_scroll_x_;
+    float      sky_scroll_y_;
 
     Colormap *indoor_fog_cmap_;
     RGBAColor indoor_fog_color_;

--- a/source_files/ddf/ddf_main.cc
+++ b/source_files/ddf/ddf_main.cc
@@ -1277,13 +1277,7 @@ void DDFMainGetPercent(const char *info, void *storage)
 
     // the number must be followed by %
     if (*p != '%')
-    {
         DDFWarnError("Bad percent value '%s': Should be a number followed by %%\n", info);
-        // -AJA- 2001/01/27: backwards compatibility
-        DoGetFloat(s, &f);
-        *dest = HMM_MAX(0, HMM_MIN(1, f));
-        return;
-    }
 
     *p = 0;
 
@@ -1315,12 +1309,7 @@ void DDFMainGetPercentAny(const char *info, void *storage)
 
     // the number must be followed by %
     if (*p != '%')
-    {
         DDFWarnError("Bad percent value '%s': Should be a number followed by %%\n", info);
-        // -AJA- 2001/01/27: backwards compatibility
-        DoGetFloat(s, dest);
-        return;
-    }
 
     *p = 0;
 

--- a/source_files/edge/p_map.cc
+++ b/source_files/edge/p_map.cc
@@ -2917,11 +2917,15 @@ bool CheckSolidSectorMove(Sector *sec, bool is_ceiling, float dh)
         return false;
     }
 
-    // Test fix for Doom 1 E3M4 crusher bug - Dasho
-    if (is_ceiling && dh < 0 && AlmostEquals(sec->ceiling_height, sec->floor_height))
+    if (is_ceiling)
     {
-        if (sec->ceiling_move)
+        if (sec->ceiling_move && dh < 0 && sec->ceiling_height <= sec->floor_height)
             sec->ceiling_move->destination_height = sec->floor_height - dh;
+    }
+    else
+    {
+        if (sec->floor_move && dh > 0 && sec->floor_height >= sec->ceiling_height)
+            sec->floor_move->destination_height = sec->ceiling_height - dh;
     }
 
     // don't allow a dummy sector to go FUBAR

--- a/source_files/edge/p_spec.cc
+++ b/source_files/edge/p_spec.cc
@@ -643,16 +643,16 @@ static void P_LineEffect(Line *target, Line *source, const LineType *special)
         {
             // BOOM spec states that the front sector is the height reference
             // for displace/accel scrollers
-            if (source->front_sector)
+            if (source->side[0]->sector)
             {
-                anim.scroll_sector_reference  = source->front_sector;
+                anim.scroll_sector_reference  = source->side[0]->sector;
                 anim.scroll_special_reference = special;
                 anim.scroll_line_reference    = source;
                 anim.side_0_x_offset_speed    = -source->side[0]->middle.offset.X / 8.0;
                 anim.side_0_y_offset_speed    = source->side[0]->middle.offset.Y / 8.0;
                 for (int i = 0; i < total_level_lines; i++)
                 {
-                    if (level_lines[i].tag == source->front_sector->tag)
+                    if (level_lines[i].tag == source->side[0]->sector->tag)
                     {
                         if (!level_lines[i].special || level_lines[i].special->count_ == 1)
                             anim.permanent = true;
@@ -710,16 +710,16 @@ static void P_LineEffect(Line *target, Line *source, const LineType *special)
             {
                 // BOOM spec states that the front sector is the height
                 // reference for displace/accel scrollers
-                if (source->front_sector)
+                if (source->side[0]->sector)
                 {
-                    anim.scroll_sector_reference  = source->front_sector;
+                    anim.scroll_sector_reference  = source->side[0]->sector;
                     anim.scroll_special_reference = special;
                     anim.scroll_line_reference    = source;
                     anim.dynamic_delta_x += x;
                     anim.dynamic_delta_y += y;
                     for (int i = 0; i < total_level_lines; i++)
                     {
-                        if (level_lines[i].tag == source->front_sector->tag)
+                        if (level_lines[i].tag == source->side[0]->sector->tag)
                         {
                             if (!level_lines[i].special || level_lines[i].special->count_ == 1)
                                 anim.permanent = true;
@@ -790,7 +790,10 @@ static void P_LineEffect(Line *target, Line *source, const LineType *special)
     if ((special->line_effect_ & kLineEffectTypeSkyTransfer) && source->side[0])
     {
         if (source->side[0]->top.image)
+        {
             sky_image = ImageLookup(source->side[0]->top.image->name_.c_str(), kImageNamespaceTexture);
+            sky_ref   = &source->side[0]->top;
+        }
     }
 
     // experimental: stretch wall texture(s) by line length
@@ -854,14 +857,14 @@ static void SectorEffect(Sector *target, Line *source, const LineType *special)
         {
             // BOOM spec states that the front sector is the height reference
             // for displace/accel scrollers
-            if (source->front_sector)
+            if (source->side[0]->sector)
             {
-                anim.scroll_sector_reference  = source->front_sector;
+                anim.scroll_sector_reference  = source->side[0]->sector;
                 anim.scroll_special_reference = special;
                 anim.scroll_line_reference    = source;
                 for (int i = 0; i < total_level_lines; i++)
                 {
-                    if (level_lines[i].tag == source->front_sector->tag)
+                    if (level_lines[i].tag == source->side[0]->sector->tag)
                     {
                         if (!level_lines[i].special || level_lines[i].special->count_ == 1)
                             anim.permanent = true;

--- a/source_files/edge/r_render.cc
+++ b/source_files/edge/r_render.cc
@@ -2014,6 +2014,7 @@ void RendererShutdownLevel()
 #ifdef EDGE_SOKOL
     deferred_sky_items.clear();
 #endif
+    ShutdownSky();
 }
 
 //

--- a/source_files/edge/r_sky.h
+++ b/source_files/edge/r_sky.h
@@ -28,6 +28,7 @@
 #include "r_image.h"
 
 extern const Image *sky_image;
+extern MapSurface  *sky_ref;
 
 // true when a custom sky box is present
 extern bool custom_skybox;
@@ -58,6 +59,8 @@ void PrecacheSky(void);
 
 void SetupSkyMatrices(void);
 void RendererRevertSkyMatrices(void);
+
+void ShutdownSky(void);
 
 //--- editor settings ---
 // vi:ts=4:sw=4:noexpandtab

--- a/source_files/edge/s_blit.h
+++ b/source_files/edge/s_blit.h
@@ -67,7 +67,7 @@ class SoundChannel
     ~SoundChannel();
 };
 
-constexpr uint16_t kMaximumSoundChannels = 32;
+constexpr uint16_t kMaximumSoundChannels = 128;
 
 extern ConsoleVariable sound_effect_volume;
 


### PR DESCRIPTION
Bumps sound channel limit to 128, tweaks some plane mover and BOOM line transfer details, and implements sky scrolling via DDFLEVEL and Boom sky transfers. DDFLEVL syntax is SKY_SCROLL_X and SKY_SCROLL_Y as percentage of the texture's width/height per tic to scroll

NOTE: Sky scrolling is only applied to 'fake' (single-texture) skies, not true skyboxes