### PR TITLE
More fixes

### DIFF
--- a/ASanSuppress.txt
+++ b/ASanSuppress.txt
@@ -19,5 +19,5 @@
 # Ignore
 ##################################################
 
-# SDL internal; likely cannot do anything about this
 leak:SDL_InitSubSystem_REAL
+leak:_dbus_*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,4 @@
-# CHANGELOG for EDGE-Classic 1.5 RC2 (since EDGE-Classic 1.5 RC1)
-
-## New Features
-
-- Added FLIP and INVERT DDFIMAGE specials to allow easier creation of mirrored images, etc
-
-## General Bugfixes
-
-- Moved bot catch-up spawn closer to the player to prevent getting stuck in level geometry
-- Fixed CTD when using the 'endoom' console command with no valid ENDOOM lump present
-- Fixed HUD messages with newline characters not formatting properly
-- Removed interpolation when performing the RTS MOVE_SECTOR action to prevent visual artifacts
-- Fixed plane movers using the sector's current floor/ceiling height as targets not updating their destination heights properly
-- Fixed CTD when loading MDL format models in the Sokol renderer (MD2/3s were not affected)
-- Fixed rendering height of things when active portals were in view (mirrors were not affected)
-
-# CHANGELOG for EDGE-Classic 1.5 RC1 (since EDGE-Classic 1.38)
+# CHANGELOG for EDGE-Classic 1.5 (since EDGE-Classic 1.38)
 
 ## New Features
 
@@ -34,10 +18,10 @@
   - Controls how much the light level is raised by actions such as A_Light1/2
 - New state action: LUA_RUN_SCRIPT("\<lua_script_name\>")
   - Will pass a table containing the calling mobj's information as a parameter
-- New states actions:  CLEAR_TARGET and FRIEND_LOOKOUT
+- New state actions:  CLEAR_TARGET and FRIEND_LOOKOUT
 - New BORE attack flag
   - Can damage the same mobj multiple times as it is passing through, versus the once-per-mobj of the existing TUNNEL special
-- New states actions: GRAVITY and NO_GRAVITY
+- New state actions: GRAVITY and NO_GRAVITY
 - New state action: SET_SCALE(float)
   - Changes the objects visual scale. This does not affect the actual collision box and is mainly intended for special effects things, such as a puff of smoke gradually dissipating by expansion (in combination with TRANS_FADE) or shrinking and disappearing.
 - New DDFTHING special: ASSIGN_TID
@@ -48,10 +32,14 @@
   - Will return a table of all active map objects with the matching tag/tid for iteration and scripting.
 - New LUA-only function: mapobject.objects_in_radius(x, y, radius).
   - Will return a table of all map objects within a given radius from the indicated XY coordinates, for iteration and scripting.
+- Added FLIP and INVERT DDFIMAGE specials to allow easier creation of mirrored images, etc
 
 
 ## General Improvements/Changes
 
+- Crosshairs and overlays no longer limited to a hardcoded list of options
+  - Images placed in the "crosshairs" or "overlays" folder will be added to the appropriate menu option
+    on the next run
 - Co-op bot improvements
   - Bots and players (non-voodoo) will no longer clip or telefrag each other
   - Bots will now follow behind the player instead of potentially obstructing their view
@@ -94,6 +82,7 @@
 - Carry scroller forces are now additive instead of averaged
 - Changed method of determining the sectors a thing is touching (for carry purposes/etc) from
 a BSP-based to a linedef-based method to be more in line with Boom behavior
+- Updated friction/wind force calculations to be more in line with Boom behavior
 
 ### MBF
 - A_Mushroom codepointer revised to be in line with original behavior
@@ -117,4 +106,7 @@ a BSP-based to a linedef-based method to be more in line with Boom behavior
 - Changed FACE() thing.ddf action to behave like it's horizontal equivalent TURN().
 - Stopped looping SFX still playing on intermission screen
 - Fixed player being able to build momentum by running against a wall/closed door
-
+- Fixed CTD when using the 'endoom' console command with no valid ENDOOM lump present
+- Fixed HUD messages with newline characters not formatting properly
+- Fixed plane movers using the sector's current floor/ceiling height as targets not updating their destination heights properly
+- Fixed UMAPINFO-defined levels that add intertext/intertextsecret without defining a backdrop not using the default flat

