### PR TITLE
Bugfix: walkable lines with a switch texture play switch SFX

### DIFF
--- a/source_files/edge/p_spec.cc
+++ b/source_files/edge/p_spec.cc
@@ -1729,6 +1729,10 @@ static bool P_ActivateSpecialLine(Line *line, const LineType *special, int tag, 
             line->special = (special->newtrignum_ <= 0) ? nullptr : LookupLineType(special->newtrignum_);
         }
 
+        // Lobo 2026: we dont' want to play the switch SFX on walkable lines even though they have a switch texture
+        if (line->special && line->special->type_ == kLineTriggerWalkable)
+            playedSound = true;
+
         ChangeSwitchTexture(line, line->special && (special->newtrignum_ == 0), special->special_flags_, playedSound);
     }
     return true;

--- a/source_files/edge/p_switch.cc
+++ b/source_files/edge/p_switch.cc
@@ -231,10 +231,17 @@ void UpdateButtons(void)
                 FatalError("INTERNAL ERROR: bwhere is kButtonNone!\n");
             }
 
-            if (b->off_sound)
+            // Lobo 2026: we dont' want to play the switch SFX on walkable lines even though they have a switch texture
+            if (b->line->special->type_ != kLineTriggerWalkable)
             {
-                StartSoundEffect(b->off_sound, kCategoryLevel, &b->line->front_sector->sound_effects_origin);
+                if (b->off_sound)
+                {
+                    StartSoundEffect(b->off_sound, kCategoryLevel, &b->line->front_sector->sound_effects_origin);
+                }
             }
+
+
+            
 
             EPI_CLEAR_MEMORY(b, Button, 1);
         }


### PR DESCRIPTION
We do not want to play the switch SFX on walkable lines even though they have a switch texture. This fixes one of the bugs mentioned here: https://github.com/edge-classic/EDGE-classic/issues/1098