### PR TITLE
Boom/Dehacked fixes

### DIFF
--- a/source_files/ddf/ddf_boom.cc
+++ b/source_files/ddf/ddf_boom.cc
@@ -397,7 +397,7 @@ static void MakeBoomCeiling(LineType *line, int number)
         break;
 
     case 5:                                                 // shorted texture
-        line->c_.destref_ = kTriggerHeightReferenceLowestLowTexture;
+        line->c_.destref_ = (TriggerHeightReference)(kTriggerHeightReferenceLowestLowTexture | kTriggerHeightReferenceCeiling);
         break;
 
     case 6: // 24

--- a/source_files/dehacked/deh_frames.cc
+++ b/source_files/dehacked/deh_frames.cc
@@ -499,6 +499,7 @@ void frames::MarkState(int st_num)
         entry->action      = kA_NULL;
         entry->next_state  = st_num;
         entry->arg_pointer = 0;
+        entry->mbf21_flags = 0;
     }
 }
 
@@ -521,6 +522,7 @@ const State *frames::NewStateElseOld(int st_num)
             entry->action      = kA_NULL;
             entry->next_state  = st_num;
             entry->arg_pointer = 0;
+            entry->mbf21_flags = 0;
             new_states[st_num] = entry;
             return entry;
         }
@@ -541,6 +543,7 @@ const State *frames::NewStateElseOld(int st_num)
             entry->action      = kA_NULL;
             entry->next_state  = st_num;
             entry->arg_pointer = 0;
+            entry->mbf21_flags = 0;
             new_states[st_num] = entry;
             return entry;
         }
@@ -1157,7 +1160,7 @@ void frames::SpecialAction(char *act_name, const State *st, int cur)
         std::string name = things::GetMobjName(type);
 
         if (name[0] == '*')
-            name = name.substr(1);
+            name = "deh_atk_" + name.substr(1);
 
         stbsp_sprintf(act_name, "DEH_WEAPON_PROJECTILE(%s,%d,%d,%d,%d)", name.c_str(), angle, pitch, hoffset, voffset);
     }
@@ -1235,6 +1238,8 @@ void frames::SpecialAction(char *act_name, const State *st, int cur)
 
         std::string name = things::GetMobjName(type);
 
+        // Dasho: Not sure if spawning "attack things" is gonna work here, will check when I actually
+        // run into a test case
         if (name[0] == '*')
             name = name.substr(1);
 
@@ -1255,7 +1260,7 @@ void frames::SpecialAction(char *act_name, const State *st, int cur)
         std::string name = things::GetMobjName(type);
 
         if (name[0] == '*')
-            name = name.substr(1);
+            name = "deh_atk_" + name.substr(1);
 
         stbsp_sprintf(act_name, "DEH_MONSTER_PROJECTILE(%s,%d,%d,%d,%d)", name.c_str(), angle, pitch, hoffset, voffset);
     }

--- a/source_files/dehacked/deh_things.cc
+++ b/source_files/dehacked/deh_things.cc
@@ -450,6 +450,10 @@ void Attacks::ConvertAttack(const DehackedMapObjectDefinition *info, int mt_num,
         wad::Printf("DAMAGE.MAX = %d;\n", info->damage * 8);
     }
 
+    if (info->splash_group >= 0)
+        wad::Printf("SPLASH_GROUP = %d;\n",
+                    info->splash_group + 1); // We don't want a '0' splash group when it hits DDF
+
     if (mt_num == kMT_BFG)
         wad::Printf("SPARE_ATTACK = BFG9000_SPRAY;\n");
 
@@ -699,7 +703,7 @@ bool things::IsSpawnable(int mt_num)
     if (info == nullptr)
         return false;
 
-    return info->doomednum > 0;
+    return (info->doomednum > 0 || mt_num >= kTotalDehackedMapObjectTypesPortCompatibility);
 }
 
 const char *things::AddScratchAttack(int damage, const std::string &sfx)

--- a/source_files/dehacked/deh_weapons.cc
+++ b/source_files/dehacked/deh_weapons.cc
@@ -210,7 +210,7 @@ void HandleSounds(const WeaponInfo *info, int w_num)
         if (info->readystate == kS_SAW)
             wad::Printf("IDLE_SOUND = \"%s\";\n", sounds::GetSound(ksfx_sawidl).c_str());
         if (info->atkstate == kS_SAW2)
-        wad::Printf("ENGAGED_SOUND = \"%s\";\n", sounds::GetSound(ksfx_sawful).c_str());
+            wad::Printf("ENGAGED_SOUND = \"%s\";\n", sounds::GetSound(ksfx_sawful).c_str());
         return;
     }
 
@@ -283,7 +283,9 @@ void HandleAttacks(const WeaponInfo *info, int w_num)
     // 2023.11.17 - Added SAWFUL ENGAGE_SOUND for non-chainsaw weapons using the
     // chainsaw attack Fixes, for instance, the Harmony Compatible knife swing
     // being silent
