### PR TITLE
Revert Font StringWidth method to use const char * again

### DIFF
--- a/source_files/edge/hu_font.cc
+++ b/source_files/edge/hu_font.cc
@@ -677,31 +677,35 @@ float TTFFont::GetYShift()
 // Find string width from hu_font chars.  The string may not contain
 // any newline characters.
 //
-float ImageFont::StringWidth(std::string_view str)
+float ImageFont::StringWidth(const char *str)
 {
     float w = 0;
 
-    if (str.empty())
+    if (!str)
         return w;
 
-    for (size_t i = 0; i < str.size(); i++)
+    std::string_view width_check(str);
+
+    for (size_t i = 0; i < width_check.size(); i++)
     {
-        w += CharWidth(str[i]);
+        w += CharWidth(width_check[i]);
     }
 
     return w;
 }
 
-float PatchFont::StringWidth(std::string_view str)
+float PatchFont::StringWidth(const char *str)
 {
     float w = 0;
 
-    if (str.empty())
+    if (!str)
         return w;
 
-    for (size_t i = 0; i < str.size(); i++)
+    std::string_view width_check(str);
+
+    for (size_t i = 0; i < width_check.size(); i++)
     {
-        w += CharWidth(str[i]);
+        w += CharWidth(width_check[i]);
     }
 
     return w;
@@ -721,18 +725,21 @@ float PatchFont::GetCharYOffset(char ch)
     return patch_font_cache_.atlas_rectangles[ch].offset_y;
 }
 
-float TTFFont::StringWidth(std::string_view str)
+float TTFFont::StringWidth(const char *str)
 {
     float w = 0;
 
-    if (str.empty())
+    if (!str)
         return w;
 
-    for (size_t i = 0; i < str.size(); i++)
+    std::string_view width_check(str);
+
+    for (size_t i = 0; i < width_check.size(); i++)
     {
-        w += CharWidth(str[i]);
-        if (i + 1 < str.size())
-            w += stbtt_GetGlyphKernAdvance(truetype_info_, GetGlyphIndex(str[i]), GetGlyphIndex(str[i + 1])) *
+        w += CharWidth(width_check[i]);
+        if (i + 1 < width_check.size())
+            w += stbtt_GetGlyphKernAdvance(truetype_info_, GetGlyphIndex(width_check[i]),
+                                           GetGlyphIndex(width_check[i + 1])) *
                  truetype_kerning_scale_[current_font_size];
     }
 

--- a/source_files/edge/hu_font.h
+++ b/source_files/edge/hu_font.h
@@ -70,10 +70,10 @@ class Font
     virtual float NominalWidth() const  = 0;
     virtual float NominalHeight() const = 0;
 
-    virtual float CharRatio(char ch)                = 0;
-    virtual float CharWidth(char ch)                = 0;
-    virtual float StringWidth(std::string_view str) = 0;
-    virtual float GetYShift()                       = 0;
+    virtual float CharRatio(char ch)           = 0;
+    virtual float CharWidth(char ch)           = 0;
+    virtual float StringWidth(const char *str) = 0;
+    virtual float GetYShift()                  = 0;
 
     virtual bool HasChar(char ch) const = 0;
 };
@@ -89,7 +89,7 @@ class ImageFont final : public Font
 
     float CharRatio(char ch) override;
     float CharWidth(char ch) override;
-    float StringWidth(std::string_view str) override;
+    float StringWidth(const char *str) override;
     float GetYShift() override
     {
         return 0;
@@ -127,7 +127,7 @@ class PatchFont final : public Font
         return 0;
     };
     float CharWidth(char ch) override;
-    float StringWidth(std::string_view str) override;
+    float StringWidth(const char *str) override;
     float GetYShift() override
     {
         return 0;
@@ -159,7 +159,7 @@ class TTFFont final : public Font
         return 0;
     };
     float CharWidth(char ch) override;
-    float StringWidth(std::string_view str) override;
+    float StringWidth(const char *str) override;
     int   GetGlyphIndex(char ch);
     float GetYShift() override;
 


### PR DESCRIPTION
Was having issues passing a potentially null pointer to construct a string_view with 