--- a/branding.cfg
+++ b/branding.cfg
@@ -1,7 +1,7 @@
 /application_name	"EDGE-Classic"
 /config_filename	"edge-classic.cfg"
 /debug_filename	"debug.txt"
-/edge_version	"1.50 RC2"
+/edge_version	"1.50"
 /homepage	"https://edge-classic.github.io"
 /log_filename	"edge-classic.log"
 /team_name	"EDGE Team"

--- a/source_files/edge/i_main.cc
+++ b/source_files/edge/i_main.cc
@@ -34,7 +34,14 @@ extern "C"
         if (SDL_Init(0) < 0)
             FatalError("Couldn't init SDL!!\n%s\n", SDL_GetError());
 
-        executable_path = SDL_GetBasePath();
+        char *exec_path = SDL_GetBasePath();
+
+        if (!exec_path)
+            FatalError("Couldn't determing program directory!\n");
+        else
+            executable_path = exec_path;
+
+        SDL_free(exec_path);
 
         EdgeMain(argc, (const char **)argv);
         EdgeShutdown();

--- a/source_files/edge/p_umapinfo.cc
+++ b/source_files/edge/p_umapinfo.cc
@@ -747,31 +747,31 @@ static void ParseUMAPINFOEntry(epi::Scanner &lex, MapEntry *val)
             val->partime = 35 * lex.state_.number;
             break;
         case umapinfo::kIntertext: {
-            std::string it_builder = value;
+            value = lex.state_.string;
             while (lex.CheckToken(','))
             {
-                it_builder.append("\n");
+                value.append("\n");
                 lex.GetNextToken();
-                it_builder.append(lex.state_.string);
+                value.append(lex.state_.string);
             }
             if (val->intertext)
                 free(val->intertext);
-            val->intertext = (char *)calloc(it_builder.size() + 1, sizeof(char));
-            epi::CStringCopyMax(val->intertext, it_builder.c_str(), it_builder.size());
+            val->intertext = (char *)calloc(value.size() + 1, sizeof(char));
+            epi::CStringCopyMax(val->intertext, value.c_str(), value.size());
         }
         break;
         case umapinfo::kIntertextSecret: {
-            std::string it_builder = value;
+            value = lex.state_.string;
             while (lex.CheckToken(','))
             {
-                it_builder.append("\n");
+                value.append("\n");
                 lex.GetNextToken();
-                it_builder.append(lex.state_.string);
+                value.append(lex.state_.string);
             }
             if (val->intertextsecret)
                 free(val->intertextsecret);
-            val->intertextsecret = (char *)calloc(it_builder.size() + 1, sizeof(char));
-            epi::CStringCopyMax(val->intertextsecret, it_builder.c_str(), it_builder.size());
+            val->intertextsecret = (char *)calloc(value.size() + 1, sizeof(char));
+            epi::CStringCopyMax(val->intertextsecret, value.c_str(), value.size());
         }
         break;
         case umapinfo::kInterbackdrop: {

--- a/source_files/edge/w_wad.cc
+++ b/source_files/edge/w_wad.cc
@@ -1475,6 +1475,8 @@ void ReadUMAPINFOLumps(void)
                         temp_level->f_end_.text_flat_ = ibd_lookup;
                     }
                 }
+                else
+                    temp_level->f_end_.text_flat_ = "FLOOR4_8";
             }
 
             if (Maps.maps[i].intermusic[0])
@@ -1583,6 +1585,8 @@ void ReadUMAPINFOLumps(void)
                                     temp_level->f_end_.text_flat_ = ibd_lookup;
                                 }
                             }
+                            else
+                                temp_level->f_end_.text_flat_ = "FLOOR4_8"; 
                         }
                         else
                         {
@@ -1613,6 +1617,8 @@ void ReadUMAPINFOLumps(void)
                                     secret_level->f_pre_.text_flat_ = ibd_lookup;
                                 }
                             }
+                            else
+                                secret_level->f_pre_.text_flat_ = "FLOOR4_8";
                         }
                     }
                 }


### PR DESCRIPTION
Updated the changelog/versioning files, and fixed the following issues:
- Memory leak from not freeing the return from SDL_GetBasePath
- UMAPINFO intertext/intertextsecret not being assigned properly (side effect from the Declarate parser migration)
- UMAPINFO levels that added an intertext without defining a backdrop having a black background instead of the default flat