### PR TITLE
Change sound effect category for FAILED_SFX

### DIFF
--- a/source_files/edge/p_spec.cc
+++ b/source_files/edge/p_spec.cc
@@ -1403,7 +1403,7 @@ static bool P_ActivateSpecialLine(Line *line, const LineType *special, int tag, 
                     ConsoleMessage(kConsoleHUDCenter, "%s", language[special->failedmessage_.c_str()]);
 
                 if (special->failed_sfx_)
-                    StartSoundEffect(special->failed_sfx_, kCategoryLevel, thing);
+                    StartSoundEffect(special->failed_sfx_, GetSoundEffectCategory(thing), thing);
 
                 return false;
             }


### PR DESCRIPTION
This changes FAILED_SFX to be treated the same way as the "noway" sound, i.e. a player noise and not a noise that originates from "within the level"