### PR TITLE
Adjust thinker loops and handling of empty states

### DIFF
--- a/source_files/ddf/ddf_states.cc
+++ b/source_files/ddf/ddf_states.cc
@@ -455,6 +455,30 @@ void DDFStateReadState(const char *info, const char *label, std::vector<StateRan
 
     cur->tics = atol(stateinfo[2].c_str());
 
+    if (redir)
+    {
+        bool zero_state = true;
+
+        for (int idx = index; idx >= 0; --idx)
+        {
+            State *ticker = &states[num_states - 1 - idx];
+            if (ticker->tics != 0 || ticker->action)
+            {
+                zero_state = false;
+                break;
+            }
+        }
+
+        // Dasho - This is an attempt to prevent a set of states in which every
+        // state is 0 tics in length, has no actions associated with it,
+        // and the last state redirects to the beginning.
+        // If we leave it as-is, then the thinking loop runs away very quickly
+        if (zero_state && DDFCompareName(redir, label) == 0)
+        {
+            cur->tics = 1;
+        }
+    }
+
     //--------------------------------------------------
     //------------STATE BRIGHTNESS LEVEL----------------
     //--------------------------------------------------

--- a/source_files/edge/p_local.h
+++ b/source_files/edge/p_local.h
@@ -40,6 +40,7 @@ constexpr float kMeleeRange      = 64.0f;
 constexpr float kMissileRange    = 2000.0f;
 constexpr float kOnFloorZ        = (float)INT_MIN;
 constexpr float kOnCeilingZ      = (float)INT_MAX;
+constexpr uint8_t kMaxThinkLoop  = 64;
 
 // -ACB- 2004/07/22 Moved here since its playsim related
 #define EDGE_DAMAGE_COMPUTE(var, dam)                                                                                  \

--- a/source_files/edge/p_mobj.cc
+++ b/source_files/edge/p_mobj.cc
@@ -78,8 +78,6 @@ static constexpr float kLadderFriction = 0.5f;
 
 static constexpr float kOofSpeed = 9.0f; // Lobo: original value 20.0f too high, almost never played oof
 
-static constexpr uint8_t kMaxThinkLoop = 255;
-
 static constexpr float   kMaximumMove  = 30.0f;
 static constexpr float   kStepMove     = 16.0f;
 static constexpr uint8_t kRespawnDelay = (kTicRate / 2);
@@ -1671,7 +1669,7 @@ static void P_MobjThinker(MapObject *mobj)
     // -AJA- 2000/10/17: reworked again.
 
     // Dasho - This used to be limited to 8 loops; but other ports don't really seem to impose an arbitrary
-    // cap on how long this can iterate through things like zero-tic states; set kMaxThinkLoop to 255 which
+    // cap on how long this can iterate through things like zero-tic states; set kMaxThinkLoop to 64 which
     // should hopefully cover everything while still allowing a safety hatch if the loop somehow runs away
     for (int loop_count = 0; loop_count < kMaxThinkLoop; loop_count++)
     {

--- a/source_files/edge/p_weapon.cc
+++ b/source_files/edge/p_weapon.cc
@@ -45,8 +45,6 @@
 extern ConsoleVariable view_bobbing;
 extern ConsoleVariable erraticism;
 
-static constexpr uint8_t kMaximumPlayerSpriteLoop = 255;
-
 static constexpr float   kWeaponSwapSpeed = 6.0f;
 static constexpr uint8_t kWeaponBottom    = 128;
 static constexpr uint8_t kWeaponTop       = 32;
@@ -859,9 +857,9 @@ void MovePlayerSprites(Player *p)
             continue;
 
         // Dasho - This used to be limited to 10 loops; but other ports don't really seem to impose an arbitrary
-        // cap on how long this can iterate through things like zero-tic states; set kMaximumPlayerSpriteLoop to 255 which
+        // cap on how long this can iterate through things like zero-tic states; set kMaxThinkLoop to 64 which
         // should hopefully cover everything while still allowing a safety hatch if the loop somehow runs away
-        for (int loop_count = 0; loop_count < kMaximumPlayerSpriteLoop; loop_count++)
+        for (int loop_count = 0; loop_count < kMaxThinkLoop; loop_count++)
         {
             // drop tic count and possibly change state
             // Note: a -1 tic count never changes.


### PR DESCRIPTION
This adjusts the max thinker loop for mobjs/psprites to 64 which is still reasonable. Also added detection of truly empty states in DDF parsing (all frames are 0-tic with no actions and will loop back to its own beginning). These states will now have the tic count for their last frame set to 1 in order to reduce unnecessary looping.