### PR TITLE
Bugfix: conflicting Lighting style causes massive lag

### DIFF
--- a/source_files/edge/r_colormap.cc
+++ b/source_files/edge/r_colormap.cc
@@ -765,7 +765,7 @@ class ColormapShader : public AbstractShader
         if (fade_texture_ == 0 ||
             (current_map->episode_->lighting_ != kLightingModelUnset &&
              lighting_model_ != current_map->episode_->lighting_) ||
-            (default_lighting.d_ != lighting_model_))
+            (current_map->episode_->lighting_ == kLightingModelUnset && default_lighting.d_ != lighting_model_))
         {
             if (fade_texture_ != 0)
             {


### PR DESCRIPTION
If the LIGHTING set via DDF was different to the Options->Video->Lighting Mode then there was a massive drop in FPS.