### PR TITLE
Address more thread and address sanitizer findings

### DIFF
--- a/ASanSuppress.txt
+++ b/ASanSuppress.txt
@@ -25,7 +25,7 @@ leak:Font::CharImage
 leak:HD_draw_image
 
 # need to investigate
-leak:BspTraverseProc
+leak:BSPTraverseProc
 
 ##################################################
 # Ignore

--- a/source_files/edge/r_bsp.cc
+++ b/source_files/edge/r_bsp.cc
@@ -126,29 +126,6 @@ ViewHeightZone view_height_zone;
 
 static Subsector *bsp_current_subsector;
 
-static void UpdateSectorInterpolation(Sector *sector)
-{
-    if (!time_stop_active && !paused && !erraticism_active && !menu_active && !rts_menu_active)
-    {
-        // Interpolate between current and last floor/ceiling position.
-        if (!AlmostEquals(sector->floor_height, sector->old_floor_height))
-            sector->interpolated_floor_height =
-                HMM_Lerp(sector->old_floor_height, fractional_tic, sector->floor_height);
-        else
-            sector->interpolated_floor_height = sector->floor_height;
-        if (!AlmostEquals(sector->ceiling_height, sector->old_ceiling_height))
-            sector->interpolated_ceiling_height =
-                HMM_Lerp(sector->old_ceiling_height, fractional_tic, sector->ceiling_height);
-        else
-            sector->interpolated_ceiling_height = sector->ceiling_height;
-    }
-    else
-    {
-        sector->interpolated_floor_height   = sector->floor_height;
-        sector->interpolated_ceiling_height = sector->ceiling_height;
-    }
-}
-
 static void BSPWalkMirror(DrawSubsector *dsub, Seg *seg, BAMAngle left, BAMAngle right, bool is_portal)
 {
     DrawMirror *mir = GetDrawMirror();
@@ -175,7 +152,7 @@ static void BSPWalkMirror(DrawSubsector *dsub, Seg *seg, BAMAngle left, BAMAngle
     clip_scope = left - right;
 
     // perform another BSP walk
-    BspWalkNode(root_node);
+    BSPWalkNode(root_node);
 
     bsp_current_subsector = save_sub;
 
@@ -352,9 +329,6 @@ static void BSPWalkSeg(DrawSubsector *dsub, Seg *seg)
 
     if (seg->linedef->blocked)
         OcclusionSet(angle_R, angle_L);
-
-    if (bsector)
-        UpdateSectorInterpolation(bsector);
 
     // --- handle sky (using the depth buffer) ---
     float             f_fh    = 0;
@@ -694,8 +668,6 @@ static void BSPWalkSubsector(int num)
     K->segs.clear();
     K->mirrors.clear();
 
-    UpdateSectorInterpolation(sector);
-
     // --- handle sky (using the depth buffer) ---
 
     if (!sector->height_sector)
@@ -906,7 +878,7 @@ static void BSPWalkSubsector(int num)
 // Walks all subsectors below a given node, traversing subtree
 // recursively, collecting information.  Just call with BSP root.
 //
-void BspWalkNode(unsigned int bspnum)
+void BSPWalkNode(unsigned int bspnum)
 {
     EDGE_ZoneScoped;
 
@@ -951,18 +923,18 @@ void BspWalkNode(unsigned int bspnum)
 
     // Recursively divide front space.
     if (BSPCheckBBox(node->bounding_boxes[side]))
-        BspWalkNode(node->children[side]);
+        BSPWalkNode(node->children[side]);
 
     // Recursively divide back space.
     if (BSPCheckBBox(node->bounding_boxes[side ^ 1]))
-        BspWalkNode(node->children[side ^ 1]);
+        BSPWalkNode(node->children[side ^ 1]);
 }
 
 #ifdef EDGE_SOKOL
 
 #ifdef BSP_MULTITHREAD
 
-static int32_t BspTraverseProc(void *thread_data)
+static int32_t BSPTraverseProc(void *thread_data)
 {
     EPI_UNUSED(thread_data);
 
@@ -978,7 +950,7 @@ static int32_t BspTraverseProc(void *thread_data)
             current_batch = nullptr;
 
             // walk the bsp tree
-            BspWalkNode(root_node);
+            BSPWalkNode(root_node);
 
             if (current_batch && current_batch->num_items_)
             {
@@ -1087,7 +1059,7 @@ void BSPStartThread()
     thread_atomic_int_store(&bsp_thread.traverse_finished_, 1);
     thread_signal_init(&bsp_thread.signal_start_);
     thread_queue_init(&bsp_thread.queue_, kMaxRenderBatch, (void **)bsp_thread.render_queue_, 0);
-    bsp_thread.thread_ = thread_create(BspTraverseProc, nullptr, THREAD_STACK_SIZE_DEFAULT);
+    bsp_thread.thread_ = thread_create(BSPTraverseProc, nullptr, THREAD_STACK_SIZE_DEFAULT);
 }
 void BSPStopThread()
 {

--- a/source_files/edge/r_defs.h
+++ b/source_files/edge/r_defs.h
@@ -30,6 +30,10 @@
 #include "m_math.h"
 #include "p_mobj.h"
 
+#if defined (EDGE_SOKOL) && !defined (EDGE_WEB)
+#include "thread.h"
+#endif
+
 class Image;
 
 //

--- a/source_files/edge/r_mirror.cc
+++ b/source_files/edge/r_mirror.cc
@@ -129,8 +129,9 @@ static void DrawPortalPolygon(DrawMirror *mir)
 
 void RenderMirror(DrawMirror *mir)
 {
-    // mark the segment on the automap
-    mir->seg->linedef->flags |= kLineFlagMapped;
+    // mark the line on the automap
+    if (!(mir->seg->linedef->flags & kLineFlagMapped))
+        newly_seen_lines.emplace(mir->seg->linedef);
 
     FinishUnitBatch();
 

--- a/source_files/edge/r_misc.cc
+++ b/source_files/edge/r_misc.cc
@@ -47,6 +47,7 @@
 #include "r_draw.h"
 #include "r_gldefs.h"
 #include "r_modes.h"
+#include "r_shader.h"
 #include "r_units.h"
 
 EDGE_DEFINE_CONSOLE_VARIABLE(field_of_view, "90", kConsoleVariableFlagArchive)
@@ -204,6 +205,7 @@ void RendererShutdown(void)
 {
     FreeBSP();
     DeleteAllImages();
+    DeleteAllLightImages();
 }
 
 Subsector *PointInSubsector(float x, float y)

--- a/source_files/edge/r_render.h
+++ b/source_files/edge/r_render.h
@@ -4,9 +4,11 @@
 #include "r_image.h"
 #include "r_units.h"
 
+extern std::unordered_set<Line *> newly_seen_lines;
+
 void RenderSubList(std::list<DrawSubsector *> &dsubs, bool for_mirror = false);
 
-void BspWalkNode(unsigned int);
+void BSPWalkNode(unsigned int);
 
 #ifdef EDGE_SOKOL
 

--- a/source_files/edge/r_shader.cc
+++ b/source_files/edge/r_shader.cc
@@ -18,8 +18,11 @@
 
 #include "r_shader.h"
 
+#include <unordered_map>
+
 #include "ddf_main.h"
 #include "epi.h"
+#include "epi_str_hash.h"
 #include "i_defs_gl.h"
 #include "im_data.h"
 #include "p_mobj.h"
@@ -48,7 +51,7 @@ class LightImage
     RGBAColor curve_[kLightImageCurveSize];
 
   public:
-    LightImage(const char *name, const Image *img) : name_(name), image_(img)
+    LightImage(std::string_view name, const Image *img) : name_(name), image_(img)
     {
     }
 
@@ -113,6 +116,8 @@ class LightImage
     }
 };
 
+static std::unordered_map<epi::StringHash, LightImage *> known_light_images;
+
 static LightImage *GetLightImage(const MapObjectDefinition *info)
 {
     // Intentional Const Overrides
@@ -120,22 +125,29 @@ static LightImage *GetLightImage(const MapObjectDefinition *info)
 
     if (!D_info->cache_data_)
     {
-        // FIXME !!!! share light_image_c instances
+        const std::string &shape = D_info->shape_;
 
-        const char *shape = D_info->shape_.c_str();
+        EPI_ASSERT(!shape.empty());
 
-        EPI_ASSERT(shape && strlen(shape) > 0);
+        if (known_light_images.count(shape))
+        {
+            D_info->cache_data_ = known_light_images[shape];
+        }
+        else
+        {
+            const Image *image = ImageLookup(shape.c_str(), kImageNamespaceGraphic, kImageLookupNull);
 
-        const Image *image = ImageLookup(shape, kImageNamespaceGraphic, kImageLookupNull);
+            if (!image)
+                FatalError("Missing dynamic light graphic: %s\n", shape.c_str());
 
-        if (!image)
-            FatalError("Missing dynamic light graphic: %s\n", shape);
+            LightImage *lim = new LightImage(shape, image);
 
-        LightImage *lim = new LightImage(shape, image);
+            lim->MakeStandardCurve();
 
-        lim->MakeStandardCurve();
+            known_light_images.try_emplace(shape, lim);
 
-        D_info->cache_data_ = lim;
+            D_info->cache_data_ = lim;
+        }
     }
 
     return (LightImage *)D_info->cache_data_;
@@ -687,6 +699,16 @@ class wall_glow_c : public AbstractShader
 AbstractShader *MakeWallGlow(MapObject *mo)
 {
     return new wall_glow_c(mo);
+}
+
+void DeleteAllLightImages()
+{
+    for (std::unordered_map<epi::StringHash, LightImage *>::iterator iter = known_light_images.begin(), iter_end = known_light_images.end();
+    iter != iter_end; ++iter)
+    {
+        delete iter->second; 
+    }
+    known_light_images.clear();
 }
 
 //--- editor settings ---

--- a/source_files/edge/r_shader.h
+++ b/source_files/edge/r_shader.h
@@ -110,5 +110,9 @@ class AbstractShader
                           bool masked, void *data, ShaderCoordinateFunction func) = 0;
 };
 
+// Delete all dynamic light "images"; cannot be done in the various shader
+// destructors as these images are shared amongst multiple instances - Dasho
+void DeleteAllLightImages();
+
 //--- editor settings ---
 // vi:ts=4:sw=4:noexpandtab


### PR DESCRIPTION
This takes care of some more race conditions and leaks:
- Moves UpdateSectorInterpolation out of BSP traversal and only runs it against actively moving planes
- Moves marking of seen lines (for automap purposes) until after world rendering is finished for the frame
- Clean up LightImages created for dynamic lights/glows