### PR TITLE
Tweak movefactor for 'muddy' sectors

### DIFF
--- a/source_files/edge/con_con.cc
+++ b/source_files/edge/con_con.cc
@@ -1628,7 +1628,7 @@ void ConsoleShowPosition(void)
     else
         y = current_screen_height - FNSZ * 15;
 
-    SolidBox(x, y - FNSZ * 10, XMUL * 16, FNSZ * 10 + 2, kRGBABlack, 0.5);
+    SolidBox(x, y - FNSZ * 11, XMUL * 16, FNSZ * 11 + 2, kRGBABlack, 0.5);
 
     RendererVertex *console_glvert = StartText();
     uint16_t        console_verts  = 0;
@@ -1660,6 +1660,10 @@ void ConsoleShowPosition(void)
 
     y -= FNSZ;
     stbsp_sprintf(textbuf, "z mom: %.4f", p->map_object_->momentum_.Z);
+    console_verts += AddText(x, y, textbuf, kRGBAWebGray, console_glvert);
+
+    y -= FNSZ;
+    stbsp_sprintf(textbuf, "speed: %.4f", p->actual_speed_);
     console_verts += AddText(x, y, textbuf, kRGBAWebGray, console_glvert);
 
     y -= FNSZ;

--- a/source_files/edge/p_user.cc
+++ b/source_files/edge/p_user.cc
@@ -407,11 +407,11 @@ static void MovePlayer(Player *player)
         else
         {
             float velocity = mo->player_->actual_speed_;
-            if (velocity > kFootingFactor * 4)
+            if (velocity > kFootingFactor)
                 factor *= 8;
-            else if (velocity > kFootingFactor * 2)
+            else if (velocity > kFootingFactor / 2)
                 factor *= 4;
-            else if (velocity > kFootingFactor)
+            else if (velocity > kFootingFactor / 4)
                 factor *= 2;
             fric *= factor;
         }


### PR DESCRIPTION
Noticed in places like Doom 2 In Rural Only MAP11 that the player was slowing down too much in high friction areas. Tweaked it to be somewhat closer to other ports.