### PR TITLE
Threading and SDL shutdown fixes

### DIFF
--- a/source_files/ddf/ddf_reverb.cc
+++ b/source_files/ddf/ddf_reverb.cc
@@ -147,14 +147,10 @@ void ReverbDefinition::CopyDetail(const ReverbDefinition &src)
     reverb_gain_   = src.reverb_gain_;
 }
 
-void ReverbDefinition::ApplyReverb(verblib *reverb) const
+void ReverbDefinition::ApplyReverb(ma_freeverb_node *reverb) const
 {
-    verblib_set_room_size(reverb, room_size_);
-    verblib_set_damping(reverb, damping_level_);
-    verblib_set_wet(reverb, wet_level_);
-    verblib_set_dry(reverb, dry_level_);
-    verblib_set_width(reverb, reverb_width_);
-    verblib_set_gain(reverb, reverb_gain_);
+    ma_freeverb_update_verb(reverb, &room_size_, &damping_level_, &wet_level_,
+        &dry_level_, &reverb_width_, &reverb_gain_);
 }
 
 void ReverbDefinition::Default()

--- a/source_files/ddf/ddf_reverb.h
+++ b/source_files/ddf/ddf_reverb.h
@@ -23,7 +23,8 @@
 #include "ddf_types.h"
 #include "epi.h"
 #include "epi_str_hash.h"
-#include "verblib.h"
+#include "miniaudio.h"
+#include "miniaudio_freeverb.h"
 
 extern epi::StringHash DDFCreateStringHash(std::string_view name);
 #ifdef __GNUC__
@@ -42,7 +43,7 @@ class ReverbDefinition final
 
     void                            Default(void);
     void                            CopyDetail(const ReverbDefinition &src);
-    void                            ApplyReverb(verblib *reverb) const;
+    void                            ApplyReverb(ma_freeverb_node *reverb) const;
     static void                     ReadDDF(const std::string &data);
     static inline ReverbDefinition *Lookup(std::string_view refname)
     {

--- a/source_files/edge/am_map.cc
+++ b/source_files/edge/am_map.cc
@@ -245,9 +245,9 @@ static void DrawAllLines()
                     current_glvert = BeginRenderUnit(GL_LINES, kMaximumLineVerts, GL_MODULATE, 0,
                                                      (GLuint)kTextureEnvironmentDisable, 0, 0, kBlendingAlpha);
                 }
-                current_glvert->position = {points->X, points->Y, 0};
+                current_glvert->position = {{points->X, points->Y, 0}};
                 current_glvert++->rgba   = col;
-                current_glvert->position = {points->Z, points->W, 0};
+                current_glvert->position = {{points->Z, points->W, 0}};
                 current_glvert++->rgba   = col;
                 current_vert_count += 2;
             }
@@ -689,15 +689,15 @@ static void DrawMLineDoor(AutomapLine *ml)
 }
 
 static HMM_Vec4 player_dagger[] = {
-    {{-0.75f, 0.0f, 0.0f, 0.0f}},                                        // center line
+    {{{{{-0.75f, 0.0f, 0.0f}}}, 0.0f}},                                              // center line
 
-    {{-0.75f, 0.125f, 1.0f, 0.0f}},                                      // blade
-    {{-0.75f, -0.125f, 1.0f, 0.0f}},
+    {{{{{-0.75f, 0.125f, 1.0f}}}, 0.0f}},                                            // blade
+    {{{{{-0.75f, -0.125f, 1.0f}}}, 0.0f}},
 
-    {{-0.75, -0.25, -0.75, 0.25}},                                       // crosspiece
-    {{-0.875, -0.25, -0.875, 0.25}},  {{-0.875, -0.25, -0.75, -0.25}},   // crosspiece connectors
-    {{-0.875, 0.25, -0.75, 0.25}},    {{-1.125, 0.125, -1.125, -0.125}}, // pommel
-    {{-1.125, 0.125, -0.875, 0.125}}, {{-1.125, -0.125, -0.875, -0.125}}};
+    {{{{{-0.75, -0.25, -0.75}}}, 0.25}},                                             // crosspiece
+    {{{{{-0.875, -0.25, -0.875}}}, 0.25}},  {{{{{-0.875, -0.25, -0.75}}}, -0.25}},   // crosspiece connectors
+    {{{{{-0.875, 0.25, -0.75}}}, 0.25}},    {{{{{-1.125, 0.125, -1.125}}}, -0.125}}, // pommel
+    {{{{{-1.125, 0.125, -0.875}}}, 0.125}}, {{{{{-1.125, -0.125, -0.875}}}, -0.125}}};
 
 static constexpr uint8_t kAutomapPlayerDaggerLines = (sizeof(player_dagger) / sizeof(HMM_Vec4));
 
