### PR TITLE
Bugfix: erroneous font ratio in some cases

### DIFF
--- a/source_files/edge/hu_font.cc
+++ b/source_files/edge/hu_font.cc
@@ -291,13 +291,13 @@ PatchFont::PatchFont(FontDefinition *definition)
     {
         patch_font_cache_.height = definition_->default_size_;
         patch_font_cache_.width  = definition_->default_size_ * (Nom.image_width / Nom.image_height);
-        patch_font_cache_.ratio  = patch_font_cache_.width / patch_font_cache_.height;
+        patch_font_cache_.ratio  = float(patch_font_cache_.width) / float(patch_font_cache_.height);
     }
     else
     {
         patch_font_cache_.width  = Nom.image_width;
         patch_font_cache_.height = Nom.image_height;
-        patch_font_cache_.ratio  = Nom.image_width / Nom.image_height;
+        patch_font_cache_.ratio  = float(Nom.image_width) / float(Nom.image_height);
     }
     spacing_ = definition_->spacing_;
 }


### PR DESCRIPTION
Dividing int by int returns an int, not a float. If the ratio was less than 1 then it was always 0. This was causing oddities further down the line e.g. characters with a width of zero, which were then not drawn properly on the HUD.