### PR TITLE
More fixes for MBF21 weapon/ammo issues

### DIFF
--- a/source_files/ddf/ddf_types.h
+++ b/source_files/ddf/ddf_types.h
@@ -465,6 +465,8 @@ enum WeaponFlag
     WeaponFlagPartialReload      = (1 << 11), // manual reload: allow partial refill
     // MBF21 flags:
     WeaponFlagNoAutofireOnReady = (1 << 12), // Do not autofire in A_WeaponReady
+    WeaponFlagEnforceAmmoType   = (1 << 13)  // Do not convert weapons that have a 0 ammo per shot
+                                             // to use the "no ammo" ammo type
 };
 
 constexpr WeaponFlag kDefaultWeaponFlags = (WeaponFlag)(WeaponFlagReloadWhileTrigger | WeaponFlagManualReload |

--- a/source_files/ddf/ddf_weapon.h
+++ b/source_files/ddf/ddf_weapon.h
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include <unordered_map>
+
 #include "ddf_states.h"
 #include "ddf_types.h"
 
@@ -37,6 +39,8 @@ class WeaponDefinitionContainer : public std::vector<WeaponDefinition *>
     // Search Functions
     int               FindFirst(const char *name, size_t startpos = 0);
     WeaponDefinition *Lookup(const char *refname);
+
+    std::unordered_map<WeaponDefinition *, Benefit *> deh_ammo_replacements;
 };
 
 // -------EXTERNALISATIONS-------

--- a/source_files/dehacked/deh_weapons.h
+++ b/source_files/dehacked/deh_weapons.h
@@ -43,6 +43,11 @@ enum WeaponFlagMBF21
 
     // Cannot be switched to when ammo is picked up
     kMBF21_NOAUTOSWITCHTO = 32,
+
+    // Not a true MBF21 flag, but prevents modified weapons
+    // with an ammo_per_shot value of 0 from being switched
+    // to using the "noammo" ammo category
+    kMBF21_REALLYUSESAMMO = 64
 };
 
 // Weapon info: sprite frames, ammunition use.


### PR DESCRIPTION
Rollup of some fixes for a few more Dehacked conversion issues:
- Added a mechanism to prevent weapons with a valid ammo type but an "ammo per shot" value of 0 from being converted to using the "noammo" ammunition type.
- Fixed "ammo per shot" value of 0 in patches from being applied properly
- For weapons modified via Dehacked to use a different ammo type than their default, added a "best effort" solution to give the correct amount of ammunition on weapon pickup. This replaces the hardcoded Doom behavior that ties ammunition pickup to specific sprites :/