### PR TITLE
Dehacked tweaks

### DIFF
--- a/source_files/ddf/ddf_states.cc
+++ b/source_files/ddf/ddf_states.cc
@@ -283,7 +283,7 @@ int DDFStateFindLabel(const std::vector<StateRange> &group, const char *label, b
     }
 
     if (!quiet)
-        DDFError("Unknown label '%s' (object has no such frames).\n", label);
+        DDFWarnError("Unknown label '%s' (object has no such frames).\n", label);
 
     return 0;
 }

--- a/source_files/dehacked/deh_weapons.cc
+++ b/source_files/dehacked/deh_weapons.cc
@@ -209,6 +209,7 @@ void HandleSounds(const WeaponInfo *info, int w_num)
         wad::Printf("START_SOUND = \"%s\";\n", sounds::GetSound(ksfx_sawup).c_str());
         if (info->readystate == kS_SAW)
             wad::Printf("IDLE_SOUND = \"%s\";\n", sounds::GetSound(ksfx_sawidl).c_str());
+        if (info->atkstate == kS_SAW2)
         wad::Printf("ENGAGED_SOUND = \"%s\";\n", sounds::GetSound(ksfx_sawful).c_str());
         return;
     }
@@ -279,7 +280,7 @@ void HandleAttacks(const WeaponInfo *info, int w_num)
 
     wad::Printf("ATTACK = %s;\n", atk);
 
-    // 2023.11.17 - Added SAWFUL ENGAGE_SOUND for non-chainsaw attacks using the
+    // 2023.11.17 - Added SAWFUL ENGAGE_SOUND for non-chainsaw weapons using the
     // chainsaw attack Fixes, for instance, the Harmony Compatible knife swing
     // being silent
     if (epi::StringCaseCompareASCII(atk, "PLAYER_SAW") == 0 && w_num != kwp_chainsaw)


### PR DESCRIPTION
Fixed two issues observed when testing Dead Sea Scrolls:
- Demoted missing frame label from DDFError to DDFWarnError
  - DSS's Dehacked patch is assigning frame numbers of zero to various Doom 2 things, presumably to prevent their usage in this WAD since it targets Ultimate Doom. This was causing a fatal error due to things like the boss brain not having a spawn state
  - Chainsaws modified via Dehacked were still playing the SAWFUL sfx when attacking even if they were not actually using the chainsaw attack anymore (DSS uses the shotgun attack instead)