@@ -1168,46 +1168,46 @@ static void DrawObjectBounds(MapObject *mo, RGBAColor rgb)
 // A line drawing of the player pointing right, starting from the
 // middle.
 
-static HMM_Vec4 player_arrow[] = {{{-0.875f, 0.0f, 1.0f, 0.0f}},     // -----
+static HMM_Vec4 player_arrow[] = {{{{{{-0.875f, 0.0f, 1.0f}}}, 0.0f}},     // -----
 
-                                  {{1.0f, 0.0f, 0.5f, 0.25f}},       // ----->
-                                  {{1.0f, 0.0f, 0.5f, -0.25f}},
+                                  {{{{{1.0f, 0.0f, 0.5f}}}, 0.25f}},       // ----->
+                                  {{{{{1.0f, 0.0f, 0.5f}}}, -0.25f}},
 
-                                  {{-0.875f, 0.0f, -1.125f, 0.25f}}, // >---->
-                                  {{-0.875f, 0.0f, -1.125f, -0.25f}},
+                                  {{{{{-0.875f, 0.0f, -1.125f}}}, 0.25f}}, // >---->
+                                  {{{{{-0.875f, 0.0f, -1.125f}}}, -0.25f}},
 
-                                  {{-0.625f, 0.0f, -0.875f, 0.25f}}, // >>--->
-                                  {{-0.625f, 0.0f, -0.875f, -0.25f}}};
+                                  {{{{{-0.625f, 0.0f, -0.875f}}}, 0.25f}}, // >>--->
+                                  {{{{{-0.625f, 0.0f, -0.875f}}}, -0.25f}}};
 
 static constexpr uint8_t kAutomapPlayerArrowLines = (sizeof(player_arrow) / sizeof(HMM_Vec4));
 
