### PR TITLE
Bugfix: Centering incorrect for SELECTED menu items

### DIFF
--- a/source_files/edge/m_menu.cc
+++ b/source_files/edge/m_menu.cc
@@ -2860,6 +2860,13 @@ void MenuDrawItems(Style *style, bool graphical_item)
             {
                 textstyle = StyleDefinition::kTextSectionSelected;
                 txtscale  = style->definition_->text_[textstyle].scale_;
+
+                //Lobo: need to recalculate center because the size could be different
+                if (style->definition_->entry_alignment_ == StyleDefinition::kAlignmentCenter)
+                {
+                    current_menu->menu_items[j].x =
+                    CenterMenuText(style, textstyle, current_menu->menu_items[j].name);
+                }
             }
         }
 


### PR DESCRIPTION
We were not taking into account that the size of the text could be different for menu items with a custom SELECTED style. We need to recalculate the center each time.