### PR TITLE
Model rendering fixes

### DIFF
--- a/source_files/edge/render/gl/gl_md2.cc
+++ b/source_files/edge/render/gl/gl_md2.cc
@@ -890,7 +890,7 @@ static void ShadeNormals(AbstractShader *shader, MD2CoordinateData *data, bool s
     }
 }
 
-static void DLIT_Model(MapObject *mo, void *dataptr)
+static void MD2DynamicLightCallback(MapObject *mo, void *dataptr)
 {
     MD2CoordinateData *data = (MD2CoordinateData *)dataptr;
 
@@ -1128,11 +1128,11 @@ void MD2RenderModel(MD2Model *md, const Image *skin_img, bool is_weapon, int fra
         {
             float r = mo->radius_;
 
-            DynamicLightIterator(mo->x - r, mo->y - r, mo->z, mo->x + r, mo->y + r, mo->z + mo->height_, DLIT_Model,
-                                 &data);
+            DynamicLightIterator(mo->x - r, mo->y - r, mo->z, mo->x + r, mo->y + r, mo->z + mo->height_,
+                                 MD2DynamicLightCallback, &data);
 
             SectorGlowIterator(mo->subsector_->sector, mo->x - r, mo->y - r, mo->z, mo->x + r, mo->y + r,
-                               mo->z + mo->height_, DLIT_Model, &data);
+                               mo->z + mo->height_, MD2DynamicLightCallback, &data);
         }
     }
 

--- a/source_files/edge/render/sokol/sokol_mdl.cc
+++ b/source_files/edge/render/sokol/sokol_mdl.cc
@@ -172,13 +172,6 @@ struct MDLPoint
     int vert_idx;
 };
 
-struct MDLTriangle
-{
-    // index to the first point (within MDLModel::points).
-    // All points for the strip are contiguous in that array.
-    int first;
-};
-
 class MDLModel
 {
   public:
@@ -188,9 +181,9 @@ class MDLModel
     int skin_width_;
     int skin_height_;
 
-    MDLFrame    *frames_;
-    MDLPoint    *points_;
-    MDLTriangle *triangles_;
+    MDLFrame *frames_;
+    MDLPoint *points_;
+    int      *triangle_indices_;
 
     int vertices_per_frame_;
 
@@ -201,16 +194,16 @@ class MDLModel
         : total_frames_(nframes), total_points_(npoints), total_triangles_(ntris), skin_width_(swidth),
           skin_height_(sheight), vertices_per_frame_(0)
     {
-        frames_    = new MDLFrame[total_frames_];
-        points_    = new MDLPoint[total_points_];
-        triangles_ = new MDLTriangle[total_triangles_];
+        frames_           = new MDLFrame[total_frames_];
+        points_           = new MDLPoint[total_points_];
+        triangle_indices_ = new int[total_triangles_];
     }
 
     ~MDLModel()
     {
         delete[] frames_;
         delete[] points_;
-        delete[] triangles_;
+        delete[] triangle_indices_;
     }
 };
 
@@ -340,20 +333,20 @@ MDLModel *MDLLoad(epi::File *f, float &radius)
 
     LogDebug("  frames:%d  points:%d  tris: %d\n", num_frames, num_points, num_tris);
 
-    md->vertices_per_frame_ = num_verts;
+    md->vertices_per_frame_ = num_points;
 
     LogDebug("  vertices_per_frame_:%d\n", md->vertices_per_frame_);
 
     // convert glcmds into tris and points
-    MDLTriangle *tri   = md->triangles_;
-    MDLPoint    *point = md->points_;
+    int      *tri   = md->triangle_indices_;
+    MDLPoint *point = md->points_;
 
     for (int i = 0; i < num_tris; i++)
     {
-        EPI_ASSERT(tri < md->triangles_ + md->total_triangles_);
+        EPI_ASSERT(tri < md->triangle_indices_ + md->total_triangles_);
         EPI_ASSERT(point < md->points_ + md->total_points_);
 
-        tri->first = point - md->points_;
+        *tri = point - md->points_;
 
         tri++;
 
@@ -373,7 +366,7 @@ MDLModel *MDLLoad(epi::File *f, float &radius)
         }
     }
 
