### PR TITLE
More leak/data race fixes

### DIFF
--- a/ASanSuppress.txt
+++ b/ASanSuppress.txt
@@ -17,15 +17,9 @@
 # ignore anything cached images, though should be investigated
 leak:ImageCacheOGL
 
-# should be once per font, needs investigation
+# cached per font, lifetime should be process
 leak:Font::LoadFontTTF
 leak:Font::LoadPatches
-leak:Font::CharImage
-# assuming cached, should be investigated
-leak:HD_draw_image
-
-# need to investigate
-leak:BSPTraverseProc
 
 ##################################################
 # Ignore
@@ -33,3 +27,6 @@ leak:BSPTraverseProc
 
 # anything that leaks in E_Startup, assuming lifetime is process
 leak:EdgeStartup
+
+# Unix: Can't do anything about SDL internal leaks
+leak:SDL.c

--- a/source_files/edge/am_map.cc
+++ b/source_files/edge/am_map.cc
@@ -206,7 +206,7 @@ static std::vector<AutomapLine *> map_line_pointers[4];
 static AutomapLine *GetMapLine()
 {
     if (automap_line_position == automap_lines.size())
-        automap_lines.push_back(new (malloc(sizeof(AutomapLine))) AutomapLine());
+        automap_lines.push_back(new AutomapLine());
 
     return automap_lines[automap_line_position++];
 }

--- a/source_files/edge/i_movie.cc
+++ b/source_files/edge/i_movie.cc
@@ -84,7 +84,7 @@ static bool MovieSetupAudioStream(int rate)
     ma_sound_set_looping(&movie_sound_buffer, MA_TRUE);
     ma_sound_start(&movie_sound_buffer);
     PauseMusic();
-    ma_sound_set_volume(&movie_sound_buffer, music_volume.f_);
+    ma_sound_group_set_volume(&music_node, music_volume.f_);
     return true;
 }
 

--- a/source_files/edge/r_misc.cc
+++ b/source_files/edge/r_misc.cc
@@ -380,42 +380,53 @@ void ClearBSP(void)
 
 void FreeBSP(void)
 {
-    if (draw_memory_buffer)
+    for (size_t i = 0; i < kDefaultDrawThings; i++)
     {
-        free(draw_memory_buffer);
-        draw_memory_buffer = nullptr;
+        draw_things[i]->~DrawThing();
     }
-
-    // Free any dynamically allocated structures
-
     for (size_t i = kDefaultDrawThings; i < draw_things.size(); i++)
     {
-        free(draw_things[i]);
+        delete draw_things[i];
     }
-
+    for (size_t i = 0; i < kDefaultDrawFloors; i++)
+    {
+        draw_floors[i]->~DrawFloor();
+    }
     for (size_t i = kDefaultDrawFloors; i < draw_floors.size(); i++)
     {
-        free(draw_floors[i]);
+        delete draw_floors[i];
     }
-
+    for (size_t i = 0; i < kDefaultDrawSegs; i++)
+    {
+        draw_segs[i]->~DrawSeg();
+    }
     for (size_t i = kDefaultDrawSegs; i < draw_segs.size(); i++)
     {
-        free(draw_segs[i]);
+        delete draw_segs[i];
     }
-
+    for (size_t i = 0; i < kDefaultDrawSubsectors; i++)
+    {
+        draw_subsectors[i]->~DrawSubsector();
+    }
     for (size_t i = kDefaultDrawSubsectors; i < draw_subsectors.size(); i++)
     {
-        free(draw_subsectors[i]);
+        delete draw_subsectors[i];
     }
-
+    for (size_t i = 0; i < kDefaultDrawMirrors; i++)
+    {
+        draw_mirrors[i]->~DrawMirror();
+    }
     for (size_t i = kDefaultDrawMirrors; i < draw_mirrors.size(); i++)
     {
-        free(draw_mirrors[i]);
+        delete draw_mirrors[i];
     }
-
+    for (size_t i = 0; i < kDefaultAutomapLines; i++)
+    {
+        automap_lines[i]->~AutomapLine();
+    }
     for (size_t i = kDefaultAutomapLines; i < automap_lines.size(); i++)
     {
-        free(automap_lines[i]);
+        delete automap_lines[i];
     }
 
     draw_things.clear();
@@ -426,12 +437,18 @@ void FreeBSP(void)
     automap_lines.clear();
 
     ClearBSP();
+
+    if (draw_memory_buffer)
+    {
+        free(draw_memory_buffer);
+        draw_memory_buffer = nullptr;
+    }
 }
 
 DrawThing *GetDrawThing()
 {
     if (draw_thing_position == draw_things.size())
-        draw_things.push_back(new (malloc(sizeof(DrawThing))) DrawThing());
+        draw_things.push_back(new DrawThing());
 
     return draw_things[draw_thing_position++];
 }
@@ -439,7 +456,7 @@ DrawThing *GetDrawThing()
 DrawFloor *GetDrawFloor()
 {
     if (draw_floor_position == draw_floors.size())
-        draw_floors.push_back(new (malloc(sizeof(DrawFloor))) DrawFloor());
+        draw_floors.push_back(new DrawFloor());
 
     return draw_floors[draw_floor_position++];
 }