-static HMM_Vec4 cheat_player_arrow[] = {{{-0.875f, 0.0f, 1.0f, 0.0f}},      // -----
+static HMM_Vec4 cheat_player_arrow[] = {{{{{{-0.875f, 0.0f, 1.0f}}}, 0.0f}},      // -----
 
-                                        {{1.0f, 0.0f, 0.5f, 0.167f}},       // ----->
-                                        {{1.0f, 0.0f, 0.5f, -0.167f}},
+                                        {{{{{1.0f, 0.0f, 0.5f}}}, 0.167f}},       // ----->
+                                        {{{{{1.0f, 0.0f, 0.5f}}}, -0.167f}},
 
-                                        {{-0.875f, 0.0f, -1.125f, 0.167f}}, // >----->
-                                        {{-0.875f, 0.0f, -1.125f, -0.167f}},
+                                        {{{{{-0.875f, 0.0f, -1.125f}}}, 0.167f}}, // >----->
+                                        {{{{{-0.875f, 0.0f, -1.125f}}}, -0.167f}},
 
-                                        {{-0.625f, 0.0f, -0.875f, 0.167f}}, // >>----->
-                                        {{-0.625f, 0.0f, -0.875f, -0.167f}},
+                                        {{{{{-0.625f, 0.0f, -0.875f}}}, 0.167f}}, // >>----->
+                                        {{{{{-0.625f, 0.0f, -0.875f}}}, -0.167f}},
 
-                                        {{-0.5f, 0.0f, -0.5f, -0.167f}},    // >>-d--->
-                                        {{-0.5f, -0.167f, -0.5f + 0.167f, -0.167f}},
-                                        {{-0.5f + 0.167f, -0.167f, -0.5f + 0.167f, 0.25f}},
+                                        {{{{{-0.5f, 0.0f, -0.5f}}}, -0.167f}},    // >>-d--->
+                                        {{{{{-0.5f, -0.167f, -0.5f + 0.167f}}}, -0.167f}},
+                                        {{{{{-0.5f + 0.167f, -0.167f, -0.5f + 0.167f}}}, 0.25f}},
 
-                                        {{-0.167f, 0.0f, -0.167f, -0.167f}}, // >>-dd-->
-                                        {{-0.167f, -0.167f, 0.0f, -0.167f}},
-                                        {{0.0f, -0.167f, 0.0f, 0.25f}},
+                                        {{{{{-0.167f, 0.0f, -0.167f}}}, -0.167f}}, // >>-dd-->
+                                        {{{{{-0.167f, -0.167f, 0.0f}}}, -0.167f}},
+                                        {{{{{0.0f, -0.167f, 0.0f}}}, 0.25f}},
 
-                                        {{0.167f, 0.25f, 0.167f, -0.143f}}, // >>-ddt->
-                                        {{0.167f, -0.143f, 0.167f + 0.031f, -0.143f - 0.031f}},
-                                        {{0.167f + 0.031f, -0.143f - 0.031f, 0.167f + 0.1f, -0.143f}}};
+                                        {{{{{0.167f, 0.25f, 0.167f}}}, -0.143f}}, // >>-ddt->
+                                        {{{{{0.167f, -0.143f, 0.167f + 0.031f}}}, -0.143f - 0.031f}},
+                                        {{{{{0.167f + 0.031f, -0.143f - 0.031f, 0.167f + 0.1f}}}, -0.143f}}};
 
 static constexpr uint8_t kAutomapCheatPlayerArrowLines = (sizeof(cheat_player_arrow) / sizeof(HMM_Vec4));
 
 static HMM_Vec4 thin_triangle_guy[] = {
-    {{-0.5f, -0.7f, 1.0f, 0.0f}}, {{1.0f, 0.0f, -0.5f, 0.7f}}, {{-0.5f, 0.7f, -0.5f, -0.7f}}};
+    {{{{{-0.5f, -0.7f, 1.0f}}}, 0.0f}}, {{{{{1.0f, 0.0f, -0.5f}}}, 0.7f}}, {{{{{-0.5f, 0.7f, -0.5f}}}, -0.7f}}};
 
 static constexpr uint8_t kAutomapThinTriangleGuyLines = (sizeof(thin_triangle_guy) / sizeof(HMM_Vec4));
 

--- a/source_files/edge/con_con.cc
+++ b/source_files/edge/con_con.cc
@@ -1412,6 +1412,7 @@ void ConsoleStart(void)
     StartupProgressMessage("Starting console...");
 }
 
+#ifdef EDGE_SOKOL
 static char *GetHumanSize(uint32_t bytes, char *hrbytes)
 {
     const char *suffix[] = {"B", "KB", "MB", "GB", "TB"};
@@ -1429,6 +1430,7 @@ static char *GetHumanSize(uint32_t bytes, char *hrbytes)
     snprintf(hrbytes, 128, "%u %s", bytes, suffix[i]);
     return (hrbytes);
 }
+#endif
 
 void ConsoleShowFPS(void)
 {

--- a/source_files/edge/i_ctrl.cc
+++ b/source_files/edge/i_ctrl.cc
@@ -776,15 +776,19 @@ void ControlGetEvents(void)
 
 void ShutdownControl(void)
 {
-    if (gamepad_info)
+    if (SDL_WasInit(SDL_INIT_GAMECONTROLLER))
     {
-        SDL_GameControllerClose(gamepad_info);
-        gamepad_info = nullptr;
-    }
-    if (joystick_info)
-    {
-        SDL_JoystickClose(joystick_info);
-        joystick_info = nullptr;
+        if (gamepad_info)
+        {
+            SDL_GameControllerClose(gamepad_info);
+            gamepad_info = nullptr;
+        }
+        if (joystick_info)
+        {
+            SDL_JoystickClose(joystick_info);
+            joystick_info = nullptr;
+        }
+        SDL_QuitSubSystem(SDL_INIT_GAMECONTROLLER);
     }
 }
 

--- a/source_files/edge/i_movie.cc
+++ b/source_files/edge/i_movie.cc
@@ -69,7 +69,7 @@ static bool MovieSetupAudioStream(int rate)
         return false;
     }
     ma_pcm_rb_set_sample_rate(&movie_ring_buffer, rate);
