### PR TITLE
Fix plane height destination/reference calculations

### DIFF
--- a/source_files/edge/p_maputl.cc
+++ b/source_files/edge/p_maputl.cc
@@ -954,9 +954,9 @@ void RecomputeGapsAroundSector(Sector *sec)
         if ((ref & kTriggerHeightReferenceMask) == kTriggerHeightReferenceCurrent)
         {
            if ((ref & kTriggerHeightReferenceCeiling) && !pl->is_ceiling)
-                pl->destination_height = sec->ceiling_height;
+                pl->destination_height = sec->ceiling_height + pl->type->dest_;
             else if (!(ref & kTriggerHeightReferenceCeiling) && pl->is_ceiling)
-                pl->destination_height = sec->floor_height; 
+                pl->destination_height = sec->floor_height + pl->type->dest_; 
         }
     }
 }

--- a/source_files/edge/p_plane.cc
+++ b/source_files/edge/p_plane.cc
@@ -119,7 +119,12 @@ static const Image *SECPIC(Sector *sec, bool is_ceiling, const Image *new_image)
 //
 static float GetSecHeightReference(const PlaneMoverDefinition *def, Sector *sec, Sector *model)
 {
-    const TriggerHeightReference ref = def->destref_;
+    TriggerHeightReference ref;
+
+    if (def->type_ == kPlaneMoverPlatform || def->type_ == kPlaneMoverContinuous || def->type_ == kPlaneMoverToggle)
+        ref = def->otherref_;
+    else
+        ref = def->destref_;
 
     switch (ref & kTriggerHeightReferenceMask)
     {


### PR DESCRIPTION
Fix a goof introduced when fixing the Boom "shortest texture" destination types