@@ -447,7 +464,7 @@ DrawFloor *GetDrawFloor()
 DrawSeg *GetDrawSeg()
 {
     if (draw_seg_position == draw_segs.size())
-        draw_segs.push_back(new (malloc(sizeof(DrawSeg))) DrawSeg());
+        draw_segs.push_back(new DrawSeg());
 
     return draw_segs[draw_seg_position++];
 }
@@ -455,7 +472,7 @@ DrawSeg *GetDrawSeg()
 DrawSubsector *GetDrawSub()
 {
     if (draw_subsector_position == draw_subsectors.size())
-        draw_subsectors.push_back(new (malloc(sizeof(DrawSubsector))) DrawSubsector());
+        draw_subsectors.push_back(new DrawSubsector());
 
     return draw_subsectors[draw_subsector_position++];
 }
@@ -463,7 +480,7 @@ DrawSubsector *GetDrawSub()
 DrawMirror *GetDrawMirror()
 {
     if (draw_mirror_position == draw_mirrors.size())
-        draw_mirrors.push_back(new (malloc(sizeof(DrawMirror))) DrawMirror());
+        draw_mirrors.push_back(new DrawMirror());
 
     return draw_mirrors[draw_mirror_position++];
 }

--- a/source_files/edge/s_blit.cc
+++ b/source_files/edge/s_blit.cc
@@ -107,7 +107,6 @@ void KillSoundChannel(int k)
     {
         chan->data_  = nullptr;
         chan->state_ = kChannelEmpty;
-        ma_sound_set_volume(&chan->channel_sound_, 0);
         ma_sound_stop(&chan->channel_sound_);
         ma_sound_uninit(&chan->channel_sound_);
         ma_audio_buffer_uninit(&chan->ref_);

--- a/source_files/edge/s_flac.cc
+++ b/source_files/edge/s_flac.cc
@@ -165,7 +165,6 @@ void FLACPlayer::Stop()
     if (status_ != kPlaying && status_ != kPaused)
         return;
 
-    ma_sound_set_volume(&flac_stream, 0);
     ma_sound_stop(&flac_stream);
 
     status_ = kStopped;

--- a/source_files/edge/s_m4p.cc
+++ b/source_files/edge/s_m4p.cc
@@ -558,7 +558,6 @@ void M4PPlayer::Stop()
     if (status_ != kPlaying && status_ != kPaused)
         return;
 
-    ma_sound_set_volume(&m4p_stream, 0);
     ma_sound_stop(&m4p_stream);
 
     status_ = kStopped;

--- a/source_files/edge/s_midi.cc
+++ b/source_files/edge/s_midi.cc
@@ -853,7 +853,6 @@ class MIDIPlayer : public AbstractMusicPlayer
         if (status_ != kPlaying && status_ != kPaused)
             return;
 
-        ma_sound_set_volume(&midi_stream, 0);
         ma_sound_stop(&midi_stream);
 
         status_ = kStopped;
@@ -865,7 +864,6 @@ class MIDIPlayer : public AbstractMusicPlayer
             return;
 
         ma_sound_stop(&midi_stream);
-        fluid_synth_all_voices_pause(edge_fluid);
 
         status_ = kPaused;
     }

--- a/source_files/edge/s_midi_ec.cc
+++ b/source_files/edge/s_midi_ec.cc
@@ -936,7 +936,6 @@ class MIDIPlayer : public AbstractMusicPlayer
         if (status_ != kPlaying && status_ != kPaused)
             return;
 
-        ma_sound_set_volume(&midi_stream, 0);
         ma_sound_stop(&midi_stream);
 
         // reset imf_rate in case tracks are switched to another format
@@ -951,8 +950,6 @@ class MIDIPlayer : public AbstractMusicPlayer
             return;
 
         ma_sound_stop(&midi_stream);
-        if (!opl_playback)
-            fluid_synth_all_voices_pause(edge_fluid);
 
         status_ = kPaused;
     }

--- a/source_files/edge/s_mp3.cc
+++ b/source_files/edge/s_mp3.cc
@@ -163,7 +163,6 @@ void MP3Player::Stop()
     if (status_ != kPlaying && status_ != kPaused)
         return;
 
-    ma_sound_set_volume(&mp3_stream, 0);
     ma_sound_stop(&mp3_stream);
 
     status_ = kStopped;

--- a/source_files/edge/s_ogg.cc
+++ b/source_files/edge/s_ogg.cc
@@ -668,7 +668,6 @@ void OGGPlayer::Stop()
     if (status_ != kPlaying && status_ != kPaused)
         return;
 
-    ma_sound_set_volume(&ogg_stream, 0);
     ma_sound_stop(&ogg_stream);
 
     status_ = kStopped;


### PR DESCRIPTION
Tracking down more TSAN/ASAN issues:
- Removed direct manipulating of Fluidlite state when pausing the game
- Fixed cleanup of various draw structures
- Removed unneeded adjustment of per-sound volume when ending sounds/songs