-    if (ma_sound_init_from_data_source(&music_engine, &movie_ring_buffer,
+    if (ma_sound_init_from_data_source(&sound_engine, &movie_ring_buffer,
                                        MA_SOUND_FLAG_NO_PITCH | MA_SOUND_FLAG_NO_SPATIALIZATION, NULL,
                                        &movie_sound_buffer) != MA_SUCCESS)
     {
@@ -83,7 +83,7 @@ static bool MovieSetupAudioStream(int rate)
     ma_sound_set_looping(&movie_sound_buffer, MA_TRUE);
     ma_sound_start(&movie_sound_buffer);
     PauseMusic();
-    ma_engine_set_volume(&music_engine, music_volume.f_);
+    ma_sound_set_volume(&movie_sound_buffer, music_volume.f_);
     return true;
 }
 
@@ -319,7 +319,6 @@ static void EndMovie()
     ma_sound_stop(&movie_sound_buffer);
     ma_sound_uninit(&movie_sound_buffer);
     ma_pcm_rb_uninit(&movie_ring_buffer);
-    ma_engine_set_volume(&music_engine, music_volume.f_);
     ResumeMusic();
 }
 

--- a/source_files/edge/i_sound.cc
+++ b/source_files/edge/i_sound.cc
@@ -50,7 +50,6 @@ extern std::string     home_directory;
 extern ConsoleVariable midi_soundfont;
 
 ma_engine sound_engine;
-ma_engine music_engine;
 // Airless/Vacuum SFX sector sounds
 ma_lpf_node vacuum_node;
 // Underwater sector sounds; these two chain into each other
@@ -77,7 +76,8 @@ void StartupAudio(void)
     {
         sound_device_frequency = ma_engine_get_sample_rate(&sound_engine);
         ma_uint32 channels     = ma_engine_get_channels(&sound_engine);
-        ma_engine_set_volume(&sound_engine, sound_effect_volume.f_ * 0.5f);
+        // This seems to be the sweet spot for not getting burnt sounds - Dasho
+        ma_engine_set_volume(&sound_engine, 0.5f);
         // configure FX nodes
 
         // Underwater/Submerged
@@ -102,17 +102,6 @@ void StartupAudio(void)
         ma_freeverb_node_init(ma_engine_get_node_graph(&sound_engine), &reverb_node_config, NULL, &reverb_node);
         ma_node_attach_output_bus(&reverb_node, 0, ma_engine_get_endpoint(&sound_engine), 0);
         ma_node_attach_output_bus(&reverb_delay_node, 0, &reverb_node, 0);
-    }
-
-    if (!no_music)
-    {
-        if (ma_engine_init(NULL, &music_engine) != MA_SUCCESS)
-        {
-            LogPrint("StartupAudio: Unable to initialize music engine!\n");
-            no_music = true;
-        }
-        else
-            ma_engine_set_volume(&music_engine, music_volume.f_);
     }
 
     // display some useful stuff

--- a/source_files/edge/i_sound.h
+++ b/source_files/edge/i_sound.h
@@ -28,7 +28,6 @@
 extern std::set<std::string> available_soundfonts;
 
 extern ma_engine        sound_engine;
-extern ma_engine        music_engine;
 extern ma_freeverb_node reverb_node;
 extern ma_delay_node    underwater_node;
 extern ma_delay_node    reverb_delay_node;

--- a/source_files/edge/i_system.cc
+++ b/source_files/edge/i_system.cc
@@ -190,6 +190,8 @@ void SystemShutdown(void)
         fclose(debug_file);
         debug_file = nullptr;
     }
+
+    SDL_Quit();
 }
 
 //--- editor settings ---

--- a/source_files/edge/i_video.cc
+++ b/source_files/edge/i_video.cc
@@ -516,12 +516,7 @@ void ShutdownGraphics(void)
         program_window = nullptr;
     }
 
-    if (SDL_WasInit(SDL_INIT_EVERYTHING))
-    {
-        DeterminePixelAspect();
-
-        SDL_Quit();
-    }
+    SDL_QuitSubSystem(SDL_INIT_VIDEO);
 }
 
 //--- editor settings ---