-    if (epi::StringCaseCompareASCII(atk, "PLAYER_SAW") == 0 && w_num != kwp_chainsaw)
+    // 2025.09.08 - Also added it for chainsaws using PLAYER_SAW but with the non-default
+    // attack state
+    if (epi::StringCaseCompareASCII(atk, "PLAYER_SAW") == 0 && (w_num != kwp_chainsaw || (info->atkstate != kS_SAW2)))
         wad::Printf("ENGAGED_SOUND = \"%s\";\n", sounds::GetSound(ksfx_sawful).c_str());
 }
 

--- a/source_files/edge/p_map.cc
+++ b/source_files/edge/p_map.cc
@@ -2693,16 +2693,18 @@ static bool RadiusAttackCallback(MapObject *thing, void *data)
 
     MapObject *source = radius_attack_check.source;
 
-    if (source && source != thing && (thing->hyper_flags_ & kHyperFlagFriendlyFireImmune) &&
-        (thing->side_ & radius_attack_check.source->side_) != 0)
+    if (source && (thing->hyper_flags_ & kHyperFlagFriendlyFireImmune) &&
+        (thing->side_ & source->side_) != 0)
     {
         return true;
     }
 
     // MBF21: If in same splash group, don't damage it
-    if (source && source != thing && thing->info_->splash_group_ > 0 &&
-        radius_attack_check.source->info_->splash_group_ > 0 &&
-        (thing->info_->splash_group_ == radius_attack_check.source->info_->splash_group_))
+    // Dasho: Note, this checks the splash group of the actual
+    // bomb spot and not its source
+    if (thing->info_->splash_group_ > 0 &&
+        radius_attack_check.spot->info_->splash_group_ > 0 &&
+        (thing->info_->splash_group_ == radius_attack_check.spot->info_->splash_group_))
     {
         return true;
     }
@@ -2716,7 +2718,7 @@ static bool RadiusAttackCallback(MapObject *thing, void *data)
         if (!source)
             return true;
         // MBF21 FORCERADIUSDMG flag
-        if (source != thing && !(source->mbf21_flags_ & kMBF21FlagForceRadiusDamage))
+        if (!(source->mbf21_flags_ & kMBF21FlagForceRadiusDamage))
             return true;
     }
 

--- a/source_files/edge/p_plane.cc
+++ b/source_files/edge/p_plane.cc
@@ -117,8 +117,10 @@ static const Image *SECPIC(Sector *sec, bool is_ceiling, const Image *new_image)
 // -ACB- 1998/09/06 Remarked and Reformatted.
 // -ACB- 2001/02/04 Move to p_plane.c
 //
