### PR TITLE
SFX updates

### DIFF
--- a/source_files/edge/f_interm.cc
+++ b/source_files/edge/f_interm.cc
@@ -2056,7 +2056,7 @@ void IntermissionStart(void)
     // Lobo 2025: if we have a camera set up we probably don't mind still hearing level sfx, otherwise nuke 'em ;)
     if (!background_camera_map_object)
     {
-        StopLevelSoundEffects();
+        StopAllSoundEffects();
         DestroyAllAmbientSounds();
     }
 }

--- a/source_files/edge/p_setup.cc
+++ b/source_files/edge/p_setup.cc
@@ -3382,7 +3382,7 @@ void ShutdownLevel(void)
 
     P_RemoveSectorStuff();
 
-    StopLevelSoundEffects();
+    StopAllSoundEffects();
 
     DestroyAllForces();
     DestroyAllLights();

--- a/source_files/edge/s_sound.cc
+++ b/source_files/edge/s_sound.cc
@@ -518,16 +518,19 @@ void StopSoundEffect(const Position *pos)
     }
 }
 
-void StopLevelSoundEffects(void)
+void StopSoundEffect(const SoundEffect *sfx)
 {
     if (no_sound)
         return;
+
+    SoundEffectDefinition *def = LookupEffectDef(sfx);
+    EPI_ASSERT(def);
 
     for (int i = 0; i < total_channels; i++)
     {
         const SoundChannel *chan = mix_channels[i];
 
-        if (chan->state_ != kChannelEmpty && chan->category_ != kCategoryUi)
+        if (chan->state_ == kChannelPlaying && chan->definition_ == def)
         {
             KillSoundChannel(i);
         }

--- a/source_files/edge/s_sound.h
+++ b/source_files/edge/s_sound.h
@@ -84,7 +84,7 @@ void ShutdownSound(void);
 void StartSoundEffect(const SoundEffect *sfx, int category = kCategoryUi, const Position *pos = nullptr, int flags = 0);
 
 void StopSoundEffect(const Position *pos);
-void StopLevelSoundEffects(void);
+void StopSoundEffect(const SoundEffect *sfx);
 void StopAllSoundEffects(void);
 
 void ResumeSound(void);

--- a/source_files/edge/script/compat/lua_hud.cc
+++ b/source_files/edge/script/compat/lua_hud.cc
@@ -775,6 +775,28 @@ static int HD_play_sound(lua_State *L)
     return 1;
 }
 
+// hud.kill_sound(name)
+//
+static int HD_kill_sound(lua_State *L)
+{
+    const char *name = luaL_checkstring(L, 1);
+
+    SoundEffect *fx = sfxdefs.GetEffect(name);
+
+    if (fx)
+    {
+        StopSoundEffect(fx);
+        lua_pushboolean(L, 1);
+    }
+    else
+    {
+        LogWarning("hud.kill_sound: unknown sfx '%s'\n", name);
+        lua_pushboolean(L, 0);
+    }
+
+    return 1;
+}
+
 // hud.screen_aspect()
 //
 static int HD_screen_aspect(lua_State *L)
@@ -1095,6 +1117,7 @@ static const luaL_Reg hudlib[] = {{"game_mode", HD_game_mode},
 
                                   // sound functions
                                   {"play_sound", HD_play_sound},
+                                  {"kill_sound", HD_kill_sound},
 
                                   // image color functions
                                   {"get_average_color", HD_get_average_color},

--- a/source_files/edge/vm_hud.cc
+++ b/source_files/edge/vm_hud.cc
@@ -781,6 +781,22 @@ static void HD_play_sound(coal::VM *vm, int argc)
         LogWarning("hud.play_sound: unknown sfx '%s'\n", name);
 }
 
+// hud.kill_sound(name)
+//
+static void HD_kill_sound(coal::VM *vm, int argc)
+{
+    EPI_UNUSED(argc);
+
+    const char *name = vm->AccessParamString(0);
+
+    SoundEffect *fx = sfxdefs.GetEffect(name);
+
+    if (fx)
+        StopSoundEffect(fx);
+    else
+        LogWarning("hud.kill_sound: unknown sfx '%s'\n", name);
+}
+
 // hud.screen_aspect()
 //
 static void HD_screen_aspect(coal::VM *vm, int argc)
@@ -1129,6 +1145,7 @@ void COALRegisterHUD()
 
     // sound functions
     ui_vm->AddNativeFunction("hud.play_sound", HD_play_sound);
+    ui_vm->AddNativeFunction("hud.kill_sound", HD_kill_sound);
 
     // image color functions
     ui_vm->AddNativeFunction("hud.get_average_color", HD_get_average_color);


### PR DESCRIPTION
- Kill all sounds when switching levels (not sure why Ui category sounds were retained)
- Add "kill_sound" function to both COAL and Lua to allow killing all sound channels playing the specified sfx definition