--- a/source_files/edge/p_inter.cc
+++ b/source_files/edge/p_inter.cc
@@ -984,6 +984,7 @@ static std::string PatternSubstitution(const char *format, const std::vector<std
 static void DoObituary(const char *format, MapObject *victim, MapObject *killer)
 {
     EPI_UNUSED(killer); // eventually use DDFLANG to actually state the killer - Dasho
+    EPI_UNUSED(victim); // and uhhh the victim
     std::vector<std::string> keywords;
 
     keywords.push_back("o");

--- a/source_files/edge/p_user.cc
+++ b/source_files/edge/p_user.cc
@@ -942,7 +942,7 @@ bool PlayerThink(Player *player)
         if (player->map_object_->subsector_->sector->sound_reverb)
         {
             sector_reverb = true;
-            player->map_object_->subsector_->sector->sound_reverb->ApplyReverb(&reverb_node.reverb);
+            player->map_object_->subsector_->sector->sound_reverb->ApplyReverb(&reverb_node);
         }
         else if (dynamic_reverb.d_)
         {
@@ -977,30 +977,34 @@ bool PlayerThink(Player *player)
                 outdoor_reverb = true;
                 ma_delay_node_set_decay(&reverb_delay_node, room_check * 0.00004316f);
                 if (dynamic_reverb.d_ == 1) // Headphones
-                    ddf::ReverbDefinition::kOutdoorWeak.ApplyReverb(&reverb_node.reverb);
+                    ddf::ReverbDefinition::kOutdoorWeak.ApplyReverb(&reverb_node);
                 else                        // Speakers
-                    ddf::ReverbDefinition::kOutdoorStrong.ApplyReverb(&reverb_node.reverb);
+                    ddf::ReverbDefinition::kOutdoorStrong.ApplyReverb(&reverb_node);
                 if (room_check < 700)
                 {
+                    float new_room_size;
                     if (room_check > 350)
-                        verblib_set_room_size(&reverb_node.reverb, 0.3f);
+                        new_room_size = 0.3f;
                     else
-                        verblib_set_room_size(&reverb_node.reverb, 0.2f);
+                        new_room_size = 0.2f;
+                    ma_freeverb_update_verb(&reverb_node, &new_room_size, NULL, NULL, NULL, NULL, NULL);
                 }
             }
             else
             {
                 outdoor_reverb = false;
                 if (dynamic_reverb.d_ == 1) // Headphones
-                    ddf::ReverbDefinition::kIndoorWeak.ApplyReverb(&reverb_node.reverb);
+                    ddf::ReverbDefinition::kIndoorWeak.ApplyReverb(&reverb_node);
                 else                        // Speakers
-                    ddf::ReverbDefinition::kIndoorStrong.ApplyReverb(&reverb_node.reverb);
+                    ddf::ReverbDefinition::kIndoorStrong.ApplyReverb(&reverb_node);
                 if (room_check < 700)
                 {
+                    float new_room_size;
                     if (room_check > 350)
-                        verblib_set_room_size(&reverb_node.reverb, 0.2f);
+                        new_room_size = 0.2f;
                     else
-                        verblib_set_room_size(&reverb_node.reverb, 0.1f);
+                        new_room_size = 0.1f;
+                    ma_freeverb_update_verb(&reverb_node, &new_room_size, NULL, NULL, NULL, NULL, NULL);
                 }
             }
         }

--- a/source_files/edge/render/gl/gl_backend.cc
+++ b/source_files/edge/render/gl/gl_backend.cc
@@ -166,10 +166,13 @@ class GLRenderBackend : public RenderBackend
 
     void Flush(int32_t commands, int32_t vertices)
     {
+        EPI_UNUSED(commands);
+        EPI_UNUSED(vertices);
     }
 
     void GetFrameStats(FrameStats &stats)
     {
+        EPI_UNUSED(stats);
     }
 
     void OnContextSwitch()

--- a/source_files/edge/render/sokol/sokol_md2.cc
+++ b/source_files/edge/render/sokol/sokol_md2.cc
@@ -513,7 +513,7 @@ MD2Model *MD2Load(epi::File *f, float &radius)
 
             which_normals[good_V->normal_idx] = 1;
 
-            HMM_Vec3 vr = {good_V->x, good_V->y, good_V->z};
+            HMM_Vec3 vr = {{good_V->x, good_V->y, good_V->z}};
             float    r  = HMM_Len(vr);
 
             if (r > radius)
@@ -760,7 +760,7 @@ MD2Model *MD3Load(epi::File *f, float &radius)
 
             which_normals[good_V->normal_idx] = 1;
 
-            HMM_Vec3 vr = {good_V->x, good_V->y, good_V->z};
+            HMM_Vec3 vr = {{good_V->x, good_V->y, good_V->z}};
             float    r  = HMM_Len(vr);
 
             if (r > radius)

--- a/source_files/edge/render/sokol/sokol_mdl.cc
+++ b/source_files/edge/render/sokol/sokol_mdl.cc
@@ -437,7 +437,7 @@ MDLModel *MDLLoad(epi::File *f, float &radius)
 
             which_normals[good_V->normal_idx] = 1;
 
-            HMM_Vec3 vr = {good_V->x, good_V->y, good_V->z};
+            HMM_Vec3 vr = {{good_V->x, good_V->y, good_V->z}};
             float    r  = HMM_Len(vr);
 
             if (r > radius)

--- a/source_files/edge/render/sokol/sokol_units.cc
+++ b/source_files/edge/render/sokol/sokol_units.cc
@@ -569,7 +569,7 @@ void RenderCurrentUnits(void)
 
                 const RendererVertex *V = local_verts + unit->first;
 
-                HMM_Vec2 aa_radius = {2.0f, 2.0f};
+                HMM_Vec2 aa_radius = {{2.0f, 2.0f}};
 
                 float line_width       = HMM_MAX(1.0f, state_width) + aa_radius.X;
                 float extension_length = aa_radius.Y;
@@ -585,21 +585,21 @@ void RenderCurrentUnits(void)
                     uint8_t blue  = epi::GetRGBABlue(src_v0->rgba);
                     uint8_t alpha = epi::GetRGBAAlpha(src_v0->rgba);
 
-                    HMM_Vec2 v0 = {src_v0->position[0], src_v0->position[1]};
-                    HMM_Vec2 v1 = {src_v1->position[0], src_v1->position[1]};
+                    HMM_Vec2 v0 = {{src_v0->position[0], src_v0->position[1]}};
+                    HMM_Vec2 v1 = {{src_v1->position[0], src_v1->position[1]}};
 
                     HMM_Vec2 line_vector = HMM_SubV2(v1, v0);
                     float    line_length = HMM_LenV2(line_vector) + 2.0f * extension_length;
                     HMM_Vec2 dir         = HMM_NormV2(line_vector);
-                    HMM_Vec2 normal      = {-dir.Y * line_width * 0.5f, dir.X * line_width * 0.5f};
+                    HMM_Vec2 normal      = {{-dir.Y * line_width * 0.5f, dir.X * line_width * 0.5f}};
 
-                    HMM_Vec2 extension = HMM_MulV2({extension_length, extension_length}, dir);
+                    HMM_Vec2 extension = HMM_MulV2({{extension_length, extension_length}}, dir);
 
-                    HMM_Vec2 a1 = {v0.X - normal.X - extension.X, v0.Y - normal.Y - extension.Y};
-                    HMM_Vec2 a0 = {v0.X + normal.X - extension.X, v0.Y + normal.Y - extension.Y};
+                    HMM_Vec2 a1 = {{v0.X - normal.X - extension.X, v0.Y - normal.Y - extension.Y}};
+                    HMM_Vec2 a0 = {{v0.X + normal.X - extension.X, v0.Y + normal.Y - extension.Y}};
 
-                    HMM_Vec2 b1 = {v1.X - normal.X + extension.X, v1.Y - normal.Y + extension.Y};
-                    HMM_Vec2 b0 = {v1.X + normal.X + extension.X, v1.Y + normal.Y + extension.Y};
+                    HMM_Vec2 b1 = {{v1.X - normal.X + extension.X, v1.Y - normal.Y + extension.Y}};
+                    HMM_Vec2 b0 = {{v1.X + normal.X + extension.X, v1.Y + normal.Y + extension.Y}};
 
                     float factor = 0.5f;
 

--- a/source_files/edge/s_blit.cc
+++ b/source_files/edge/s_blit.cc
@@ -118,8 +118,6 @@ void UpdateSounds(MapObject *listener, BAMAngle angle)
 {
     EDGE_ZoneScoped;
 
-    ma_engine_set_volume(&sound_engine, sound_effect_volume.f_ * 0.5f);
-
     listen_x = listener ? listener->x : 0;
     listen_y = listener ? listener->y : 0;
     listen_z = listener ? listener->z : 0;
@@ -138,6 +136,8 @@ void UpdateSounds(MapObject *listener, BAMAngle angle)
 
         if (chan->state_ == kChannelPlaying)
         {
+            ma_sound_set_volume(&chan->channel_sound_, sound_effect_volume.f_);
+
             if (chan->loop_)
             {
                 ma_uint64 cur_pos = 0;

--- a/source_files/edge/s_flac.cc
+++ b/source_files/edge/s_flac.cc
@@ -85,7 +85,7 @@ bool FLACPlayer::OpenMemory(uint8_t *data, int length)
         return false;
     }
 
-    if (ma_sound_init_from_data_source(&music_engine, &flac_decoder,
+    if (ma_sound_init_from_data_source(&sound_engine, &flac_decoder,
                                        MA_SOUND_FLAG_NO_PITCH | MA_SOUND_FLAG_STREAM | MA_SOUND_FLAG_NO_SPATIALIZATION,
                                        NULL, &flac_stream) != MA_SUCCESS)
     {
@@ -173,7 +173,7 @@ void FLACPlayer::Ticker()
 {
     if (status_ == kPlaying)
     {
-        ma_engine_set_volume(&music_engine, music_volume.f_);
+        ma_sound_set_volume(&flac_stream, music_volume.f_);
 
         if (pc_speaker_mode)
             Stop();

--- a/source_files/edge/s_m4p.cc
+++ b/source_files/edge/s_m4p.cc
@@ -481,7 +481,7 @@ bool M4PPlayer::OpenMemory(const uint8_t *data, int length)
         return false;
     }
 
-    if (ma_sound_init_from_data_source(&music_engine, &m4p_decoder,
+    if (ma_sound_init_from_data_source(&sound_engine, &m4p_decoder,
                                        MA_SOUND_FLAG_NO_PITCH | MA_SOUND_FLAG_UNKNOWN_LENGTH | MA_SOUND_FLAG_STREAM |
                                            MA_SOUND_FLAG_NO_SPATIALIZATION,
                                        NULL, &m4p_stream) != MA_SUCCESS)
@@ -566,8 +566,7 @@ void M4PPlayer::Ticker()
 {
     if (status_ == kPlaying)
     {
-        ma_engine_set_volume(&music_engine, music_volume.f_);
-
+        ma_sound_set_volume(&m4p_stream, music_volume.f_);
         if (pc_speaker_mode)
             Stop();
         if (ma_sound_at_end(&m4p_stream)) // This should only be true if finished and not set to looping

--- a/source_files/edge/s_midi.cc
+++ b/source_files/edge/s_midi.cc
@@ -797,7 +797,7 @@ class MIDIPlayer : public AbstractMusicPlayer
             return false;
         }
 
-        if (ma_sound_init_from_data_source(&music_engine, &midi_decoder,
+        if (ma_sound_init_from_data_source(&sound_engine, &midi_decoder,
                                            MA_SOUND_FLAG_NO_PITCH | MA_SOUND_FLAG_STREAM |
                                                MA_SOUND_FLAG_UNKNOWN_LENGTH | MA_SOUND_FLAG_NO_SPATIALIZATION,
                                            NULL, &midi_stream) != MA_SUCCESS)
@@ -880,16 +880,9 @@ class MIDIPlayer : public AbstractMusicPlayer
 
     void Ticker(void)
     {
-        if (fluidlite_gain.CheckModified())
-        {
-            fluidlite_gain.f_ = HMM_Clamp(0.0, fluidlite_gain.f_, 2.0f);
-            fluidlite_gain    = fluidlite_gain.f_;
-            fluid_synth_set_gain(edge_fluid, fluidlite_gain.f_);
-        }
-
         if (status_ == kPlaying)
         {
-            ma_engine_set_volume(&music_engine, music_volume.f_);
+            ma_sound_set_volume(&midi_stream, music_volume.f_);
 
             if (pc_speaker_mode)
                 Stop();

--- a/source_files/edge/s_midi_ec.cc
+++ b/source_files/edge/s_midi_ec.cc
@@ -877,7 +877,7 @@ class MIDIPlayer : public AbstractMusicPlayer
             return false;
         }
 
-        if (ma_sound_init_from_data_source(&music_engine, &midi_decoder,
+        if (ma_sound_init_from_data_source(&sound_engine, &midi_decoder,
                                            MA_SOUND_FLAG_NO_PITCH | MA_SOUND_FLAG_STREAM |
                                                MA_SOUND_FLAG_UNKNOWN_LENGTH | MA_SOUND_FLAG_NO_SPATIALIZATION,
                                            NULL, &midi_stream) != MA_SUCCESS)
@@ -967,16 +967,9 @@ class MIDIPlayer : public AbstractMusicPlayer
 
     void Ticker(void) override
     {
-        if (fluidlite_gain.CheckModified())
-        {
-            fluidlite_gain.f_ = HMM_Clamp(0.0, fluidlite_gain.f_, 2.0f);
-            fluidlite_gain    = fluidlite_gain.f_;
-            fluid_synth_set_gain(edge_fluid, fluidlite_gain.f_);
-        }
-
         if (status_ == kPlaying)
         {
-            ma_engine_set_volume(&music_engine, music_volume.f_);
+            ma_sound_set_volume(&midi_stream, music_volume.f_);
 
             if (pc_speaker_mode)
                 Stop();

--- a/source_files/edge/s_mp3.cc
+++ b/source_files/edge/s_mp3.cc
@@ -83,7 +83,7 @@ bool MP3Player::OpenMemory(const uint8_t *data, int length)
         return false;
     }
 
-    if (ma_sound_init_from_data_source(&music_engine, &mp3_decoder,
+    if (ma_sound_init_from_data_source(&sound_engine, &mp3_decoder,
                                        MA_SOUND_FLAG_NO_PITCH | MA_SOUND_FLAG_STREAM | MA_SOUND_FLAG_NO_SPATIALIZATION,
                                        NULL, &mp3_stream) != MA_SUCCESS)
     {
@@ -171,7 +171,7 @@ void MP3Player::Ticker()
 {
     if (status_ == kPlaying)
     {
-        ma_engine_set_volume(&music_engine, music_volume.f_);
+        ma_sound_set_volume(&mp3_stream, music_volume.f_);
 
         if (pc_speaker_mode)
             Stop();

--- a/source_files/edge/s_ogg.cc
+++ b/source_files/edge/s_ogg.cc
@@ -588,7 +588,7 @@ bool OGGPlayer::OpenMemory(const uint8_t *data, int length)
         return false;
     }
 
-    if (ma_sound_init_from_data_source(&music_engine, &ogg_decoder,
+    if (ma_sound_init_from_data_source(&sound_engine, &ogg_decoder,
                                        MA_SOUND_FLAG_NO_PITCH | MA_SOUND_FLAG_STREAM | MA_SOUND_FLAG_NO_SPATIALIZATION,
                                        NULL, &ogg_stream) != MA_SUCCESS)
     {
@@ -676,7 +676,7 @@ void OGGPlayer::Ticker()
 {
     if (status_ == kPlaying)
     {
-        ma_engine_set_volume(&music_engine, music_volume.f_);
+        ma_sound_set_volume(&ogg_stream, music_volume.f_);
 
         if (pc_speaker_mode)
             Stop();

--- a/source_files/edge/s_sound.cc
+++ b/source_files/edge/s_sound.cc
@@ -237,7 +237,6 @@ void ShutdownSound(void)
 
     SoundCacheClearAll();
 
-    ma_engine_uninit(&music_engine);
     ma_engine_uninit(&sound_engine);
 }
 


### PR DESCRIPTION
This addresses various miniaudio-related race conditions as identified by Clang TSAN, as well as tweaked the order of SDL subsystem shutdown and initialization checks. Incidentally cleaned up some Clang-related formatting warnings