-static float GetSecHeightReference(TriggerHeightReference ref, Sector *sec, Sector *model)
+static float GetSecHeightReference(const PlaneMoverDefinition *def, Sector *sec, Sector *model)
 {
+    const TriggerHeightReference ref = def->destref_;
+
     switch (ref & kTriggerHeightReferenceMask)
     {
     case kTriggerHeightReferenceAbsolute:
@@ -137,7 +139,7 @@ static float GetSecHeightReference(TriggerHeightReference ref, Sector *sec, Sect
         return FindSurroundingHeight(ref, sec);
 
     case kTriggerHeightReferenceLowestLowTexture:
-        return FindRaiseToTexture(sec);
+        return FindRaiseToTexture(def, sec);
 
     default:
         FatalError("GetSecHeightReference: undefined reference %d\n", ref);
@@ -693,12 +695,12 @@ static PlaneMover *P_SetupSectorAction(Sector *sector, const PlaneMoverDefinitio
 
     float start = HEIGHT(sector, def->is_ceiling_);
 
-    float dest = GetSecHeightReference(def->destref_, sector, model);
+    float dest = GetSecHeightReference(def, sector, model);
     dest += def->dest_;
 
     if (def->type_ == kPlaneMoverPlatform || def->type_ == kPlaneMoverContinuous || def->type_ == kPlaneMoverToggle)
     {
-        start = GetSecHeightReference(def->otherref_, sector, model);
+        start = GetSecHeightReference(def, sector, model);
         start += def->other_;
     }
 

--- a/source_files/edge/p_spec.cc
+++ b/source_files/edge/p_spec.cc
@@ -208,36 +208,72 @@ float FindSurroundingHeight(const TriggerHeightReference ref, const Sector *sec)
 //
 // -KM- 1998/09/01 Lines.ddf; used to be inlined in p_floors
 //
-float FindRaiseToTexture(Sector *sec)
+float FindRaiseToTexture(const PlaneMoverDefinition *def, Sector *sec)
 {
     int   i;
     Side *side;
     float minsize = (float)INT_MAX;
     int   secnum  = sec - level_sectors;
+    const TriggerHeightReference ref = def->destref_;
 
-    for (i = 0; i < sec->line_count; i++)
+    if (ref & kTriggerHeightReferenceCeiling)
     {
-        if (LineIsTwoSided(secnum, i))
+        for (i = 0; i < sec->line_count; i++)
         {
-            side = GetLineSidedef(secnum, i, 0);
-
-            if (side->bottom.image)
+            if (LineIsTwoSided(secnum, i))
             {
-                if (side->bottom.image->ScaledHeightActual() < minsize)
-                    minsize = side->bottom.image->ScaledHeightActual();
-            }
+                side = GetLineSidedef(secnum, i, 0);
 
-            side = GetLineSidedef(secnum, i, 1);
+                if (side->top.image)
+                {
+                    if (side->top.image->ScaledHeightActual() < minsize)
+                        minsize = side->top.image->ScaledHeightActual();
+                }
 
-            if (side->bottom.image)
-            {
-                if (side->bottom.image->ScaledHeightActual() < minsize)
-                    minsize = side->bottom.image->ScaledHeightActual();
+                side = GetLineSidedef(secnum, i, 1);
+
+                if (side->top.image)
+                {
+                    if (side->top.image->ScaledHeightActual() < minsize)
+                        minsize = side->top.image->ScaledHeightActual();
+                }
             }
         }
-    }
 
-    return sec->floor_height + minsize;
+        if (def->speed_down_ > 0)
+            return sec->ceiling_height - minsize;
+        else
+            return sec->ceiling_height + minsize;
+    }
+    else
+    {
+        for (i = 0; i < sec->line_count; i++)
+        {
+            if (LineIsTwoSided(secnum, i))
+            {
+                side = GetLineSidedef(secnum, i, 0);
+
+                if (side->bottom.image)
+                {
+                    if (side->bottom.image->ScaledHeightActual() < minsize)
+                        minsize = side->bottom.image->ScaledHeightActual();
+                }
+
+                side = GetLineSidedef(secnum, i, 1);
+
+                if (side->bottom.image)
+                {
+                    if (side->bottom.image->ScaledHeightActual() < minsize)
+                        minsize = side->bottom.image->ScaledHeightActual();
+                }
+            }
+        }
+
+        if (def->speed_down_ > 0)
+            return sec->floor_height - minsize;
+        else
+            return sec->floor_height + minsize;
+    }
 }
 
 //

--- a/source_files/edge/p_spec.h
+++ b/source_files/edge/p_spec.h
@@ -183,7 +183,7 @@ Sector *GetLineSectorAdjacent(const Line *line, const Sector *sec, bool ignore_s
 
 // Info Needs....
 float   FindSurroundingHeight(const TriggerHeightReference ref, const Sector *sec);
-float   FindRaiseToTexture(Sector *sec); // -KM- 1998/09/01 New func, old inline
+float   FindRaiseToTexture(const PlaneMoverDefinition *def, Sector *sec); // -KM- 1998/09/01 New func, old inline
 Sector *FindSectorFromTag(int tag);
 int     FindMinimumSurroundingLight(Sector *sector, int max);
 

--- a/source_files/edge/w_wad.cc
+++ b/source_files/edge/w_wad.cc
@@ -2144,7 +2144,7 @@ int FindFlatSequence(const char *start, const char *end, int *s_offset, int *e_o
         int i;
         for (i = 0; i < (int)wad->flat_lumps_.size(); i++)
         {
-            if (strncmp(start, GetLumpNameFromIndex(wad->flat_lumps_[i]), 8) == 0)
+            if (epi::StringCaseCompareMaxASCII(start, GetLumpNameFromIndex(wad->flat_lumps_[i]), 8) == 0)
                 break;
         }
 
@@ -2156,7 +2156,7 @@ int FindFlatSequence(const char *start, const char *end, int *s_offset, int *e_o
         // look for end name
         for (i++; i < (int)wad->flat_lumps_.size(); i++)
         {
-            if (strncmp(end, GetLumpNameFromIndex(wad->flat_lumps_[i]), 8) == 0)
+            if (epi::StringCaseCompareMaxASCII(end, GetLumpNameFromIndex(wad->flat_lumps_[i]), 8) == 0)
             {
                 (*e_offset) = i;
                 return file;


### PR DESCRIPTION
This fixes the following issues observed while testing:
- Boom generalized lift shortest lower/upper texture targets were unconditionally using the floor height + shortest lower texture size as the destination
- ANIMATED lumps with lowercase lump names were not being animated properly
- Dehacked->DDF converter was not covering all cases in which the SAWFUL ENGAGED_SOUND needs to be added for a weapon
- RadiusAttackCallback was using the projectile source's MBF21 'splash group' and not that of the projectile itself when making a radius attack to check damage
- MBF21 projectile attacks referencing objects with no DDFTHING definition (i.e, ad-hoc things created when processing DDFATK) were not working properly
- Several instances in which the "MBF21 Bits" field of a Dehacked frame was not zero-initialized