### PR TITLE
Height sector fixes

### DIFF
--- a/source_files/edge/p_action.cc
+++ b/source_files/edge/p_action.cc
@@ -1424,7 +1424,7 @@ static MapObject *DoLaunchProjectile(MapObject *source, float tx, float ty, floa
     if (source->player_)
         projz += (source->player_->view_z_ - source->player_->standard_view_height_);
     else if (cur_source_sec->sink_depth > 0 && !cur_source_sec->extrafloor_used && !cur_source_sec->height_sector &&
-             abs(source->z - cur_source_sec->floor_height) < 1)
+             AlmostEquals(source->z, cur_source_sec->floor_height))
         projz -= (source->height_ * 0.5 * cur_source_sec->sink_depth);
 
     if (attack->flags_ & kAttackFlagOffsetsLast)
@@ -1472,7 +1472,7 @@ static MapObject *DoLaunchProjectile(MapObject *source, float tx, float ty, floa
             Sector *cur_target_sec = target->subsector_->sector;
 
             if (cur_target_sec->sink_depth > 0 && !cur_target_sec->extrafloor_used && !cur_target_sec->height_sector &&
-                abs(target->z - cur_target_sec->floor_height) < 1)
+                AlmostEquals(target->z, cur_target_sec->floor_height))
                 tz -= (target->height_ * 0.5 * cur_target_sec->sink_depth);
         }
 
@@ -1502,7 +1502,7 @@ static MapObject *DoLaunchProjectile(MapObject *source, float tx, float ty, floa
             Sector *cur_target_sec = target->subsector_->sector;
 
             if (cur_target_sec->sink_depth > 0 && !cur_target_sec->extrafloor_used && !cur_target_sec->height_sector &&
-                abs(target->z - cur_target_sec->floor_height) < 1)
+                AlmostEquals(target->z, cur_target_sec->floor_height))
                 tz -= (target->height_ * 0.5 * cur_target_sec->sink_depth);
         }
 

--- a/source_files/edge/p_maputl.cc
+++ b/source_files/edge/p_maputl.cc
@@ -623,8 +623,9 @@ void ComputeGaps(Line *ld)
     {
         // closed door.
 
-        // -AJA- MUNDO HACK for slopes!!!!
-        if (front->floor_slope || back->floor_slope || front->ceiling_slope || back->ceiling_slope)
+        // -AJA- MUNDO HACK for slopes (and line 242)!!!!
+        if (front->floor_slope || back->floor_slope || front->ceiling_slope || back->ceiling_slope
+            || front->height_sector || back->height_sector)
         {
             ld->blocked = false;
         }

--- a/source_files/edge/p_spec.cc
+++ b/source_files/edge/p_spec.cc
@@ -982,7 +982,7 @@ static void SectorEffect(Sector *target, Line *source, const LineType *special)
     // support for drawn heights coming from different sector
     if (special->sector_effect_ & kSectorEffectTypeBoomHeights)
     {
-        target->height_sector      = source->front_sector;
+        target->height_sector      = source->side[0]->sector;
         target->height_sector_side = source->side[0];
         for (int i = 0; i < target->line_count; i++)
         {


### PR DESCRIPTION
This fixes ComputeGaps not marking 0-height line 242 sectors as non-blocking (for rendering purposes), as well as a few other values