### PR TITLE
Update active plane mover destinations when recomputing gaps

### DIFF
--- a/source_files/edge/p_map.cc
+++ b/source_files/edge/p_map.cc
@@ -2910,26 +2910,36 @@ bool CheckSolidSectorMove(Sector *sec, bool is_ceiling, float dh)
     // first check real sector
     //
 
-    if (is_ceiling && dh < 0 && sec->top_extrafloor && (sec->ceiling_height - dh < sec->top_extrafloor->top_height))
+    if (sec->top_extrafloor)
     {
-        return false;
-    }
-
-    if (!is_ceiling && dh > 0 && sec->bottom_extrafloor &&
-        (sec->floor_height + dh > sec->bottom_extrafloor->bottom_height))
-    {
-        return false;
-    }
-
-    if (is_ceiling)
-    {
-        if (sec->ceiling_move && dh < 0 && sec->ceiling_height <= sec->floor_height)
-            sec->ceiling_move->destination_height = sec->floor_height - dh;
+        if (is_ceiling && dh < 0 && (sec->ceiling_height - dh < sec->top_extrafloor->top_height))
+        {
+            return false;
+        }
     }
     else
     {
-        if (sec->floor_move && dh > 0 && sec->floor_height >= sec->ceiling_height)
-            sec->floor_move->destination_height = sec->ceiling_height - dh;
+        if (is_ceiling && dh < 0 && (sec->ceiling_height - dh < sec->floor_height))
+        {
+            return false;
+        }
+    }
+
+    if (sec->bottom_extrafloor)
+    {
+        if (!is_ceiling && dh > 0 &&
+            (sec->floor_height + dh > sec->bottom_extrafloor->bottom_height))
+        {
+            return false;
+        }
+    }
+    else
+    {
+        if (!is_ceiling && dh > 0 &&
+            (sec->floor_height + dh > sec->ceiling_height))
+        {
+            return false;
+        }
     }
 
     // don't allow a dummy sector to go FUBAR

--- a/source_files/edge/p_maputl.cc
+++ b/source_files/edge/p_maputl.cc
@@ -49,6 +49,7 @@
 #include "r_state.h"
 
 extern unsigned int root_node;
+extern std::vector<PlaneMover *>       active_planes;
 
 //
 // ApproximateDistance
@@ -941,6 +942,53 @@ void RecomputeGapsAroundSector(Sector *sec)
     }
 
     sec->sight_gap_number = GapSightConstruct(sec->sight_gaps, sec);
+
+    // Dasho - Update plane mover destinations if necessary
+
+    for (PlaneMover *pl : active_planes)
+    {
+        if (!pl || !pl->sector || pl->sector != sec)
+            continue;
+
+        if (pl->model && pl->model == sec)
+        {
+            if ((pl->type->destref_ & kTriggerHeightReferenceMask) == kTriggerHeightReferenceTriggeringLinedef)
+            {
+                if (pl->type->destref_ & kTriggerHeightReferenceCeiling)
+                    pl->destination_height = sec->ceiling_height;
+                else
+                    pl->destination_height = sec->floor_height;
+            }
+        }
+        else if (pl->sector && pl->sector == sec)
+        {
+            TriggerHeightReference ref = pl->type->destref_;
+
+            switch (ref & kTriggerHeightReferenceMask)
+            {
+                case kTriggerHeightReferenceCurrent:
+                {
+                    if ((ref & kTriggerHeightReferenceCeiling) && !pl->is_ceiling)
+                        pl->destination_height = sec->ceiling_height;
+                    else if (!(ref & kTriggerHeightReferenceCeiling) && pl->is_ceiling)
+                        pl->destination_height = sec->floor_height;
+                    break;
+                }
+
+                case kTriggerHeightReferenceSurrounding:
+                    pl->destination_height = FindSurroundingHeight(ref, sec);
+                    break;
+
+                case kTriggerHeightReferenceLowestLowTexture:
+                    pl->destination_height = FindRaiseToTexture(sec);
+                    break;
+
+                case kTriggerHeightReferenceAbsolute:
+                default:
+                    break;
+            }
+        }
+    }
 }
 
 static inline bool CheckBoundingBoxOverlap(float *bspcoord, float *test)

--- a/source_files/edge/p_plane.cc
+++ b/source_files/edge/p_plane.cc
@@ -687,6 +687,7 @@ static PlaneMover *P_SetupSectorAction(Sector *sector, const PlaneMoverDefinitio
         sector->floor_move = plane;
 
     plane->sector               = sector;
+    plane->model                = model;
     plane->crush                = def->crush_damage_;
     plane->sound_effect_started = false;
 

--- a/source_files/edge/p_spec.h
+++ b/source_files/edge/p_spec.h
@@ -86,6 +86,7 @@ struct PlaneMover
 {
     const PlaneMoverDefinition *type;
     Sector                     *sector;
+    Sector                     *model = nullptr;
 
     bool is_ceiling;
     bool is_elevator;

--- a/source_files/edge/sv_misc.cc
+++ b/source_files/edge/sv_misc.cc
@@ -340,7 +340,8 @@ static SaveField sv_fields_plane_move[] = {
                     SR_PlaneMovePutType),
     EDGE_SAVE_FIELD(dummy_plane_mover, sector, "sector", 1, kSaveFieldIndex, 4, "sectors", SaveGameGetSector,
                     SaveGamePutSector),
-
+    EDGE_SAVE_FIELD(dummy_plane_mover, model, "model", 1, kSaveFieldIndex, 4, "sectors", SaveGameGetSector,
+                    SaveGamePutSector),
     EDGE_SAVE_FIELD(dummy_plane_mover, is_ceiling, "is_ceiling", 1, kSaveFieldNumeric, 4, nullptr, SaveGameGetBoolean,
                     SaveGamePutBoolean),
     EDGE_SAVE_FIELD(dummy_plane_mover, is_elevator, "is_elevator", 1, kSaveFieldNumeric, 4, nullptr, SaveGameGetBoolean,


### PR DESCRIPTION
This is a more robust answer to my really old Doom E3M4 crusher fix