-    EPI_ASSERT(tri == md->triangles_ + md->total_triangles_);
+    EPI_ASSERT(tri == md->triangle_indices_ + md->total_triangles_);
     EPI_ASSERT(point == md->points_ + md->total_points_);
 
     /* PARSE FRAMES */
@@ -479,9 +472,9 @@ class MDLCoordinateData
 
     MDLModel *model_;
 
-    const MDLFrame    *frame1_;
-    const MDLFrame    *frame2_;
-    const MDLTriangle *strip_;
+    const MDLFrame *frame1_;
+    const MDLFrame *frame2_;
+    const int      *triangle_indices_;
 
     float lerp_;
     float x_, y_, z_;
@@ -622,14 +615,14 @@ static inline void ModelCoordFunc(MDLCoordinateData *data, int v_idx)
 {
     const MDLModel *md = data->model_;
 
-    const MDLFrame    *frame1 = data->frame1_;
-    const MDLFrame    *frame2 = data->frame2_;
-    const MDLTriangle *strip  = data->strip_;
+    const MDLFrame *frame1 = data->frame1_;
+    const MDLFrame *frame2 = data->frame2_;
+    const int      *tri    = data->triangle_indices_;
 
-    EPI_ASSERT(strip->first + v_idx >= 0);
-    EPI_ASSERT(strip->first + v_idx < md->total_points_);
+    EPI_ASSERT(*tri + v_idx >= 0);
+    EPI_ASSERT(*tri + v_idx < md->total_points_);
 
-    const MDLPoint *point = &md->points_[strip->first + v_idx];
+    const MDLPoint *point = &md->points_[*tri + v_idx];
 
     const MDLVertex *vert1 = &frame1->vertices[point->vert_idx];
     const MDLVertex *vert2 = &frame2->vertices[point->vert_idx];
@@ -684,8 +677,6 @@ void MDLRenderModel(MDLModel *md, bool is_weapon, int frame1, int frame2, float 
         LogDebug("Render model: bad frame %d\n", frame1);
         return;
     }
-
-    render_backend->Flush(1, md->total_triangles_ * 3);
 
     MDLCoordinateData data;
 
@@ -827,7 +818,7 @@ void MDLRenderModel(MDLModel *md, bool is_weapon, int frame1, int frame2, float 
 
     /* draw the model */
 
-    int num_pass = 1; // data.is_fuzzy_ ? 1 : (detail_level > 0 ? 4 : 3);
+    int num_pass = data.is_fuzzy_ ? 1 : (detail_level > 0 ? 4 : 3);
 
     RGBAColor fc_to_use = mo->subsector_->sector->properties.fog_color;
     float     fd_to_use = mo->subsector_->sector->properties.fog_density;
@@ -894,6 +885,8 @@ void MDLRenderModel(MDLModel *md, bool is_weapon, int frame1, int frame2, float 
 
     for (int pass = 0; pass < num_pass; pass++)
     {
+        render_backend->Flush(1, md->total_triangles_ * 3);
+
         if (pass == 1)
         {
             blending = (BlendingMode)(blending & ~kBlendingAlpha);
@@ -1008,7 +1001,7 @@ void MDLRenderModel(MDLModel *md, bool is_weapon, int frame1, int frame2, float 
 
         for (int i = 0; i < md->total_triangles_; i++)
         {
-            data.strip_ = &md->triangles_[i];
+            data.triangle_indices_ = &md->triangle_indices_[i];
 
             for (int v_idx = 0; v_idx < 3; v_idx++)
             {
@@ -1036,13 +1029,11 @@ void MDLRenderModel(MDLModel *md, bool is_weapon, int frame1, int frame2, float 
 void MDLRenderModel2D(MDLModel *md, int frame, float x, float y, float xscale, float yscale,
                       const MapObjectDefinition *info)
 {
-    // Review these after this function is updated
-    EPI_UNUSED(x);
-    EPI_UNUSED(y);
-    EPI_UNUSED(xscale);
     // check if frame is valid
     if (frame < 0 || frame >= md->total_frames_)
         return;
+
+    render_backend->Flush(1, md->total_triangles_ * 3);
 
     GLuint skin_tex = md->skin_id_list_[0]; // Just use skin 0?
 
@@ -1058,41 +1049,49 @@ void MDLRenderModel2D(MDLModel *md, int frame, float x, float y, float xscale, f
     render_state->Enable(GL_BLEND);
     render_state->Enable(GL_CULL_FACE);
 
-    if (info->flags_ & kMapObjectFlagFuzzy)
-        render_state->GLColor(epi::MakeRGBA(0, 0, 0, 128));
-    else
-        render_state->GLColor(kRGBAWhite);
+    RGBAColor color = (info->flags_ & kMapObjectFlagFuzzy) ? epi::MakeRGBA(0, 0, 0, 128) : kRGBAWhite;
+
+    sgl_enable_texture();
+    sg_image img;
+    img.id = skin_tex;
+
+    sg_sampler img_sampler;
+    GetImageSampler(skin_tex, &img_sampler.id);
+
+    sgl_texture(img, img_sampler);
+
+    uint32_t pipeline_flags = 0;
+    pipeline_flags |= kPipelineDepthWrite;
+
+    render_state->SetPipeline(pipeline_flags);
+
+    sgl_begin_triangles();
 
     for (int i = 0; i < md->total_triangles_; i++)
     {
-        /*
-        const MDLTriangle *strip = &md->triangles_[i];
-
-        //glBegin(GL_TRIANGLES);
+        const int *tri = &md->triangle_indices_[i];
 
         for (int v_idx = 0; v_idx < 3; v_idx++)
         {
             const MDLFrame *frame_ptr = &md->frames_[frame];
 
-            EPI_ASSERT(strip->first + v_idx >= 0);
-            EPI_ASSERT(strip->first + v_idx < md->total_points_);
+            EPI_ASSERT(*tri + v_idx >= 0);
+            EPI_ASSERT(*tri + v_idx < md->total_points_);
 
-            const MDLPoint  *point = &md->points_[strip->first + v_idx];
+            const MDLPoint  *point = &md->points_[*tri + v_idx];
             const MDLVertex *vert  = &frame_ptr->vertices[point->vert_idx];
-            const HMM_Vec2   texc  = { point->skin_s, point->skin_t };
-
-            render_state->MultiTexCoord(GL_TEXTURE0, &texc);
+            const HMM_Vec2   texc  = {{point->skin_s, point->skin_t}};
 
             float dx = vert->x * xscale;
             float dy = vert->y * xscale;
             float dz = (vert->z + info->model_bias_) * yscale;
 
-            //glVertex3f(x + dy, y + dz, dx / 256.0f);
+            sgl_v3f_t2f_c4b(x + dy, y + dz, dx / 256.0f, texc.U, texc.V, epi::GetRGBARed(color),
+                            epi::GetRGBAGreen(color), epi::GetRGBABlue(color), epi::GetRGBAAlpha(color));
         }
-
-       // glEnd();
-       */
     }
+
+    sgl_end();
 
     render_state->Disable(GL_BLEND);
     render_state->Disable(GL_TEXTURE_2D);


### PR DESCRIPTION
This fixes some issues with Sokol and model rendering:
- All supported models are now loaded as batches of triangles, eliminating the GL command behavior previously used to handle MD2s (legacy GL renderer still uses these). This will allow draw command merging and prevent issues with batching/flushing.
- Restored dynamic light passes for models as well as the "2D" MDL drawing function (for drawing models during the finale sequence)