### PR TITLE
Fix xoffset for A_SpawnObject

### DIFF
--- a/source_files/ddf/ddf_thing.cc
+++ b/source_files/ddf/ddf_thing.cc
@@ -1890,7 +1890,7 @@ static void DDFMobjStateGetDEHSpawn(const char *arg, State *cur_state)
     {
         int x_offset = 0;
         if (sscanf(args[2].c_str(), "%d", &x_offset) == 1 && x_offset != 0)
-            params->x_offset = (float)x_offset / -65536.0f;
+            params->x_offset = (float)x_offset / 65536.0f;
     }
     if (arg_size > 3)
     {


### PR DESCRIPTION
Inverted xoffset when fixing MBF21 weapon/projectile attacks; this is actually wrong for A_SpawnObject