### PR TITLE
Various audio fixes

### DIFF
--- a/source_files/edge/e_main.cc
+++ b/source_files/edge/e_main.cc
@@ -2224,14 +2224,7 @@ static void InitializeDDF(void)
 void EdgeShutdown(void)
 {
     StopMusic();
-
-    // Pause to allow sounds to finish
-    for (int loop = 0; loop < 30; loop++)
-    {
-        SoundTicker();
-        SleepForMilliseconds(50);
-    }
-
+    StopAllSoundEffects();
     LevelShutdown();
     AudioShutdown();
     RendererShutdown();

--- a/source_files/edge/i_movie.cc
+++ b/source_files/edge/i_movie.cc
@@ -80,6 +80,7 @@ static bool MovieSetupAudioStream(int rate)
     plm_set_audio_lead_time(decoder, (double)1024 / (double)rate);
     // ring buffer based sounds need to unconditionally "loop" so that even if the buffer
     // has no data ready to read it will not report being "finished"
+    ma_node_attach_output_bus(&movie_sound_buffer, 0, &music_node, 0);
     ma_sound_set_looping(&movie_sound_buffer, MA_TRUE);
     ma_sound_start(&movie_sound_buffer);
     PauseMusic();

--- a/source_files/edge/i_sound.h
+++ b/source_files/edge/i_sound.h
@@ -28,6 +28,8 @@
 extern std::set<std::string> available_soundfonts;
 
 extern ma_engine        sound_engine;
+extern ma_sound_group   sfx_node;
+extern ma_sound_group   music_node;
 extern ma_freeverb_node reverb_node;
 extern ma_delay_node    underwater_node;
 extern ma_delay_node    reverb_delay_node;

--- a/source_files/edge/m_menu.cc
+++ b/source_files/edge/m_menu.cc
@@ -1622,42 +1622,6 @@ static void QuitResponse(int ch)
     if (ch != 'y' && ch != kGamepadA && ch != kMouse1)
         return;
 
-    if (!network_game)
-    {
-        int  numsounds = 0;
-        char refname[64];
-        char sound[64];
-        int  i, start;
-
-        // Count the quit messages
-        do
-        {
-            stbsp_sprintf(refname, "QuitSnd%d", numsounds + 1);
-            if (language.IsValidRef(refname))
-                numsounds++;
-            else
-                break;
-        } while (true);
-
-        if (numsounds)
-        {
-            // cycle through all the quit sounds, until one of them exists
-            // (some of the default quit sounds do not exist in DOOM 1)
-            start = i = RandomByte() % numsounds;
-            do
-            {
-                stbsp_sprintf(refname, "QuitSnd%d", i + 1);
-                stbsp_sprintf(sound, "DS%s", language[refname]);
-                if (CheckLumpNumberForName(sound) != -1)
-                {
-                    StartSoundEffect(sfxdefs.GetEffect(language[refname]));
-                    break;
-                }
-                i = (i + 1) % numsounds;
-            } while (i != start);
-        }
-    }
-
     // -ACB- 1999/09/20 New exit code order
     // Write the default config file first
     LogPrint("Saving system defaults...\n");

--- a/source_files/edge/p_user.cc
+++ b/source_files/edge/p_user.cc
@@ -45,6 +45,7 @@
 #include "r_misc.h"
 #include "rad_trig.h"
 #include "s_blit.h"
+#include "s_music.h"
 #include "s_sound.h"
 #include "script/compat/lua_compat.h"
 #include "stb_sprintf.h"
@@ -939,7 +940,9 @@ bool PlayerThink(Player *player)
     // Adjust reverb node parameters if applicable
     if (players[console_player] == player)
     {
-        if (player->map_object_->subsector_->sector->sound_reverb)
+        if (pc_speaker_mode)
+            sector_reverb = false;
+        else if (player->map_object_->subsector_->sector->sound_reverb)
         {
             sector_reverb = true;
             player->map_object_->subsector_->sector->sound_reverb->ApplyReverb(&reverb_node);

--- a/source_files/edge/s_blit.cc
+++ b/source_files/edge/s_blit.cc
@@ -118,6 +118,8 @@ void UpdateSounds(MapObject *listener, BAMAngle angle)
 {
     EDGE_ZoneScoped;
 
+    ma_sound_group_set_volume(&sfx_node, sound_effect_volume.f_ * 0.5f);
+
     listen_x = listener ? listener->x : 0;
     listen_y = listener ? listener->y : 0;
     listen_z = listener ? listener->z : 0;
@@ -136,8 +138,6 @@ void UpdateSounds(MapObject *listener, BAMAngle angle)
 
         if (chan->state_ == kChannelPlaying)
         {
-            ma_sound_set_volume(&chan->channel_sound_, sound_effect_volume.f_);
-
             if (chan->loop_)
             {
                 ma_uint64 cur_pos = 0;

--- a/source_files/edge/s_flac.cc
+++ b/source_files/edge/s_flac.cc
@@ -94,6 +94,8 @@ bool FLACPlayer::OpenMemory(uint8_t *data, int length)
         return false;
     }
 
+    ma_node_attach_output_bus(&flac_stream, 0, &music_node, 0);
+
     flac_data_ = data;
 
     // Loaded, but not playing
@@ -173,8 +175,6 @@ void FLACPlayer::Ticker()
 {
     if (status_ == kPlaying)
     {
-        ma_sound_set_volume(&flac_stream, music_volume.f_);
-
         if (pc_speaker_mode)
             Stop();
         if (ma_sound_at_end(&flac_stream)) // This should only be true if finished and not set to looping

--- a/source_files/edge/s_m4p.cc
+++ b/source_files/edge/s_m4p.cc
@@ -491,6 +491,8 @@ bool M4PPlayer::OpenMemory(const uint8_t *data, int length)
         return false;
     }
 
+    ma_node_attach_output_bus(&m4p_stream, 0, &music_node, 0);
+
     // Loaded, but not playing
     status_ = kStopped;
 
@@ -566,7 +568,6 @@ void M4PPlayer::Ticker()
 {
     if (status_ == kPlaying)
     {
-        ma_sound_set_volume(&m4p_stream, music_volume.f_);
         if (pc_speaker_mode)
             Stop();
         if (ma_sound_at_end(&m4p_stream)) // This should only be true if finished and not set to looping

--- a/source_files/edge/s_midi.cc
+++ b/source_files/edge/s_midi.cc
@@ -807,6 +807,8 @@ class MIDIPlayer : public AbstractMusicPlayer
             return false;
         }
 
+        ma_node_attach_output_bus(&midi_stream, 0, &music_node, 0);
+
         // Loaded, but not playing
         status_ = kStopped;
 
@@ -882,8 +884,6 @@ class MIDIPlayer : public AbstractMusicPlayer
     {
         if (status_ == kPlaying)
         {
-            ma_sound_set_volume(&midi_stream, music_volume.f_);
-
             if (pc_speaker_mode)
                 Stop();
             if (ma_sound_at_end(&midi_stream)) // This should only be true if finished and not set to looping

--- a/source_files/edge/s_midi_ec.cc
+++ b/source_files/edge/s_midi_ec.cc
@@ -887,6 +887,8 @@ class MIDIPlayer : public AbstractMusicPlayer
             return false;
         }
 
+        ma_node_attach_output_bus(&midi_stream, 0, &music_node, 0);
+
         // Loaded, but not playing
         status_ = kStopped;
 
@@ -969,8 +971,6 @@ class MIDIPlayer : public AbstractMusicPlayer
     {
         if (status_ == kPlaying)
         {
-            ma_sound_set_volume(&midi_stream, music_volume.f_);
-
             if (pc_speaker_mode)
                 Stop();
             if (ma_sound_at_end(&midi_stream)) // This should only be true if finished and not set to looping

--- a/source_files/edge/s_mp3.cc
+++ b/source_files/edge/s_mp3.cc
@@ -92,6 +92,8 @@ bool MP3Player::OpenMemory(const uint8_t *data, int length)
         return false;
     }
 
+    ma_node_attach_output_bus(&mp3_stream, 0, &music_node, 0);
+
     mp3_data_ = data;
 
     // Loaded, but not playing
@@ -171,8 +173,6 @@ void MP3Player::Ticker()
 {
     if (status_ == kPlaying)
     {
-        ma_sound_set_volume(&mp3_stream, music_volume.f_);
-
         if (pc_speaker_mode)
             Stop();
         if (ma_sound_at_end(&mp3_stream)) // This should only be true if finished and not set to looping

--- a/source_files/edge/s_music.cc
+++ b/source_files/edge/s_music.cc
@@ -29,6 +29,7 @@
 #include "epi_filesystem.h"
 #include "epi_str_util.h"
 #include "i_movie.h"
+#include "i_sound.h"
 #include "i_system.h"
 #include "m_misc.h"
 #include "s_flac.h"
@@ -247,6 +248,8 @@ void StopMusic(void)
 
 void MusicTicker(void)
 {
+    ma_sound_group_set_volume(&music_node, music_volume.f_);
+
     if (music_player)
         music_player->Ticker();
 }

--- a/source_files/edge/s_ogg.cc
+++ b/source_files/edge/s_ogg.cc
@@ -597,6 +597,8 @@ bool OGGPlayer::OpenMemory(const uint8_t *data, int length)
         return false;
     }
 
+    ma_node_attach_output_bus(&ogg_stream, 0, &music_node, 0);
+
     ogg_data_ = data;
 
     // Loaded, but not playing
@@ -676,8 +678,6 @@ void OGGPlayer::Ticker()
 {
     if (status_ == kPlaying)
     {
-        ma_sound_set_volume(&ogg_stream, music_volume.f_);
-
         if (pc_speaker_mode)
             Stop();
         if (ma_sound_at_end(&ogg_stream)) // This should only be true if finished and not set to looping

--- a/source_files/edge/s_sound.cc
+++ b/source_files/edge/s_sound.cc
@@ -32,6 +32,7 @@
 #include "p_local.h" // ApproximateDistance
 #include "s_blit.h"
 #include "s_cache.h"
+#include "s_music.h"
 #include "s_sound.h"
 #include "w_wad.h"
 
@@ -237,6 +238,9 @@ void ShutdownSound(void)
 
     SoundCacheClearAll();
 
+    if (!no_music)
+        ma_sound_group_uninit(&music_node);
+    ma_sound_group_uninit(&sfx_node);
     ma_engine_uninit(&sound_engine);
 }
 
@@ -291,7 +295,9 @@ static void S_PlaySound(int idx, const SoundEffectDefinition *def, int category,
         ma_sound_set_max_distance(&chan->channel_sound_,
                                   chan->boss_ ? kBossSoundClipDistance : kMaximumSoundClipDistance);
         ma_sound_set_position(&chan->channel_sound_, pos->x, pos->z, -pos->y);
-        if (vacuum_sound_effects)
+        if (pc_speaker_mode)
+            ma_node_attach_output_bus(&chan->channel_sound_, 0, &sfx_node, 0);
+        else if (vacuum_sound_effects)
             ma_node_attach_output_bus(&chan->channel_sound_, 0, &vacuum_node, 0);
         else if (submerged_sound_effects)
             ma_node_attach_output_bus(&chan->channel_sound_, 0, &underwater_node, 0);
@@ -305,12 +311,14 @@ static void S_PlaySound(int idx, const SoundEffectDefinition *def, int category,
                 ma_node_attach_output_bus(&chan->channel_sound_, 0, &reverb_node, 0);
         }
         else
-            ma_node_attach_output_bus(&chan->channel_sound_, 0, &sound_engine, 0);
+            ma_node_attach_output_bus(&chan->channel_sound_, 0, &sfx_node, 0);
     }
     else
     {
         ma_sound_set_attenuation_model(&chan->channel_sound_, ma_attenuation_model_none);
-        if (category != kCategoryUi)
+        if (pc_speaker_mode)
+            ma_node_attach_output_bus(&chan->channel_sound_, 0, &sfx_node, 0);
+        else if (category != kCategoryUi)
         {
             if (vacuum_sound_effects)
                 ma_node_attach_output_bus(&chan->channel_sound_, 0, &vacuum_node, 0);
@@ -326,10 +334,10 @@ static void S_PlaySound(int idx, const SoundEffectDefinition *def, int category,
                     ma_node_attach_output_bus(&chan->channel_sound_, 0, &reverb_node, 0);
             }
             else
-                ma_node_attach_output_bus(&chan->channel_sound_, 0, &sound_engine, 0);
+                ma_node_attach_output_bus(&chan->channel_sound_, 0, &sfx_node, 0);
         }
         else
-            ma_node_attach_output_bus(&chan->channel_sound_, 0, &sound_engine, 0);
+            ma_node_attach_output_bus(&chan->channel_sound_, 0, &sfx_node, 0);
     }
     if (chan->boss_)
         ma_sound_set_volume(&chan->channel_sound_, 1.0f);


### PR DESCRIPTION
This fixes a few issues:
- Uses miniaudio sound groups for sound/music volume split instead of setting each stream's audio independently
- Sounds will no longer be affected by underwater/vacuum/reverb filters in PC Speaker mode
- Quit response sound and associate loop on shutdown have been removed