### PR TITLE
Use associative map for various Dehacked converter items

### DIFF
--- a/source_files/dehacked/deh_field.cc
+++ b/source_files/dehacked/deh_field.cc
@@ -28,6 +28,7 @@
 #include "deh_field.h"
 
 #include <ctype.h>
+#include <limits.h>
 #include <stdarg.h>
 #include <string.h>
 
@@ -110,13 +111,13 @@ static bool FieldValidateValue(const FieldReference *reference, int new_val)
 
         // for DSDehacked, allow very high values
         case kFieldTypeFrameNumber:
-            max_obj = 32767;
+            max_obj = INT_MAX;
             break;
         case kFieldTypeSpriteNumber:
-            max_obj = 32767;
+            max_obj = INT_MAX;
             break;
         case kFieldTypeSoundNumber:
-            max_obj = 32767;
+            max_obj = INT_MAX;
             break;
 
         default:

--- a/source_files/dehacked/deh_main.cc
+++ b/source_files/dehacked/deh_main.cc
@@ -54,7 +54,6 @@ namespace dehacked
 std::vector<InputBuffer *> input_buffers;
 
 bool quiet_mode;
-bool all_mode;
 
 void Init()
 {
@@ -74,7 +73,6 @@ void Init()
     /* reset parameters */
 
     quiet_mode = false;
-    all_mode   = false;
 }
 
 void FreeInputBuffers(void)

--- a/source_files/dehacked/deh_patch.cc
+++ b/source_files/dehacked/deh_patch.cc
@@ -28,6 +28,7 @@
 #include "deh_patch.h"
 
 #include <ctype.h>
+#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -886,16 +887,16 @@ bool ValidateObject(void)
 
         // for DSDehacked, allow very high values
         case kDEH_FRAME:
-            max_obj = 32767;
+            max_obj = INT_MAX;
             break;
         case kDEH_PTR:
-            max_obj = 32767;
+            max_obj = INT_MAX;
             break;
         case kDEH_SOUND:
-            max_obj = 32767;
+            max_obj = INT_MAX;
             break;
         case kDEH_THING:
-            max_obj = 32767;
+            max_obj = INT_MAX;
             min_obj = 1;
             break;
 

--- a/source_files/dehacked/deh_rscript.cc
+++ b/source_files/dehacked/deh_rscript.cc
@@ -160,7 +160,7 @@ void rscript::HandleLevel(const std::string &map, int flag1, int mt1, int flag2,
     if (flag2 != 0 && (list2.size() != 1 || list2[0] != mt2))
         different = true;
 
-    if (!different && !all_mode)
+    if (!different)
         return;
 
     wad::Printf("START_MAP %s\n", map.c_str());

--- a/source_files/dehacked/deh_system.h
+++ b/source_files/dehacked/deh_system.h
@@ -22,7 +22,6 @@ namespace dehacked
 {
 
 extern bool quiet_mode;
-extern bool all_mode;
 
 void System_Startup(void);
 

--- a/source_files/dehacked/deh_text.cc
+++ b/source_files/dehacked/deh_text.cc
@@ -659,7 +659,7 @@ void text_strings::ConvertLDF(void)
 
     for (int i = 0; lang_list[i].orig_text; i++)
     {
-        if (!all_mode && !lang_list[i].new_text)
+        if (!lang_list[i].new_text)
             continue;
 
         WriteTextString(lang_list + i);
@@ -672,7 +672,7 @@ void text_strings::ConvertLDF(void)
 
     for (int i = 0; cheat_list[i].orig_text; i++)
     {
-        if (!all_mode && !cheat_list[i].new_text)
+        if (!cheat_list[i].new_text)
             continue;
 
         WriteTextString(cheat_list + i);

--- a/source_files/dehacked/deh_things.cc
+++ b/source_files/dehacked/deh_things.cc
@@ -1805,17 +1805,6 @@ void things::ConvertTHING(void)
 
     CollectTheCast();
 
-    if (all_mode)
-    {
-        for (int i = 0; i < kTotalDehackedMapObjectTypesPortCompatibility; i++)
-            MarkThing(i);
-
-        /* this is debatable...
-        for (int i = kMT_EXTRA00 ; i <= kMT_EXTRA99 ; i++)
-            MarkThing(i);
-        */
-    }
-
     bool got_one = false;
 
     for (int i = 0; i < (int)new_mobjinfo.size(); i++)
@@ -1852,8 +1841,6 @@ void things::ConvertATK()
     {
         Attacks::ConvertScratch(&Attacks::scratchers[k]);
     }
-
-    // Note: all_mode was handled by ConvertTHING
 
     for (int i = 0; i < (int)new_mobjinfo.size(); i++)
     {

--- a/source_files/dehacked/deh_weapons.cc
+++ b/source_files/dehacked/deh_weapons.cc
@@ -396,7 +396,7 @@ void weapons::ConvertWEAP(void)
 
     for (int i = 0; i < kTotalWeapons; i++)
     {
-        if (!all_mode && !weapon_modified[i])
+        if (!weapon_modified[i])
             continue;
 
         ConvertWeapon(i);


### PR DESCRIPTION
This removes the hard cap of 32767 for various Dehacked items that was imposed to prevent (potentially) allocations of millions of items. Now we use an associative map instead of a simple vector, only inserting/allocating frames/etc that are required by the patch currently being processed.