### PR TITLE
Add check for empty new_states container

### DIFF
--- a/source_files/dehacked/deh_frames.cc
+++ b/source_files/dehacked/deh_frames.cc
@@ -573,6 +573,9 @@ bool frames::DependRangeWasModified(int low, int high)
     if (high < 0)
         return false;
 
+    if (new_states.empty())
+        return false;
+
     EPI_ASSERT(low <= high);
     EPI_ASSERT(low > kS_NULL);
 


### PR DESCRIPTION
Now that we don't unconditionally allocate items, have to check that 'new_states' isn't empty