### PR TITLE
Change behaviour of RTS menus with only 1 option

### DIFF
--- a/source_files/edge/rad_act.cc
+++ b/source_files/edge/rad_act.cc
@@ -1185,11 +1185,24 @@ void ScriptJumpOn(RADScriptTrigger *R, void *param)
         cache_state = FindScriptStateByLabel(R->info, label);
         R->state    = cache_state;
     }
-    else
+    else //if we are here then they cancelled out of a menu
     {
-        cache_state  = R->info->first_state;
-        R->state     = cache_state;
-        R->activated = false;
+        if (count == 1) // Only 1 menu option so just assume "Cancel" is the same as "OK"
+        {
+            label = jm->labels[0]; //always just grab the only option
+
+            // FIXME: do this in a post-parsing analysis
+            cache_state = FindScriptStateByLabel(R->info, label);
+            R->state    = cache_state;
+        }
+        else
+        {
+            cache_state  = R->info->first_state;
+            R->state     = cache_state;
+            R->activated = false;
+        }
+
+        
     }
 
     if (!cache_state && label)


### PR DESCRIPTION
An RTS menu with only 1 option i.e. "OK" is really just a TIP that stays on screen till the user presses USE or CANCEL. If they press CANCEL then it goes into a loop constantly repeating the menu till you press USE, which is unexpected behaviour. Now both USE and CANCEL will dismiss the menu.